### PR TITLE
Allow setting custom query size limit NET-254

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7630,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "sqd-assignments"
 version = "0.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=020e5e9#020e5e9da5b05101c956cba79a57bcc6760266f1"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=f0018dd#f0018dd75ec2a05a125f48bdf84ae7afd3ded4fb"
 dependencies = [
  "anyhow",
  "crypto_box",
@@ -7654,7 +7654,7 @@ dependencies = [
 [[package]]
 name = "sqd-contract-client"
 version = "1.2.1"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=020e5e9#020e5e9da5b05101c956cba79a57bcc6760266f1"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=f0018dd#f0018dd75ec2a05a125f48bdf84ae7afd3ded4fb"
 dependencies = [
  "async-trait",
  "clap",
@@ -7674,7 +7674,7 @@ dependencies = [
 [[package]]
 name = "sqd-messages"
 version = "2.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=020e5e9#020e5e9da5b05101c956cba79a57bcc6760266f1"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=f0018dd#f0018dd75ec2a05a125f48bdf84ae7afd3ded4fb"
 dependencies = [
  "bytemuck",
  "flate2",
@@ -7690,7 +7690,7 @@ dependencies = [
 [[package]]
 name = "sqd-network-transport"
 version = "3.0.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=020e5e9#020e5e9da5b05101c956cba79a57bcc6760266f1"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=f0018dd#f0018dd75ec2a05a125f48bdf84ae7afd3ded4fb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7733,7 +7733,7 @@ dependencies = [
 
 [[package]]
 name = "sqd-portal"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqd-portal"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 
 [features]
@@ -60,10 +60,10 @@ proptest_async = { version = "0.2.1", default-features = false, features = ["tok
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", features = ["profiling"] }
 
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "020e5e9", features = ["reader"] }
-sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "020e5e9", version = "1.2.1" }
-sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "020e5e9", version = "2.0.1", features = ["semver", "bitstring"] }
-sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "020e5e9", version = "3.0.0", features = ["portal", "metrics"] }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "f0018dd", features = ["reader"] }
+sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "f0018dd", version = "1.2.1" }
+sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "f0018dd", version = "2.0.1", features = ["semver", "bitstring"] }
+sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "f0018dd", version = "3.0.0", features = ["portal", "metrics"] }
 
 sqd-primitives = { git = "https://github.com/subsquid/data.git", rev = "b10a969", features = ["serde"] }
 sqd-query = { git = "https://github.com/subsquid/data.git", rev = "b10a969" }

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,6 +83,13 @@ pub struct Config {
     #[serde(default)]
     pub use_gzjoin: bool,
 
+    #[serde(default)]
+    pub ignore_deprecated_workers: bool,
+
+    /// Please avoid overriding this value. It may eventually become unsupported.
+    #[serde(default = "default_query_size_limit")]
+    pub query_size_limit: u64,
+
     #[serde(default = "default_sentry_dsn")]
     pub sentry_dsn: String,
 
@@ -186,6 +193,10 @@ fn default_assignments_update_interval() -> Duration {
 
 fn default_datasets_update_interval() -> Duration {
     Duration::from_secs(10 * 60)
+}
+
+fn default_query_size_limit() -> u64 {
+    sqd_network_transport::protocol::MAX_RAW_QUERY_SIZE
 }
 
 fn default_sentry_sampling_rate() -> f32 {

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -934,14 +934,19 @@ where
 {
     type Rejection = Response;
 
-    async fn from_request(req: Request, _state: &S) -> Result<Self, Self::Rejection> {
+    async fn from_request(mut req: Request, _state: &S) -> Result<Self, Self::Rejection> {
+        let Extension(config) = req
+            .extract_parts::<Extension<Arc<Config>>>()
+            .await
+            .map_err(IntoResponse::into_response)?;
+
         let body: String = req
             .with_limited_body()
             .extract()
             .await
             .map_err(IntoResponse::into_response)?;
 
-        if body.len() as u64 > sqd_network_transport::protocol::MAX_RAW_QUERY_SIZE {
+        if body.len() as u64 > config.query_size_limit {
             return Err(RequestError::BadRequest("Query is too large".to_string()).into_response());
         }
 

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -125,12 +125,15 @@ impl NetworkClientBuilder {
 
         let datasets_copy = datasets.clone();
 
-        let network_state = NetworkState::new(
+        let mut network_state = NetworkState::new(
             datasets.clone(),
             network,
             &config.assignments_url,
             config.priorities.clone(),
         );
+        if config.ignore_deprecated_workers {
+            network_state.ignore_deprecated_workers();
+        }
 
         let this = Arc::new(NetworkClient {
             chain_update_interval: config.chain_update_interval,

--- a/src/network/state.rs
+++ b/src/network/state.rs
@@ -31,6 +31,10 @@ impl NetworkState {
         }
     }
 
+    pub fn ignore_deprecated_workers(&mut self) {
+        self.dataset_storage.ignore_deprecated_workers();
+    }
+
     pub async fn try_update_assignment(&self) {
         self.dataset_storage.try_update_assignment().await;
     }

--- a/src/network/storage.rs
+++ b/src/network/storage.rs
@@ -19,6 +19,7 @@ pub struct StorageClient {
     latest_assignment_id: RwLock<Option<String>>,
     network_state_url: String,
     reqwest_client: reqwest::Client,
+    ignore_deprecated_workers: bool,
 }
 
 #[derive(thiserror::Error, Debug, Clone)]
@@ -54,7 +55,12 @@ impl StorageClient {
                 .user_agent(format!("SQD Portal/{}", env!("CARGO_PKG_VERSION")))
                 .build()
                 .unwrap(),
+            ignore_deprecated_workers: false,
         }
+    }
+
+    pub fn ignore_deprecated_workers(&mut self) {
+        self.ignore_deprecated_workers = true;
     }
 
     pub fn has_assignment(&self) -> bool {
@@ -219,6 +225,11 @@ impl StorageClient {
             .filter_map(|idx| {
                 let w = assignment.get_worker_by_index(idx);
                 if w.status() == sqd_assignments::WorkerStatus::UnsupportedVersion {
+                    return None;
+                }
+                if self.ignore_deprecated_workers
+                    && w.status() == sqd_assignments::WorkerStatus::DeprecatedVersion
+                {
                     return None;
                 }
                 w.peer_id()


### PR DESCRIPTION
Adds two config params:
- `query_size_limit` — the default one stays at 256kb
- `ignore_deprecated_workers` — avoids using deprecated worker versions