### PR TITLE
bugfix: Do not handle unexpected base block error as 500

### DIFF
--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -601,6 +601,7 @@ fn retriable(result: &QueryResult) -> bool {
         Err(QueryError::Retriable(_)) => true,
         Err(QueryError::Failure(_)) => false,
         Err(QueryError::RateLimitExceeded) => true,
+        Err(QueryError::BaseBlockMismatch(_)) => false,
     }
 }
 

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -525,9 +525,16 @@ impl NetworkClient {
                                 Err(QueryError::Retriable(s))
                             }
                             Err::ServerError(s) => {
-                                metrics::report_query_result(&peer_id, "server_error");
-                                self.network_state.report_query_error(peer_id);
-                                Err(QueryError::Failure(s))
+                                if let Some(block_ref) = parse_base_block_mismatch(&s) {
+                                    // That's input validation rather than bad query response
+                                    metrics::report_query_result(&peer_id, "block_missmatch");
+                                    self.network_state.report_query_success(peer_id);
+                                    Err(QueryError::BaseBlockMismatch(block_ref))
+                                } else {
+                                    metrics::report_query_result(&peer_id, "server_error");
+                                    self.network_state.report_query_error(peer_id);
+                                    Err(QueryError::Failure(s))
+                                }
                             }
                             Err::ServerOverloaded(()) => {
                                 metrics::report_query_result(&peer_id, "server_overloaded");
@@ -671,4 +678,55 @@ pub fn timestamp_now_ms() -> u64 {
         .as_millis()
         .try_into()
         .expect("not that far in the future")
+}
+
+/// Parses error messages like:
+/// "unexpected base block: expected 0xabc..., but got 12345#0xdef..."
+/// we would like to have this manually parsed till
+/// https://linear.app/sqd-ai/issue/NET-248/correctly-propagate-all-errors-from-the-query-engine
+/// is realised to all workers
+fn parse_base_block_mismatch(s: &str) -> Option<BlockRef> {
+    let after_got = s
+        .strip_prefix("unexpected base block: expected ")?
+        .split(", but got ")
+        .nth(1)?;
+    let (number_str, hash) = after_got.split_once('#')?;
+    let number = number_str.parse().ok()?;
+    Some(BlockRef {
+        number,
+        hash: hash.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_base_block_mismatch_valid() {
+        let msg = "unexpected base block: expected 0x8e1f85e345e0752737699a43a07713515b97287c21b30a240e91dbfbbf1006ab, but got 24799999#0x151e093f39962caed11a903e118d74712dbf7ee18e6107224f519831b5079af8";
+        let result = parse_base_block_mismatch(msg).unwrap();
+        assert_eq!(result.number, 24799999);
+        assert_eq!(
+            result.hash,
+            "0x151e093f39962caed11a903e118d74712dbf7ee18e6107224f519831b5079af8"
+        );
+    }
+
+    #[test]
+    fn parse_base_block_mismatch_different_error() {
+        assert!(parse_base_block_mismatch("some other server error").is_none());
+    }
+
+    #[test]
+    fn parse_base_block_mismatch_malformed_no_hash() {
+        let msg = "unexpected base block: expected 0xabc, but got 12345";
+        assert!(parse_base_block_mismatch(msg).is_none());
+    }
+
+    #[test]
+    fn parse_base_block_mismatch_malformed_no_number() {
+        let msg = "unexpected base block: expected 0xabc, but got #0xdef";
+        assert!(parse_base_block_mismatch(msg).is_none());
+    }
 }

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -684,7 +684,7 @@ pub fn timestamp_now_ms() -> u64 {
 /// "unexpected base block: expected 0xabc..., but got 12345#0xdef..."
 /// we would like to have this manually parsed till
 /// https://linear.app/sqd-ai/issue/NET-248/correctly-propagate-all-errors-from-the-query-engine
-/// is realised to all workers
+/// is released to all workers
 fn parse_base_block_mismatch(s: &str) -> Option<BlockRef> {
     let after_got = s
         .strip_prefix("unexpected base block: expected ")?

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -527,7 +527,7 @@ impl NetworkClient {
                             Err::ServerError(s) => {
                                 if let Some(block_ref) = parse_base_block_mismatch(&s) {
                                     // That's input validation rather than bad query response
-                                    metrics::report_query_result(&peer_id, "block_missmatch");
+                                    metrics::report_query_result(&peer_id, "block_mismatch");
                                     self.network_state.report_query_success(peer_id);
                                     Err(QueryError::BaseBlockMismatch(block_ref))
                                 } else {

--- a/src/types/errors.rs
+++ b/src/types/errors.rs
@@ -21,6 +21,8 @@ pub enum RequestError {
     RateLimitExceeded,
     #[error("Service is overloaded, please try again later")]
     BusyFor(Duration),
+    #[error("Base block mismatch")]
+    BaseBlockMismatch(sqd_primitives::BlockRef),
 }
 
 #[derive(thiserror::Error, Debug, Clone)]
@@ -33,6 +35,8 @@ pub enum QueryError {
     Failure(String),
     #[error("rate limit exceeded")]
     RateLimitExceeded,
+    #[error("base block mismatch")]
+    BaseBlockMismatch(sqd_primitives::BlockRef),
 }
 
 #[derive(thiserror::Error, Debug, Clone)]
@@ -52,6 +56,7 @@ impl RequestError {
             }
             QueryError::Failure(s) => RequestError::Failure(format!("worker {worker} failed: {s}")),
             QueryError::RateLimitExceeded => RequestError::RateLimitExceeded,
+            QueryError::BaseBlockMismatch(block_ref) => RequestError::BaseBlockMismatch(block_ref),
         }
     }
 }
@@ -91,6 +96,13 @@ impl axum::response::IntoResponse for RequestError {
                 format!("All query attempts failed, last error: {e}"),
             )
                 .into_response(),
+
+            Self::BaseBlockMismatch(block_ref) => {
+                let body = serde_json::json!({
+                    "previousBlocks": [block_ref],
+                });
+                return (StatusCode::CONFLICT, axum::Json(body)).into_response();
+            }
         };
         response.headers_mut().insert(
             header::CONTENT_TYPE,
@@ -108,6 +120,7 @@ impl RequestError {
             Self::InternalError(_) => "internal_error",
             Self::Failure(_) => "failure",
             Self::Unavailable | Self::BusyFor(_) | Self::RateLimitExceeded => "overloaded",
+            Self::BaseBlockMismatch(_) => "base_block_mismatch",
         }
     }
 }


### PR DESCRIPTION
## What is this PR about?

Handle `unexpected base block` worker errors as [409 Conflict](https://github.com/subsquid/specs/blob/main/network-rfc/11_portal_api.md#409-conflict).

## How does that work?

When a worker returns a `ServerError` with "unexpected base block: expected ..., but got {number}#{hash}", the portal now parses it and returns a **409 Conflict** with a `previousBlocks` JSON body instead of a 500 Internal Server Error. The worker is no longer penalized for this (treated as input validation, not a server fault).

Validated with https://github.com/subsquid/network-e2e/pull/12