### PR TITLE
Net 224: gap before hotblocks

### DIFF
--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -17,8 +17,8 @@ use crate::{
     controller::timeouts::TimeoutManager,
     network::{ChunkNotFound, NetworkClient, NoWorker, QueryResult},
     types::{
-        BlockRange, ChunkId, StreamRequest, DataChunk, QueryError, RequestError, ResponseChunk,
-        SendQueryError,
+        BlockRange, ChunkId, DataChunk, QueryError, RequestError, ResponseChunk, SendQueryError,
+        StreamRequest,
     },
     utils::{logging::StreamStats, SlidingArray},
 };

--- a/src/controller/task_manager.rs
+++ b/src/controller/task_manager.rs
@@ -10,7 +10,7 @@ use tracing_futures::Instrument;
 use crate::{
     metrics,
     network::NetworkClient,
-    types::{StreamRequest, RequestError, ResponseChunk},
+    types::{RequestError, ResponseChunk, StreamRequest},
 };
 
 use super::stream::StreamController;

--- a/src/controller/timeouts.rs
+++ b/src/controller/timeouts.rs
@@ -35,8 +35,8 @@ impl TimeoutManager {
         if durations.len() < WINDOW_SIZE {
             return DEFAULT_TIMEOUT;
         }
-        let kth = ((durations.len() as f32 * self.quantile).floor() as usize)
-            .min(durations.len() - 1);
+        let kth =
+            ((durations.len() as f32 * self.quantile).floor() as usize).min(durations.len() - 1);
         // TODO: optimize time complexity
         durations.sort();
         durations[kth]

--- a/src/datasets.rs
+++ b/src/datasets.rs
@@ -189,8 +189,7 @@ struct NetworkDataset {
 async fn load_yaml<T: serde::de::DeserializeOwned>(url: &str) -> anyhow::Result<T> {
     if let Some(path) = url.strip_prefix("file://") {
         tracing::debug!("Loading local file from {}", path);
-        let file =
-            File::open(path).with_context(|| format!("failed to open file {path}"))?;
+        let file = File::open(path).with_context(|| format!("failed to open file {path}"))?;
         let reader = BufReader::new(file);
         serde_yaml::from_reader(reader).with_context(|| format!("failed to parse {path}"))
     } else {

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -429,23 +429,30 @@ async fn run_stream_internal(
 
         // Then try hotblocks storage
         _ if dataset.hotblocks.is_some() => {
-            if should_treat_as_hotblocks_gap(
-                &network,
-                &hotblocks,
-                dataset.network_id.as_ref(),
-                &dataset.default_name,
-                request.query.first_block(),
-            )
-            .await
-            {
-                return delayed_no_content_response(DATA_SOURCE_REALTIME).await;
-            }
+            let first_block = request.query.first_block();
+            let hotblocks_response = hotblocks
+                .stream(&dataset.default_name, &request.query.into_string(), mode)
+                .await;
 
-            let mut res = forward_hotblocks_response(
-                hotblocks
-                    .stream(&dataset.default_name, &request.query.into_string(), mode)
-                    .await,
-            );
+            let mut res = match hotblocks_response {
+                Ok(response) => {
+                    if !response.status().is_success()
+                        && should_treat_as_hotblocks_gap(
+                            &network,
+                            &hotblocks,
+                            dataset.network_id.as_ref(),
+                            &dataset.default_name,
+                            first_block,
+                        )
+                        .await
+                    {
+                        return delayed_no_content_response(DATA_SOURCE_REALTIME).await;
+                    }
+
+                    forward_response(response)
+                }
+                Err(e) => forward_hotblocks_response(Err(e)),
+            };
 
             if res.status().is_success() {
                 res.headers_mut()

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -428,8 +428,30 @@ async fn run_stream_internal(
         }
 
         // Then try hotblocks storage
-        // TODO: if the query is below the first hotblock, return 500 instead of 400
         _ if dataset.hotblocks.is_some() => {
+            if let Some(dataset_id) = &dataset.network_id {
+                if let Some(height) = network.get_height(dataset_id) {
+                    let first_block = request.query.first_block();
+                    if first_block > height {
+                        // Only convert a hotblocks gap to delayed 204 when status exposes the
+                        // retained range. If status has no data or cannot be fetched, preserve
+                        // the old behavior and let hotblocks answer the stream request.
+                        if let Ok(status) = hotblocks.get_status(&dataset.default_name).await {
+                            if let Some(data) = status.data {
+                                if is_hotblocks_gap(first_block, height, data.first_block) {
+                                    tokio::time::sleep(Duration::from_secs(5)).await;
+                                    return Response::builder()
+                                        .header(DATA_SOURCE_HEADER, DATA_SOURCE_REALTIME)
+                                        .status(StatusCode::NO_CONTENT)
+                                        .body(().into())
+                                        .unwrap();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             let mut res = forward_hotblocks_response(
                 hotblocks
                     .stream(&dataset.default_name, &request.query.into_string(), mode)
@@ -462,6 +484,10 @@ async fn run_stream_internal(
             )
         }
     }
+}
+
+fn is_hotblocks_gap(first_block: u64, archival_height: u64, hotblocks_first_block: u64) -> bool {
+    first_block > archival_height && first_block < hotblocks_first_block
 }
 
 async fn get_status(Extension(client): Extension<Arc<NetworkClient>>) -> impl IntoResponse {
@@ -1079,3 +1105,38 @@ const HEAD_NUMBER_HEADER: &str = "x-sqd-head-number";
 const DATA_SOURCE_HEADER: &str = "x-sqd-data-source";
 const DATA_SOURCE_NETWORK: HeaderValue = HeaderValue::from_static("network");
 const DATA_SOURCE_REALTIME: HeaderValue = HeaderValue::from_static("real_time");
+
+#[cfg(test)]
+mod tests {
+    use super::is_hotblocks_gap;
+
+    #[test]
+    fn hotblocks_gap_detects_missing_blocks_after_archival_height() {
+        assert!(is_hotblocks_gap(101, 100, 105));
+    }
+
+    #[test]
+    fn hotblocks_gap_does_not_apply_at_archival_height() {
+        assert!(!is_hotblocks_gap(100, 100, 105));
+    }
+
+    #[test]
+    fn hotblocks_gap_does_not_apply_before_archival_height() {
+        assert!(!is_hotblocks_gap(99, 100, 105));
+    }
+
+    #[test]
+    fn hotblocks_gap_does_not_apply_at_first_hotblock() {
+        assert!(!is_hotblocks_gap(105, 100, 105));
+    }
+
+    #[test]
+    fn hotblocks_gap_does_not_apply_after_first_hotblock() {
+        assert!(!is_hotblocks_gap(200, 100, 105));
+    }
+
+    #[test]
+    fn hotblocks_gap_requires_actual_gap_between_sources() {
+        assert!(!is_hotblocks_gap(101, 100, 101));
+    }
+}

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -429,27 +429,16 @@ async fn run_stream_internal(
 
         // Then try hotblocks storage
         _ if dataset.hotblocks.is_some() => {
-            if let Some(dataset_id) = &dataset.network_id {
-                if let Some(height) = network.get_height(dataset_id) {
-                    let first_block = request.query.first_block();
-                    if first_block > height {
-                        // Only convert a hotblocks gap to delayed 204 when status exposes the
-                        // retained range. If status has no data or cannot be fetched, preserve
-                        // the old behavior and let hotblocks answer the stream request.
-                        if let Ok(status) = hotblocks.get_status(&dataset.default_name).await {
-                            if let Some(data) = status.data {
-                                if is_hotblocks_gap(first_block, height, data.first_block) {
-                                    tokio::time::sleep(Duration::from_secs(5)).await;
-                                    return Response::builder()
-                                        .header(DATA_SOURCE_HEADER, DATA_SOURCE_REALTIME)
-                                        .status(StatusCode::NO_CONTENT)
-                                        .body(().into())
-                                        .unwrap();
-                                }
-                            }
-                        }
-                    }
-                }
+            if should_treat_as_hotblocks_gap(
+                &network,
+                &hotblocks,
+                dataset.network_id.as_ref(),
+                &dataset.default_name,
+                request.query.first_block(),
+            )
+            .await
+            {
+                return delayed_no_content_response(DATA_SOURCE_REALTIME).await;
             }
 
             let mut res = forward_hotblocks_response(
@@ -466,9 +455,6 @@ async fn run_stream_internal(
         }
         // If requested block is above the network height and there is no hotblocks storage, return 204
         Some(dataset_id) => {
-            // Delay request from this client for 5 seconds to avoid unnecessary retries
-            tokio::time::sleep(Duration::from_secs(5)).await;
-
             let mut res = Response::builder();
             res = res.header(DATA_SOURCE_HEADER, DATA_SOURCE_NETWORK);
             if let Some(head) = network.head(&dataset_id) {
@@ -476,7 +462,7 @@ async fn run_stream_internal(
                 res = res.header(FINALIZED_HASH_HEADER, head.hash);
                 res = res.header(HEAD_NUMBER_HEADER, head.number);
             }
-            res.status(StatusCode::NO_CONTENT).body(().into()).unwrap()
+            delayed_no_content_response_with_builder(res).await
         }
         None => {
             unreachable!(
@@ -486,8 +472,56 @@ async fn run_stream_internal(
     }
 }
 
+async fn should_treat_as_hotblocks_gap(
+    network: &NetworkClient,
+    hotblocks: &HotblocksHandle,
+    dataset_id: Option<&DatasetId>,
+    dataset_name: &str,
+    first_block: u64,
+) -> bool {
+    let Some(dataset_id) = dataset_id else {
+        return false;
+    };
+    let Some(height) = network.get_height(dataset_id) else {
+        return false;
+    };
+    if first_block <= height {
+        return false;
+    }
+
+    // Only convert a hotblocks gap to delayed 204 when status exposes the
+    // retained range. If status has no data or cannot be fetched, preserve
+    // the old behavior and let hotblocks answer the stream request.
+    let Ok(status) = hotblocks.get_status(dataset_name).await else {
+        return false;
+    };
+    let Some(data) = status.data else {
+        return false;
+    };
+
+    is_hotblocks_gap(first_block, height, data.first_block)
+}
+
 fn is_hotblocks_gap(first_block: u64, archival_height: u64, hotblocks_first_block: u64) -> bool {
     first_block > archival_height && first_block < hotblocks_first_block
+}
+
+async fn delayed_no_content_response(data_source: HeaderValue) -> Response {
+    delayed_no_content_response_with_builder(
+        Response::builder().header(DATA_SOURCE_HEADER, data_source),
+    )
+    .await
+}
+
+async fn delayed_no_content_response_with_builder(
+    builder: axum::http::response::Builder,
+) -> Response {
+    // Delay request from this client for 5 seconds to avoid unnecessary retries.
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    builder
+        .status(StatusCode::NO_CONTENT)
+        .body(().into())
+        .unwrap()
 }
 
 async fn get_status(Extension(client): Extension<Arc<NetworkClient>>) -> impl IntoResponse {

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ async fn main() -> anyhow::Result<()> {
     let args = Cli::parse();
 
     // Initialize Sentry before tracing to integrate them
-    if args.config.sentry_is_enabled { 
+    if args.config.sentry_is_enabled {
         let _sentry_guard = setup_sentry(&args.config, &args);
     }
     setup_tracing(args.json_log, args.log_span_durations);
@@ -122,12 +122,8 @@ async fn main() -> anyhow::Result<()> {
 
     let config = Arc::new(args.config);
     let hotblocks = Arc::new(hotblocks::build_client(&config).await?);
-    let network_client_builder = NetworkClient::builder(
-        args.transport,
-        config.clone(),
-        datasets.clone(),
-    )
-    .await?;
+    let network_client_builder =
+        NetworkClient::builder(args.transport, config.clone(), datasets.clone()).await?;
 
     let peer_id = network_client_builder.peer_id();
     sentry::configure_scope(|scope| {
@@ -138,11 +134,7 @@ async fn main() -> anyhow::Result<()> {
     });
 
     let mut metrics_registry = Registry::with_labels(
-        vec![(
-            Cow::Borrowed("portal_id"),
-            Cow::Owned(peer_id.to_string()),
-        )]
-        .into_iter(),
+        vec![(Cow::Borrowed("portal_id"), Cow::Owned(peer_id.to_string()))].into_iter(),
     );
     metrics::register_metrics(metrics_registry.sub_registry_with_prefix("portal"));
     sqd_network_transport::metrics::register_metrics(


### PR DESCRIPTION
### Summary

  Handle archival-to-hotblocks retention gaps as temporary no-data responses.

  When /stream routes a request to hotblocks because the requested first block is above the archival height, the portal now
  checks hotblocks status first. If the request falls before the oldest retained hotblock, it returns a delayed 204 No Content
  instead of forwarding the hotblocks error.

  ### Details

  - Added hotblocks gap detection using StatusData.first_block.
  - Preserved existing behavior when hotblocks status is unavailable or has no data.
  - Reused delayed 204 response construction for both:
      - no hotblocks source above archival height
      - confirmed archival/hotblocks gap
  - Added focused unit tests for the gap predicate and boundary cases.

  ### Validation

  - cargo test hotblocks_gap