### PR TITLE
Make query size limit configurable

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -90,7 +90,10 @@ pub struct Config {
     pub sentry_sampling_rate: f32,
 
     #[serde(default = "default_true")]
-    pub sentry_is_enabled: bool
+    pub sentry_is_enabled: bool,
+
+    #[serde(default = "default_max_query_size")]
+    pub max_query_size: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -186,6 +189,10 @@ fn default_assignments_update_interval() -> Duration {
 
 fn default_datasets_update_interval() -> Duration {
     Duration::from_secs(10 * 60)
+}
+
+fn default_max_query_size() -> u64 {
+    sqd_network_transport::protocol::MAX_RAW_QUERY_SIZE
 }
 
 fn default_sentry_sampling_rate() -> f32 {

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -48,6 +48,9 @@ use crate::sql;
 #[cfg(feature = "sql")]
 use axum::body;
 
+#[derive(Clone, Copy)]
+struct MaxQuerySize(u64);
+
 pub async fn run_server(
     task_manager: Arc<TaskManager>,
     network_client: Arc<NetworkClient>,
@@ -162,6 +165,7 @@ pub async fn run_server(
             // This layer is added here to be applied before the request reaches trace layers
             SetRequestIdLayer::x_request_id(MakeRequestUuid::default()),
         )
+        .layer(Extension(MaxQuerySize(config.max_query_size)))
         .layer(Extension(task_manager))
         .layer(Extension(network_client))
         .layer(Extension(config))
@@ -936,14 +940,19 @@ where
 {
     type Rejection = Response;
 
-    async fn from_request(req: Request, _state: &S) -> Result<Self, Self::Rejection> {
+    async fn from_request(mut req: Request, _state: &S) -> Result<Self, Self::Rejection> {
+        let Extension(MaxQuerySize(max_query_size)) = req
+            .extract_parts::<Extension<MaxQuerySize>>()
+            .await
+            .expect("MaxQuerySize extension should be set");
+
         let body: String = req
             .with_limited_body()
             .extract()
             .await
             .map_err(IntoResponse::into_response)?;
 
-        if body.len() as u64 > sqd_network_transport::protocol::MAX_RAW_QUERY_SIZE {
+        if body.len() as u64 > max_query_size {
             return Err(RequestError::BadRequest("Query is too large".to_string()).into_response());
         }
 


### PR DESCRIPTION
## Summary
- Add `max_query_size` config option (in bytes) to override the default 256KB query size limit
- Value is resolved once at startup and stored as a lightweight Extension — no per-request config extraction
- When not set, existing default from `sqd-network-transport` is preserved
- Allows specific portal deployments to accept larger queries (e.g. Morpho's base-mainnet queries at ~308KB)

## Usage
Add to portal config YAML:
```yaml
max_query_size: 524288  # 512KB
```

## Test plan
- [ ] Verify portal builds and tests pass
- [ ] Deploy without `max_query_size` set — confirm existing 256KB limit still applies
- [ ] Deploy with `max_query_size: 524288` — confirm larger queries are accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)