### PR TITLE
Remove pings processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7109,7 +7109,7 @@ dependencies = [
 [[package]]
 name = "sqd-contract-client"
 version = "1.2.1"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=d69f018#d69f01821df55fe4ccd9c344e6d49c581e85e0e5"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=e4723af#e4723afe53c85f0b724f889efad7e01958924328"
 dependencies = [
  "async-trait",
  "clap",
@@ -7191,7 +7191,7 @@ source = "git+https://github.com/subsquid/data.git?rev=0837fea#0837fea0a9b74a0bf
 [[package]]
 name = "sqd-messages"
 version = "2.0.2"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=d69f018#d69f01821df55fe4ccd9c344e6d49c581e85e0e5"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=e4723af#e4723afe53c85f0b724f889efad7e01958924328"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -7199,6 +7199,7 @@ dependencies = [
  "flate2",
  "hex",
  "libp2p",
+ "libp2p-identity",
  "prost 0.13.4",
  "prost-build",
  "reqwest 0.12.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7214,7 +7215,7 @@ dependencies = [
 [[package]]
 name = "sqd-network-transport"
 version = "3.0.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=d69f018#d69f01821df55fe4ccd9c344e6d49c581e85e0e5"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=e4723af#e4723afe53c85f0b724f889efad7e01958924328"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7288,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "sqd-portal"
-version = "0.6.2"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8134,6 +8135,7 @@ dependencies = [
  "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqd-portal"
-version = "0.6.2"
+version = "0.7.1"
 edition = "2021"
 
 [dependencies]
@@ -33,7 +33,7 @@ thiserror = "1.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 tokio-stream = "0.1"
 tokio-util = "0.7.11"
-tower-http = { version = "0.6.1", features = ["cors", "decompression-gzip"] }
+tower-http = { version = "0.6.1", features = ["cors", "decompression-gzip", "trace"] }
 tracing = { version = "0.1", features = ["async-await"] }
 tracing-futures = { version = "0.2.5", features = ["tokio", "futures-03"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
@@ -43,9 +43,9 @@ uuid = { version = "1", features = ["v4", "fast-rng"] }
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", features = ["profiling"] }
 
-sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "d69f018", version = "1.2.1" }
-sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "d69f018", version = "2.0.1", features = ["semver", "bitstring", "assignment_reader"] }
-sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "d69f018", version = "3.0.0", features = ["gateway", "metrics"] }
+sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "e4723af", version = "1.2.1" }
+sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "e4723af", version = "2.0.1", features = ["semver", "bitstring", "assignment_reader"] }
+sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "e4723af", version = "3.0.0", features = ["gateway", "metrics"] }
 
 sqd-data-client = { git = "https://github.com/subsquid/data.git", rev = "0837fea" }
 sqd-hotblocks = { git = "https://github.com/subsquid/data.git", package = "sqd-node", rev = "0837fea" }

--- a/mainnet.config.yml
+++ b/mainnet.config.yml
@@ -1,6 +1,5 @@
 hostname: http://0.0.0.0:8000
 max_buffer_size: 1000
-assignments_stored: 2
 sqd_network:
   datasets: https://cdn.subsquid.io/sqd-network/datasets.yml
   serve: "all"

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,20 +18,10 @@ pub struct Config {
     #[serde(deserialize_with = "parse_hostname")]
     pub hostname: String,
 
-    #[serde(default = "default_worker_versions")]
-    pub worker_versions: semver::VersionReq,
-
     #[serde(default = "default_max_parallel_streams")]
     pub max_parallel_streams: usize,
 
     pub max_chunks_per_stream: Option<usize>,
-
-    #[serde_as(as = "DurationSeconds")]
-    #[serde(
-        rename = "worker_inactive_threshold_sec",
-        default = "default_worker_inactive_threshold"
-    )]
-    pub worker_inactive_threshold: Duration,
 
     #[serde_as(as = "DurationSeconds")]
     #[serde(
