### PR TITLE
Decrement running queries on failure

### DIFF
--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -573,6 +573,7 @@ impl NetworkClient {
             }
             Err(QueryFailure::InvalidRequest(e)) => {
                 metrics::report_query_result(&peer_id, "invalid");
+                self.network_state.report_query_failure(peer_id);
                 Err(QueryError::Failure(format!(
                     "portal tried to send invalid request: {e}"
                 )))


### PR DESCRIPTION
my suspicion is that there can be requests to workers that don't decrement running queries on failure so portal keeps treating some workers as "Busy"