### PR TITLE
Handle retry_after hint from workers

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -60,10 +60,7 @@ lazy_static::lazy_static! {
     // TODO: add metrics for procedure durations
 }
 
-pub fn report_query_result(
-    worker: PeerId,
-    status: &str,
-) {
+pub fn report_query_result(worker: PeerId, status: &str) {
     QUERY_RESULTS
         .get_or_create(&vec![
             ("worker".to_owned(), worker.to_string()),

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -5,5 +5,6 @@ mod storage;
 
 pub use client::NetworkClient;
 pub use client::QueryResult;
+pub use priorities::NoWorker;
 pub use state::NetworkState;
 pub use storage::StorageClient;

--- a/src/utils/sliding_array.rs
+++ b/src/utils/sliding_array.rs
@@ -48,10 +48,6 @@ impl<T> SlidingArray<T> {
         &self.data
     }
 
-    pub fn mut_data(&mut self) -> &mut VecDeque<T> {
-        &mut self.data
-    }
-
     pub fn enumerate_mut(&mut self) -> impl Iterator<Item = (usize, &mut T)> {
         self.data
             .iter_mut()
@@ -59,8 +55,8 @@ impl<T> SlidingArray<T> {
             .map(|(i, v)| (i + self.first_index, v))
     }
 
-    pub fn front(&self) -> Option<&T> {
-        self.data.front()
+    pub fn back(&self) -> Option<&T> {
+        self.data.back()
     }
 
     pub fn get(&self, index: usize) -> Option<&T> {


### PR DESCRIPTION
Make the stream run slower if the rate limit is hit instead of interrupting

Implementation idea
- The `WorkersPool` keeps the moment of time when the worker will become available (as hinted by the `retry_after_ms` response field).
- On the query attempt, if all the suitable workers are in this paused state, the time until the next worker becomes available is selected as a "back off" time.
- The query is delayed for the back off time. It applies to both queries for the new `Slot`s and retries of the existing queries.
- If the client reads the stream up to the delayed chunk, the decision is made. If the idling time exceeds 1 second, the stream is interrupted and should be retried; otherwise it is just delayed until the data arrives. It allows the portals with small amount of CU to run the streams at their limit instead of constant failures and retries.
- In the code, the `PendingRequests.timeout` is a future that notifies when the next query should be sent. It is either set to run a follow-up query when the previous one is running for too long (as before) or to try to find a worker again when the hinted back off period ends. Note that now the `RequestState::Pending` may be created without any pending queries (in the "`paused`" state), but the `timeout` is always set.