@@ -66,9 +56,6 @@ pub struct Config {
     )]
     pub assignments_update_interval: Duration,
 
-    #[serde(default = "default_assignments_stored")]
-    pub assignments_stored: usize,
-
     #[serde_as(as = "DurationSeconds")]
     #[serde(
         rename = "datasets_update_interval_sec",
@@ -82,9 +69,6 @@ pub struct Config {
 
     #[serde(default)]
     pub datasets: DatasetsConfig,
-
-    #[serde(default)]
-    pub worker_status_via_gossipsub: bool,
 }
 
 #[serde_as]
@@ -147,16 +131,8 @@ impl Config {
     }
 }
 
-fn default_worker_versions() -> semver::VersionReq {
-    semver::VersionReq::parse("^2.0.0").unwrap()
-}
-
 fn default_max_parallel_streams() -> usize {
     1024
-}
-
-fn default_worker_inactive_threshold() -> Duration {
-    Duration::from_secs(120)
 }
 
 fn default_transport_timeout() -> Duration {
@@ -164,15 +140,15 @@ fn default_transport_timeout() -> Duration {
 }
 
 fn default_default_buffer_size() -> usize {
-    10
+    50
 }
 
 fn default_max_buffer_size() -> usize {
-    100
+    1000
 }
 
 fn default_default_retries() -> u8 {
-    3
+    7
 }
 
 fn default_default_timeout_quantile() -> f32 {
@@ -185,10 +161,6 @@ fn default_chain_update_interval() -> Duration {
 
 fn default_assignments_update_interval() -> Duration {
     Duration::from_secs(60)
-}
-
-fn default_assignments_stored() -> usize {
-    5
 }
 
 fn default_datasets_update_interval() -> Duration {

--- a/src/datasets.rs
+++ b/src/datasets.rs
@@ -112,6 +112,7 @@ impl Datasets {
         self.datasets.iter()
     }
 
+    #[cfg(test)]
     pub fn network_datasets(&self) -> impl Iterator<Item = (&DatasetId, &str)> {
         self.id_to_default_name
             .iter()

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -235,6 +235,7 @@ async fn run_stream(
     let mut request = restrict_request(&config, request);
 
     let (head, body) = match (dataset.network_id, hotblocks) {
+        // TODO: prefer hotblocks storage
         // Prefer data from the network
         (Some(dataset_id), _)
             if network
@@ -327,7 +328,7 @@ async fn get_dataset_state(
     dataset_id: DatasetId,
     Extension(network): Extension<Arc<NetworkClient>>,
 ) -> impl IntoResponse {
-    axum::Json(network.dataset_state(&dataset_id).unwrap())
+    axum::Json(network.dataset_state(&dataset_id))
 }
 
 async fn get_dataset_metadata(

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,13 +83,8 @@ async fn main() -> anyhow::Result<()> {
 
     let config = Arc::new(args.config);
     let hotblocks = hotblocks::build_server(&config).await?.map(Arc::new);
-    let network_client = NetworkClient::new(
-        args.transport,
-        config.clone(),
-        datasets.clone(),
-        hotblocks.clone(),
-    )
-    .await?;
+    let network_client =
+        NetworkClient::new(args.transport, config.clone(), datasets.clone()).await?;
 
     let mut metrics_registry = Registry::with_labels(
         vec![(

--- a/src/network/state.rs
+++ b/src/network/state.rs
@@ -1,105 +1,32 @@
-use serde::Serialize;
-use std::collections::HashMap;
+use sqd_contract_client::Network;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-use sqd_messages::RangeSet;
 use sqd_network_transport::PeerId;
 
-use crate::config::Config;
-use crate::datasets::Datasets;
-use crate::metrics;
+use crate::network::StorageClient;
 use crate::types::api_types::WorkerDebugInfo;
 use crate::types::DatasetId;
 use crate::utils::RwLock;
+use crate::{datasets::Datasets, types::api_types::DatasetState};
 
 use super::priorities::{NoWorker, WorkersPool};
 
-#[derive(Default, Serialize)]
-pub struct DatasetState {
-    worker_ranges: HashMap<PeerId, RangeSet>,
-    highest_seen_block: u64,
-    first_gap: u64,
-    #[serde(skip)]
-    height_update_subscribers: Vec<Box<dyn FnMut(u64) + Send>>,
-}
-
-impl DatasetState {
-    pub fn get_workers_with_block(&self, block: u64) -> impl Iterator<Item = PeerId> + '_ {
-        self.worker_ranges
-            .iter()
-            .filter_map(move |(peer_id, range_set)| range_set.has(block).then_some(*peer_id))
-    }
-
-    pub fn update(&mut self, peer_id: PeerId, state: RangeSet) {
-        let mut could_close_gap = false;
-        if let Some(range) = state.ranges.last() {
-            if range.end > self.highest_seen_block {
-                self.highest_seen_block = range.end;
-                self.notify_height_update();
-            }
-            if range.end >= self.first_gap {
-                could_close_gap = true;
-            }
-        }
-        self.worker_ranges.insert(peer_id, state);
-        if could_close_gap {
-            self.first_gap = self.highest_indexable_block() + 1;
-        }
-    }
-
-    /// The last block such that every block from the beginning to this one is owned by at least one worker
-    pub fn highest_indexable_block(&self) -> u64 {
-        let range_set: RangeSet = self
-            .worker_ranges
-            .values()
-            .cloned()
-            .flat_map(|r| r.ranges)
-            .into();
-        match range_set.ranges.first() {
-            Some(range) => range.end,
-            _ => 0,
-        }
-    }
-
-    /// The last block known to be downloaded by at least one worker
-    pub fn highest_known_block(&self) -> u64 {
-        self.highest_seen_block
-    }
-
-    pub fn subscribe_height_updates(&mut self, subscriber: Box<dyn FnMut(u64) + Send>) {
-        self.height_update_subscribers.push(subscriber);
-    }
-
-    pub fn unsubscribe_height_updates(&mut self) {
-        self.height_update_subscribers.clear();
-    }
-
-    fn notify_height_update(&mut self) {
-        let height = self.highest_seen_block;
-        for subscriber in &mut self.height_update_subscribers {
-            subscriber(height);
-        }
-    }
-}
-
 pub struct NetworkState {
-    config: Arc<Config>,
-    datasets: Arc<RwLock<Datasets>>,
-    dataset_states: HashMap<DatasetId, DatasetState>,
-    last_pings: HashMap<PeerId, Instant>,
-    pool: WorkersPool,
+    pool: RwLock<WorkersPool>,
+    pub dataset_storage: StorageClient,
 }
 
 impl NetworkState {
-    pub fn new(config: Arc<Config>, datasets: Arc<RwLock<Datasets>>) -> Self {
+    pub fn new(datasets: Arc<RwLock<Datasets>>, network: Network) -> Self {
         Self {
-            config,
-            datasets,
-            dataset_states: Default::default(),
-            last_pings: Default::default(),
-            pool: WorkersPool::default(),
+            pool: RwLock::new(WorkersPool::default(), "NetworkState::pool"),
+            dataset_storage: StorageClient::new(datasets, network),
         }
+    }
+
+    pub async fn try_update_assignment(&self) {
+        self.dataset_storage.try_update_assignment().await;
     }
 
     // TODO: return a guard object that will automatically release the worker when dropped
@@ -107,134 +34,83 @@ impl NetworkState {
         &self,
         dataset_id: &DatasetId,
         start_block: u64,
+        lease: bool,
     ) -> Result<PeerId, NoWorker> {
         let dataset_state = self
-            .dataset_states
-            .get(dataset_id)
-            .ok_or(NoWorker::AllUnavailable)?;
+            .dataset_storage
+            .find_chunk(dataset_id, start_block)
+            .map_err(|e| {
+                tracing::warn!(
+                    %dataset_id,
+                    block = start_block,
+                    error = %e,
+                    "Requesting worker for non-existing chunk",
+                );
+                NoWorker::AllUnavailable
+            })?;
 
-        // Choose an active worker having the requested start_block with the top priority
-        let deadline = Instant::now() - self.config.worker_inactive_threshold;
-        let available = dataset_state
-            .get_workers_with_block(start_block)
-            .filter(|peer_id| Self::worker_active(&self.last_pings, peer_id, deadline));
-        self.pool.pick(available)
+        // Choose a worker having the requested start_block with the top priority
+        self.pool.write().pick(dataset_state.workers.iter().copied(), lease)
     }
 
     pub fn get_workers(&self, dataset_id: &DatasetId, start_block: u64) -> Vec<WorkerDebugInfo> {
-        let Some(dataset_state) = self.dataset_states.get(dataset_id) else {
+        let Ok(chunk) = self.dataset_storage.find_chunk(dataset_id, start_block) else {
             return vec![];
         };
 
-        let workers = dataset_state.get_workers_with_block(start_block);
-        let now = Instant::now();
         self.pool
-            .get_priorities(workers)
+            .read()
+            .get_priorities(chunk.workers.iter().copied())
             .into_iter()
-            .map(|(peer_id, priority)| WorkerDebugInfo {
-                peer_id,
-                priority,
-                since_last_heartbeat: self.last_pings.get(&peer_id).map(|t| (now - *t).as_secs()),
-            })
+            .map(|(peer_id, priority)| WorkerDebugInfo { peer_id, priority })
             .collect()
     }
 
     pub fn get_all_workers(&self) -> Vec<WorkerDebugInfo> {
-        let now = Instant::now();
+        let workers = self.dataset_storage.get_all_workers();
         self.pool
-            .get_priorities(self.last_pings.keys().copied())
+            .read()
+            .get_priorities(workers)
             .into_iter()
-            .map(|(peer_id, priority)| WorkerDebugInfo {
-                peer_id,
-                priority,
-                since_last_heartbeat: self.last_pings.get(&peer_id).map(|t| (now - *t).as_secs()),
-            })
+            .map(|(peer_id, priority)| WorkerDebugInfo { peer_id, priority })
             .collect()
     }
 
-    pub fn update_dataset_states(
-        &mut self,
-        worker_id: PeerId,
-        mut worker_state: HashMap<DatasetId, RangeSet>,
-    ) {
-        self.last_pings.insert(worker_id, Instant::now());
-        metrics::KNOWN_WORKERS.set(self.last_pings.len() as i64);
-        let datasets = self.datasets.read();
-        for (dataset_id, default_name) in datasets.network_datasets() {
-            let dataset_state = worker_state
-                .remove(dataset_id)
-                .unwrap_or_else(RangeSet::empty);
-            let entry = self.dataset_states.entry(dataset_id.clone()).or_default();
-            entry.update(worker_id, dataset_state);
-            metrics::report_dataset_updated(
-                dataset_id,
-                Some(default_name.to_owned()),
-                entry.highest_seen_block,
-                entry.first_gap,
-            );
-        }
+    pub fn lease_worker(&self, worker: PeerId) {
+        self.pool.write().lease(worker);
     }
 
-    pub fn lease_worker(&mut self, worker: PeerId) {
-        self.pool.lease(worker);
+    pub fn report_query_success(&self, worker: PeerId) {
+        self.pool.write().success(worker);
     }
 
-    pub fn report_query_success(&mut self, worker: PeerId) {
-        self.pool.success(worker);
+    pub fn report_query_error(&self, worker: PeerId) {
+        self.pool.write().error(worker);
     }
 
-    pub fn report_query_error(&mut self, worker: PeerId) {
-        self.pool.error(worker);
+    pub fn report_query_failure(&self, worker: PeerId) {
+        self.pool.write().failure(worker);
     }
 
-    pub fn report_query_failure(&mut self, worker: PeerId) {
-        self.pool.failure(worker);
+    pub fn report_query_outrun(&self, worker: PeerId) {
+        self.pool.write().outrun(worker);
     }
 
-    pub fn report_query_outrun(&mut self, worker: PeerId) {
-        self.pool.outrun(worker);
+    pub fn hint_backoff(&self, worker: PeerId, duration: Duration) {
+        self.pool.write().hint_backoff(worker, duration);
     }
 
-    pub fn hint_backoff(&mut self, worker: PeerId, duration: Duration) {
-        self.pool.hint_backoff(worker, duration);
-    }
-
-    pub fn reset_allocations(&mut self) {
-        self.pool.reset_allocations();
+    pub fn reset_allocations(&self) {
+        self.pool.write().reset_allocations();
     }
 
     pub fn get_height(&self, dataset_id: &DatasetId) -> Option<u64> {
-        self.dataset_states
-            .get(dataset_id)
-            .map(|state| state.highest_known_block())
+        self.dataset_storage
+            .head(dataset_id)
+            .map(|block| block.number)
     }
 
-    fn worker_active(
-        last_pings: &HashMap<PeerId, Instant>,
-        worker_id: &PeerId,
-        deadline: Instant,
-    ) -> bool {
-        last_pings.get(worker_id).is_some_and(|t| *t > deadline)
-    }
-
-    pub fn dataset_state(&self, dataset_id: &DatasetId) -> Option<&DatasetState> {
-        self.dataset_states.get(dataset_id)
-    }
-
-    pub fn subscribe_height_updates(
-        &mut self,
-        dataset_id: &DatasetId,
-        subscriber: Box<dyn FnMut(u64) + Send>,
-    ) {
-        self.dataset_states
-            .entry(dataset_id.clone())
-            .or_default()
-            .subscribe_height_updates(subscriber);
-    }
-
-    pub fn unsubscribe_all_height_updates(&mut self) {
-        for state in self.dataset_states.values_mut() {
-            state.unsubscribe_height_updates();
-        }
+    pub fn dataset_state(&self, dataset_id: &DatasetId) -> Option<DatasetState> {
+        self.dataset_storage.get_dataset_state(dataset_id)
     }
 }

--- a/src/network/storage.rs
+++ b/src/network/storage.rs
@@ -1,54 +1,129 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use sqd_messages::assignments;
+use itertools::Itertools;
+use sqd_contract_client::{Network, PeerId};
+use sqd_messages::assignments::{self, Assignment, ChunkSummary};
 use sqd_primitives::BlockRef;
+use tracing::instrument;
 
 use crate::{
     datasets::Datasets,
     metrics,
-    types::{BlockNumber, DataChunk, DatasetId},
+    types::{api_types::DatasetState, BlockNumber, DataChunk, DatasetId},
     utils::RwLock,
 };
 
+#[derive(Debug, Clone)]
+pub struct AssignedChunk {
+    pub chunk: DataChunk,
+    pub workers: Arc<Vec<PeerId>>,
+}
+
 pub struct DatasetIndex {
-    pub chunks: Vec<DataChunk>,
+    pub chunks: Vec<AssignedChunk>,
     pub summary: Option<assignments::ChunkSummary>,
 }
 
 pub struct StorageClient {
     datasets: RwLock<HashMap<DatasetId, DatasetIndex>>,
     datasets_config: Arc<RwLock<Datasets>>,
+    workers: RwLock<Vec<PeerId>>,
+    latest_assignment: RwLock<Option<String>>,
+    network_state_url: String,
 }
 
+#[derive(thiserror::Error, Debug, Clone)]
 pub enum ChunkNotFound {
+    #[error("Unknown dataset")]
     UnknownDataset,
+    #[error("Block is before the first block which is {first_block}")]
     BeforeFirst { first_block: BlockNumber },
+    #[error("Block falls in a gap between chunks")]
     Gap,
+    #[error("Block is after the last block")]
     AfterLast,
 }
 
 impl StorageClient {
-    pub fn new(datasets_config: Arc<RwLock<Datasets>>) -> Self {
+    pub fn new(datasets_config: Arc<RwLock<Datasets>>, network: Network) -> Self {
+        let network_state_filename = match network {
+            Network::Tethys => "network-state-tethys.json",
+            Network::Mainnet => "network-state-mainnet.json",
+        };
+        let network_state_url =
+            format!("https://metadata.sqd-datasets.io/{network_state_filename}");
         Self {
             datasets: RwLock::new(Default::default(), "StorageClient::datasets"),
             datasets_config,
+            workers: RwLock::new(Vec::new(), "StorageClient::workers"),
+            latest_assignment: RwLock::new(None, "StorageClient::latest_assignment"),
+            network_state_url,
         }
     }
 
-    pub fn update_datasets(&self, mut new_datasets: HashMap<DatasetId, DatasetIndex>) {
+    pub fn has_assignment(&self) -> bool {
+        self.latest_assignment.read().is_some()
+    }
+
+    pub async fn try_update_assignment(&self) {
+        tracing::debug!("Checking for new assignment");
+        let latest_assignment = self.latest_assignment.read().clone();
+        let assignment = match Assignment::try_download(
+            self.network_state_url.clone(),
+            latest_assignment,
+            Duration::from_secs(60),
+        )
+        .await
+        {
+            Ok(Some(assignment)) => assignment,
+            Ok(None) => {
+                tracing::debug!("Assignment has not been changed");
+                return;
+            }
+            Err(err) => {
+                tracing::error!(error = ?err, "Unable to get assignment");
+                return;
+            }
+        };
+
+        // TODO: use assignment.effective_from
+
+        let assignment_id = assignment.id.clone();
+        tracing::debug!("Got assignment {:?}", assignment_id);
+        *self.latest_assignment.write() = Some(assignment_id.clone());
+
+        let workers = assignment.get_all_peer_ids();
+        let datasets = match parse_assignment(assignment) {
+            Ok(datasets) => datasets,
+            Err(err) => {
+                tracing::error!(error = ?err, "Failed to parse assignment, waiting for the next one");
+                return;
+            }
+        };
+        tracing::debug!("Assignment parsed");
+
+        self.update_datasets(datasets);
+        crate::metrics::KNOWN_WORKERS.set(workers.len() as i64);
+        *self.workers.write() = workers;
+        tracing::info!("New assignment saved");
+    }
+
+    #[instrument(skip_all)]
+    fn update_datasets(&self, new_datasets: HashMap<DatasetId, DatasetIndex>) {
         tracing::info!("Saving known chunks");
 
-        let timer = tokio::time::Instant::now();
+        debug_assert!(
+            new_datasets
+                .values()
+                .all(|index| index.chunks.is_sorted_by_key(|c| c.chunk.first_block)),
+            "Chunks in the assignment must be sorted"
+        );
 
-        for index in new_datasets.values_mut() {
-            index.chunks.sort_by_key(|r| r.first_block);
-        }
-
-        let mut datasets = self.datasets.write();
-        for (dataset, index) in new_datasets {
+        let datasets = self.datasets.read();
+        for (dataset, index) in &new_datasets {
             let new_len = index.chunks.len();
-            let last_block = index.chunks.last().map_or(0, |r| r.last_block);
-            let prev = datasets.insert(dataset.clone(), index);
+            let last_block = index.chunks.last().map_or(0, |r| r.chunk.last_block);
+            let prev = datasets.get(dataset);
             let old_len = prev.map_or(0, |i| i.chunks.len());
             if old_len < new_len {
                 tracing::info!(
@@ -60,50 +135,57 @@ impl StorageClient {
             let dataset_name = self
                 .datasets_config
                 .read()
-                .default_name(&dataset)
+                .default_name(dataset)
                 .map(ToOwned::to_owned);
-            metrics::report_chunk_list_updated(&dataset, dataset_name, new_len, last_block);
+            metrics::report_chunk_list_updated(dataset, dataset_name, new_len, last_block);
         }
+        drop(datasets);
 
-        let elapsed = timer.elapsed().as_millis();
-        tracing::debug!("Chunks parsed in {elapsed} ms");
+        *self.datasets.write() = new_datasets;
     }
 
-    pub fn find_chunk(&self, dataset: &DatasetId, block: u64) -> Result<DataChunk, ChunkNotFound> {
+    pub fn find_chunk(
+        &self,
+        dataset: &DatasetId,
+        block: u64,
+    ) -> Result<AssignedChunk, ChunkNotFound> {
         let datasets = self.datasets.read();
         let chunks = &datasets
             .get(dataset)
             .ok_or(ChunkNotFound::UnknownDataset)?
             .chunks;
-        let first_block = chunks.first().ok_or(ChunkNotFound::Gap)?.first_block;
+        let first_block = chunks.first().ok_or(ChunkNotFound::Gap)?.chunk.first_block;
         if block < first_block {
             return Err(ChunkNotFound::BeforeFirst { first_block });
         }
-        let first_suspect = chunks.partition_point(|chunk: &DataChunk| (chunk.last_block) < block);
+        let first_suspect =
+            chunks.partition_point(|chunk: &AssignedChunk| (chunk.chunk.last_block) < block);
         if first_suspect >= chunks.len() {
             return Err(ChunkNotFound::AfterLast);
         }
-        if chunks[first_suspect].first_block <= block {
-            Ok(chunks[first_suspect])
+        if chunks[first_suspect].chunk.first_block <= block {
+            Ok(chunks[first_suspect].clone())
         } else {
             Err(ChunkNotFound::Gap)
         }
     }
 
     pub fn next_chunk(&self, dataset: &DatasetId, chunk: &DataChunk) -> Option<DataChunk> {
-        self.find_chunk(dataset, chunk.last_block + 1).ok()
+        self.find_chunk(dataset, chunk.last_block + 1)
+            .ok()
+            .map(|c| c.chunk)
     }
 
     pub fn first_block(&self, dataset: &DatasetId) -> Option<BlockNumber> {
         self.datasets
             .read()
             .get(dataset)
-            .and_then(|index| index.chunks.first().map(|chunk| chunk.first_block))
+            .and_then(|index| index.chunks.first().map(|c| c.chunk.first_block))
     }
 
     pub fn head(&self, dataset: &DatasetId) -> Option<BlockRef> {
         self.datasets.read().get(dataset).and_then(|index| {
-            let number = index.chunks.last().map(|c| c.last_block);
+            let number = index.chunks.last().map(|c| c.chunk.last_block);
             match (number, index.summary.as_ref()) {
                 (Some(number), Some(summary)) => Some(BlockRef {
                     number: number,
@@ -113,4 +195,65 @@ impl StorageClient {
             }
         })
     }
+
+    pub fn get_all_workers(&self) -> Vec<PeerId> {
+        self.workers.read().clone()
+    }
+
+    pub fn get_dataset_state(&self, dataset: &DatasetId) -> Option<DatasetState> {
+        let mut ranges: HashMap<_, Vec<_>> = HashMap::new();
+        for c in &self.datasets.read().get(dataset)?.chunks {
+            for &worker in c.workers.iter() {
+                ranges.entry(worker).or_default().push(c.chunk.range_msg())
+            }
+        }
+        Some(DatasetState {
+            worker_ranges: ranges
+                .into_iter()
+                .map(|(peer_id, ranges)| (peer_id, sqd_messages::RangeSet::from(ranges)))
+                .collect(),
+        })
+    }
+}
+
+#[tracing::instrument(skip_all)]
+fn parse_assignment(assignment: Assignment) -> anyhow::Result<HashMap<DatasetId, DatasetIndex>> {
+    let mut chunks: Vec<(DatasetId, DataChunk, Vec<PeerId>, Option<ChunkSummary>)> = assignment
+        .datasets
+        .into_iter()
+        .flat_map(|dataset| {
+            let dataset_id = DatasetId::from_url(&dataset.id);
+            dataset.chunks.into_iter().flat_map(move |chunk| {
+                chunk
+                    .id
+                    .parse::<DataChunk>()
+                    .map_err(|e| {
+                        tracing::warn!(error=%e, "Couldn't parse chunk id '{}'", chunk.id);
+                    })
+                    .map(|id| (dataset_id.clone(), id, vec![], chunk.summary))
+            })
+        })
+        .collect_vec();
+    for (peer_id, worker) in assignment.worker_assignments {
+        let mut index = 0;
+        for delta in worker.chunks_deltas {
+            index += delta;
+            chunks[index as usize].2.push(peer_id);
+        }
+    }
+    chunks.sort_unstable_by_key(|(dataset, chunk, _, _)| (dataset.clone(), chunk.first_block));
+    let mut datasets = HashMap::new();
+    for (dataset_id, chunk, workers, summary) in chunks {
+        let dataset_index = datasets.entry(dataset_id).or_insert_with(|| DatasetIndex {
+            chunks: Vec::new(),
+            summary: None,
+        });
+        dataset_index.chunks.push(AssignedChunk {
+            chunk,
+            workers: Arc::new(workers),
+        });
+        dataset_index.summary = summary; // taken from the last chunk
+    }
+
+    Ok(datasets)
 }

--- a/src/types/api_types.rs
+++ b/src/types/api_types.rs
@@ -1,5 +1,8 @@
+use std::collections::HashMap;
+
 use serde::Serialize;
 use sqd_contract_client::PeerId;
+use sqd_messages::RangeSet;
 
 use crate::{datasets::DatasetConfig, network};
 
@@ -40,7 +43,6 @@ impl From<DatasetConfig> for AvailableDatasetApiResponse {
 pub struct WorkerDebugInfo {
     pub peer_id: PeerId,
     pub priority: network::Priority,
-    pub since_last_heartbeat: Option<u64>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
@@ -49,4 +51,9 @@ pub enum DatasetRef {
     Name(String),
     #[serde(rename = "dataset_id")]
     Id(DatasetId),
+}
+
+#[derive(Default, Serialize)]
+pub struct DatasetState {
+    pub worker_ranges: HashMap<PeerId, RangeSet>,
 }

--- a/src/utils/measuring_mutex.rs
+++ b/src/utils/measuring_mutex.rs
@@ -25,18 +25,6 @@ impl<T> MeasuringMutex<T> {
             name: self.name,
         }
     }
-
-    pub fn try_lock(&self) -> Option<MeasuringMutexGuard<'_, T>> {
-        match self.mutex.try_lock() {
-            Ok(guard) => Some(MeasuringMutexGuard {
-                guard,
-                start: std::time::Instant::now(),
-                name: self.name,
-            }),
-            Err(std::sync::TryLockError::WouldBlock) => None,
-            Err(e @ std::sync::TryLockError::Poisoned(_)) => Err(e).unwrap(),
-        }
-    }
 }
 
 impl<T> Drop for MeasuringMutex<T> {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,12 +2,14 @@ pub mod conversion;
 pub mod logging;
 mod measuring_mutex;
 mod measuring_rwlock;
+#[allow(dead_code)]
 mod once;
 mod sliding_array;
 mod string_pool;
 
 pub use measuring_mutex::MeasuringMutex as Mutex;
 pub use measuring_rwlock::MeasuringRwLock as RwLock;
+#[allow(unused_imports)]
 pub use once::UseOnce;
 pub use sliding_array::SlidingArray;
 pub use string_pool::intern_string;


### PR DESCRIPTION
Thorough tracking of presence of chunks of workers is not required anymore with consistent scheduling.
Portal optimistically assumes that the chunk is present and if it gets "not found" error, it bans that worker for 30s.

It allows drastically save on heartbeats processing, only store one latest assignment and simplify state handling.

Closes #33 