### PR TITLE
Support traceless counterparts for the hotblocks datasets NET-433

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7646,7 +7646,7 @@ dependencies = [
 [[package]]
 name = "sqd-bloom-filter"
 version = "0.1.0"
-source = "git+https://github.com/subsquid/data.git?rev=b10a969#b10a9692b92920e4d97306f8dd32c77c79291983"
+source = "git+https://github.com/subsquid/data.git?rev=b17ed28#b17ed282eb7c5b769b3cf33e4203f9fd215f8345"
 dependencies = [
  "xxhash-rust",
 ]
@@ -7722,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "sqd-polars"
 version = "0.1.0"
-source = "git+https://github.com/subsquid/data.git?rev=b10a969#b10a9692b92920e4d97306f8dd32c77c79291983"
+source = "git+https://github.com/subsquid/data.git?rev=b17ed28#b17ed282eb7c5b769b3cf33e4203f9fd215f8345"
 dependencies = [
  "anyhow",
  "arrow",
@@ -7733,7 +7733,7 @@ dependencies = [
 
 [[package]]
 name = "sqd-portal"
-version = "0.9.7"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7795,7 +7795,7 @@ dependencies = [
 [[package]]
 name = "sqd-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subsquid/data.git?rev=b10a969#b10a9692b92920e4d97306f8dd32c77c79291983"
+source = "git+https://github.com/subsquid/data.git?rev=b17ed28#b17ed282eb7c5b769b3cf33e4203f9fd215f8345"
 dependencies = [
  "serde",
 ]
@@ -7803,7 +7803,7 @@ dependencies = [
 [[package]]
 name = "sqd-query"
 version = "0.1.0"
-source = "git+https://github.com/subsquid/data.git?rev=b10a969#b10a9692b92920e4d97306f8dd32c77c79291983"
+source = "git+https://github.com/subsquid/data.git?rev=b17ed28#b17ed282eb7c5b769b3cf33e4203f9fd215f8345"
 dependencies = [
  "anyhow",
  "arrow",
@@ -7820,6 +7820,7 @@ dependencies = [
  "sqd-bloom-filter",
  "sqd-polars",
  "sqd-primitives",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqd-portal"
-version = "0.9.8"
+version = "0.9.9"
 edition = "2021"
 
 [features]
@@ -65,8 +65,7 @@ sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev
 sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "f0018dd", version = "2.0.1", features = ["semver", "bitstring"] }
 sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "f0018dd", version = "3.0.0", features = ["portal", "metrics"] }
 
-sqd-primitives = { git = "https://github.com/subsquid/data.git", rev = "b10a969", features = ["serde"] }
-sqd-query = { git = "https://github.com/subsquid/data.git", rev = "b10a969" }
+sqd-primitives = { git = "https://github.com/subsquid/data.git", rev = "b17ed28", features = ["serde"] }
+sqd-query = { git = "https://github.com/subsquid/data.git", rev = "b17ed28" }
 
 sql_query_plan = { git = "https://github.com/subsquid/qplan.git", rev = "2e61b51", optional = true }
-

--- a/src/config.rs
+++ b/src/config.rs
@@ -138,6 +138,8 @@ pub struct RealTimeConfig {
     pub url: Url,
     // By default use the dataset name as in the config key
     pub dataset: Option<String>,
+    // If set, queries that don't require traces or statediffs are routed here
+    pub dataset_traceless: Option<String>,
     // By default use the kind in config
     pub kind: Option<String>,
 }

--- a/src/endpoints/stream.rs
+++ b/src/endpoints/stream.rs
@@ -13,7 +13,7 @@ use crate::{
     config::Config,
     controller::task_manager::TaskManager,
     datasets::DatasetConfig,
-    hotblocks::{HotblocksHandle, StreamMode},
+    hotblocks::{traceless_key, HotblocksHandle, StreamMode},
     http_server::{forward_hotblocks_response, forward_response},
     network::NetworkClient,
     types::{Compression, DatasetId, RequestError, StreamRequest},
@@ -119,6 +119,19 @@ async fn run_stream_internal(
 ) -> Response {
     let request = restrict_request(&config, request);
 
+    // Use the traceless hotblocks variant when the query doesn't need traces/statediffs
+    let hotblocks_name = if dataset
+        .hotblocks
+        .as_ref()
+        .and_then(|r| r.dataset_traceless.as_ref())
+        .is_some()
+        && request.query.is_traceless()
+    {
+        traceless_key(&dataset.default_name)
+    } else {
+        dataset.default_name.clone()
+    };
+
     match dataset.network_id.clone() {
         Some(dataset_id)
             if network
@@ -130,15 +143,15 @@ async fn run_stream_internal(
                 config,
                 network,
                 hotblocks,
-                dataset,
                 request,
                 mode,
                 dataset_id,
+                hotblocks_name,
             )
             .await
         }
         _ if dataset.hotblocks.is_some() => {
-            stream_from_hotblocks(network, hotblocks, dataset, request, mode).await
+            stream_from_hotblocks(network, hotblocks, dataset, request, mode, hotblocks_name).await
         }
         Some(dataset_id) => stream_after_network_head(&network, dataset_id).await,
         None => {
@@ -154,19 +167,18 @@ async fn stream_from_network(
     config: Arc<Config>,
     network: Arc<NetworkClient>,
     hotblocks: Arc<HotblocksHandle>,
-    dataset: DatasetConfig,
     mut request: StreamRequest,
     mode: StreamMode,
     dataset_id: DatasetId,
+    hotblocks_name: String,
 ) -> Response {
     let archival_head = network.head(&dataset_id);
     let head_task = tokio::spawn({
         let archival_head = archival_head.clone();
         async move {
-            let ds = &dataset.default_name;
             let head = match mode {
-                StreamMode::RealTime => hotblocks.get_head(ds).await,
-                StreamMode::Finalized => hotblocks.get_finalized_head(ds).await,
+                StreamMode::RealTime => hotblocks.get_head(&hotblocks_name).await,
+                StreamMode::Finalized => hotblocks.get_finalized_head(&hotblocks_name).await,
             };
             head.ok().or(archival_head.clone()).map(|b| b.number)
         }
@@ -201,10 +213,11 @@ async fn stream_from_hotblocks(
     dataset: DatasetConfig,
     request: StreamRequest,
     mode: StreamMode,
+    hotblocks_name: String,
 ) -> Response {
     let first_block = request.query.first_block();
     let hotblocks_response = hotblocks
-        .stream(&dataset.default_name, &request.query.into_string(), mode)
+        .stream(&hotblocks_name, &request.query.into_string(), mode)
         .await;
 
     let mut res = match hotblocks_response {
@@ -214,7 +227,7 @@ async fn stream_from_hotblocks(
                     &network,
                     &hotblocks,
                     dataset.network_id.as_ref(),
-                    &dataset.default_name,
+                    &hotblocks_name,
                     first_block,
                 )
                 .await

--- a/src/hotblocks.rs
+++ b/src/hotblocks.rs
@@ -6,8 +6,13 @@ use crate::config::Config;
 
 pub struct HotblocksHandle {
     pub client: reqwest::Client,
-    // Datasets are referenced by their default name in the config
+    // Datasets are referenced by their default name in the config.
+    // Traceless variants are stored under the key returned by `traceless_key`.
     pub urls: BTreeMap<String, String>,
+}
+
+pub fn traceless_key(default_name: &str) -> String {
+    format!("{default_name}#traceless")
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -56,6 +61,16 @@ pub async fn build_client(config: &Config) -> anyhow::Result<HotblocksHandle> {
                 .join(remote_name)
                 .unwrap();
             urls.insert(default_name.clone(), url.into());
+
+            if let Some(traceless_name) = &hotblocks.dataset_traceless {
+                let traceless_url = hotblocks
+                    .url
+                    .join("datasets/")
+                    .unwrap()
+                    .join(traceless_name)
+                    .unwrap();
+                urls.insert(traceless_key(default_name), traceless_url.into());
+            }
         }
     }
 

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -48,6 +48,15 @@ impl ParsedQuery {
         self.parsed.last_block()
     }
 
+    /// Returns `true` when the query does not need traces or statediffs,
+    /// meaning it can be served by a traceless dataset.
+    pub fn is_traceless(&self) -> bool {
+        match &self.parsed {
+            Query::Eth(q) => !q.requires_traces() && !q.requires_statediffs(),
+            _ => false,
+        }
+    }
+
     pub fn intersect_with(&self, range: &BlockRange) -> Option<BlockRange> {
         let begin = std::cmp::max(*range.start(), self.first_block());
         let end = if let Some(last_block) = self.last_block() {
@@ -81,6 +90,9 @@ impl ParsedQuery {
                     q.parent_block_hash = None;
                 }
                 Query::HyperliquidReplicaCmds(ref mut q) => {
+                    q.parent_block_hash = None;
+                }
+                Query::Tron(ref mut q) => {
                     q.parent_block_hash = None;
                 }
             }


### PR DESCRIPTION
This change allows using two hotblocks datasets under a single name. One version doesn't have traces/statediffs and is only used when the query doesn't use them. Another one is the full dataset and is only used for queries requiring traces/statediffs.

It should allow reducing latency for simple queries significantly.