### PR TITLE
Net 86 data heavy queries

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -94,6 +94,9 @@ pub struct Config {
     #[serde(default)]
     pub use_gzjoin: bool,
 
+    #[serde(default = "default_true")]
+    pub eager_continuations: bool,
+
     #[serde(default)]
     pub ignore_deprecated_workers: bool,
 

--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -106,6 +106,8 @@ struct Slot {
     state: RequestState,
 }
 
+/// Represents a chunk's parts (possibly multiple consecutive DataRange requests).
+/// Invariant: the front contains the next part to emit (Done/Partial), newer continuations are appended to the back.
 struct ChunkSlot {
     parts: VecDeque<Slot>,
 }
@@ -306,15 +308,8 @@ impl StreamController {
                     slot.take_partial_continuation_if_eager(self.request.eager_continuations)
                 };
                 if let Some(next_data_range) = next_data_range {
-                    let next_slot = match self.start_querying_chunk(next_data_range, ctx) {
-                        Ok(slot) => slot,
-                        Err((slot, e)) => {
-                            tracing::debug!("Couldn't schedule continuation request: {e:?}");
-                            slot
-                        }
-                    };
-                    chunk_slot.parts.push_back(next_slot);
-                    updated = true;
+                    let status = self.schedule_continuation(chunk_slot, next_data_range, false, ctx);
+                    updated |= status.updated();
                 }
             }
 
@@ -326,6 +321,28 @@ impl StreamController {
         } else {
             UpdateStatus::NotUpdated
         }
+    }
+
+    fn schedule_continuation(
+        &mut self,
+        chunk_slot: &mut ChunkSlot,
+        next_data_range: DataRange,
+        push_front: bool,
+        ctx: &mut Context<'_>,
+    ) -> UpdateStatus {
+        let next_slot = match self.start_querying_chunk(next_data_range, ctx) {
+            Ok(slot) => slot,
+            Err((slot, e)) => {
+                tracing::debug!("Couldn't schedule continuation request: {e:?}");
+                slot
+            }
+        };
+        if push_front {
+            chunk_slot.parts.push_front(next_slot);
+        } else {
+            chunk_slot.parts.push_back(next_slot);
+        }
+        UpdateStatus::Updated
     }
 
     #[instrument(skip_all, level="debug", fields(chunk_index = slot.data_range.chunk_index))]
@@ -590,14 +607,7 @@ impl StreamController {
                 let read_range =
                     BlockRange::new(*slot.data_range.range.start(), *next_range.start() - 1);
                 let next_data_range = slot.data_range.with_range(next_range);
-                let slot = match self.start_querying_chunk(next_data_range, ctx) {
-                    Ok(slot) => slot,
-                    Err((slot, e)) => {
-                        tracing::debug!("Couldn't schedule continuation request: {e:?}");
-                        slot
-                    }
-                };
-                chunk_slot.parts.push_front(slot);
+                let _ = self.schedule_continuation(&mut chunk_slot, next_data_range, true, ctx);
                 self.buffer.push_front(chunk_slot);
                 (Poll::Ready(Some(Ok(data))), read_range)
             }
@@ -776,7 +786,7 @@ impl StreamController {
             range.range.end(),
             lease,
         );
-        let query = query_for_range(&mut self.request.query, &range.range);
+        let query = build_query_for_range(&mut self.request.query, &range.range);
         let start_time = tokio::time::Instant::now();
 
         let priority = self.stream_index * self.priority_stride + range.chunk_index as u32;
@@ -863,9 +873,19 @@ impl Slot {
             unreachable!("slot state was checked to be partial")
         };
 
-        let read_range = BlockRange::new(*self.data_range.range.start(), *next_range.start() - 1);
-        let next_data_range = self.data_range.clone().with_range(next_range);
-        self.data_range = self.data_range.clone().with_range(read_range);
+        // Clone the current data_range once and compute both the read_range and the next_data_range from it.
+        let old = self.data_range.clone();
+        let read_range = BlockRange::new(*old.range.start(), *next_range.start() - 1);
+        let next_data_range = DataRange {
+            range: next_range,
+            chunk: old.chunk.clone(),
+            chunk_index: old.chunk_index,
+        };
+        self.data_range = DataRange {
+            range: read_range,
+            chunk: old.chunk,
+            chunk_index: old.chunk_index,
+        };
         self.state = RequestState::Done(Ok(data));
         Some(next_data_range)
     }
@@ -991,7 +1011,7 @@ fn parse_response(
     state
 }
 
-fn query_for_range(query: &mut crate::types::ParsedQuery, range: &BlockRange) -> String {
+fn build_query_for_range(query: &mut crate::types::ParsedQuery, range: &BlockRange) -> String {
     if *range.start() == query.first_block() {
         query.to_string()
     } else {
@@ -1143,10 +1163,26 @@ mod tests {
         }"#;
         let mut query = ParsedQuery::try_from(query_json.to_owned()).unwrap();
 
-        let first_query = query_for_range(&mut query, &BlockRange::new(100, 120));
-        let continuation_query = query_for_range(&mut query, &BlockRange::new(121, 200));
+        let first_query = build_query_for_range(&mut query, &BlockRange::new(100, 120));
+        let continuation_query = build_query_for_range(&mut query, &BlockRange::new(121, 200));
 
         assert!(first_query.contains("parentBlockHash"));
         assert!(!continuation_query.contains("parentBlockHash"));
+    }
+
+    #[test]
+    fn chunk_slot_allows_many_parts() {
+        let mut chunk_slot = ChunkSlot::new(partial_slot(100, 200, 120, b"first"));
+        for i in 0..1000 {
+            chunk_slot.parts.push_back(Slot {
+                data_range: DataRange {
+                    range: BlockRange::new(201 + i, 300 + i),
+                    chunk: test_chunk(),
+                    chunk_index: (i + 1) as usize,
+                },
+                state: RequestState::NoWorkers,
+            });
+        }
+        assert_eq!(chunk_slot.parts.len(), 1001);
     }
 }

--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -188,6 +188,11 @@ enum PendingSlotPoll {
     NotUpdated,
 }
 
+enum ContinuationPosition {
+    Front,
+    Back,
+}
+
 impl UpdateStatus {
     fn updated(&self) -> bool {
         matches!(self, UpdateStatus::Updated)
@@ -308,8 +313,12 @@ impl StreamController {
                     slot.take_partial_continuation_if_eager(self.request.eager_continuations)
                 };
                 if let Some(next_data_range) = next_data_range {
-                    let status =
-                        self.schedule_continuation(chunk_slot, next_data_range, false, ctx);
+                    let status = self.schedule_continuation(
+                        chunk_slot,
+                        next_data_range,
+                        ContinuationPosition::Back,
+                        ctx,
+                    );
                     updated |= status.updated();
                 }
             }
@@ -328,7 +337,7 @@ impl StreamController {
         &mut self,
         chunk_slot: &mut ChunkSlot,
         next_data_range: DataRange,
-        push_front: bool,
+        position: ContinuationPosition,
         ctx: &mut Context<'_>,
     ) -> UpdateStatus {
         let next_slot = match self.start_querying_chunk(next_data_range, ctx) {
@@ -338,10 +347,9 @@ impl StreamController {
                 slot
             }
         };
-        if push_front {
-            chunk_slot.parts.push_front(next_slot);
-        } else {
-            chunk_slot.parts.push_back(next_slot);
+        match position {
+            ContinuationPosition::Front => chunk_slot.parts.push_front(next_slot),
+            ContinuationPosition::Back => chunk_slot.parts.push_back(next_slot),
         }
         UpdateStatus::Updated
     }
@@ -608,7 +616,12 @@ impl StreamController {
                 let read_range =
                     BlockRange::new(*slot.data_range.range.start(), *next_range.start() - 1);
                 let next_data_range = slot.data_range.with_range(next_range);
-                let _ = self.schedule_continuation(&mut chunk_slot, next_data_range, true, ctx);
+                let _ = self.schedule_continuation(
+                    &mut chunk_slot,
+                    next_data_range,
+                    ContinuationPosition::Front,
+                    ctx,
+                );
                 self.buffer.push_front(chunk_slot);
                 (Poll::Ready(Some(Ok(data))), read_range)
             }
@@ -1172,18 +1185,44 @@ mod tests {
     }
 
     #[test]
-    fn chunk_slot_allows_many_parts() {
-        let mut chunk_slot = ChunkSlot::new(partial_slot(100, 200, 120, b"first"));
-        for i in 0..1000 {
+    fn chunk_slot_keeps_many_continuations_in_same_chunk_order() {
+        let mut chunk_slot = ChunkSlot::new(Slot {
+            data_range: data_range(100, 120),
+            state: RequestState::Done(Ok(b"first".to_vec())),
+        });
+        for i in 0..3 {
+            let start = 121 + i * 10;
             chunk_slot.parts.push_back(Slot {
                 data_range: DataRange {
-                    range: BlockRange::new(201 + i, 300 + i),
+                    range: BlockRange::new(start, start + 9),
                     chunk: test_chunk(),
-                    chunk_index: (i + 1) as usize,
+                    chunk_index: 0,
                 },
                 state: RequestState::NoWorkers,
             });
         }
-        assert_eq!(chunk_slot.parts.len(), 1001);
+
+        let ranges: Vec<_> = chunk_slot
+            .parts
+            .iter()
+            .map(|slot| slot.data_range.range.clone())
+            .collect();
+        assert_eq!(
+            ranges,
+            vec![
+                BlockRange::new(100, 120),
+                BlockRange::new(121, 130),
+                BlockRange::new(131, 140),
+                BlockRange::new(141, 150),
+            ]
+        );
+        assert!(chunk_slot
+            .parts
+            .iter()
+            .all(|slot| slot.data_range.chunk == test_chunk()));
+        assert!(chunk_slot
+            .parts
+            .iter()
+            .all(|slot| slot.data_range.chunk_index == 0));
     }
 }

--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -308,7 +308,8 @@ impl StreamController {
                     slot.take_partial_continuation_if_eager(self.request.eager_continuations)
                 };
                 if let Some(next_data_range) = next_data_range {
-                    let status = self.schedule_continuation(chunk_slot, next_data_range, false, ctx);
+                    let status =
+                        self.schedule_continuation(chunk_slot, next_data_range, false, ctx);
                     updated |= status.updated();
                 }
             }

--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -56,6 +56,7 @@
 #![allow(unstable_name_collisions)]
 
 use std::{
+    collections::VecDeque,
     future::Future,
     pin::Pin,
     sync::Arc,
@@ -83,7 +84,7 @@ const MAX_IDLE_TIME: Duration = Duration::from_millis(1000);
 pub struct StreamController {
     request: StreamRequest,
     network: Arc<NetworkClient>,
-    buffer: SlidingArray<Slot>,
+    buffer: SlidingArray<ChunkSlot>,
     next_chunk: Option<DataChunk>,
     timeouts: TimeoutManager,
     stats: StreamStats,
@@ -105,6 +106,10 @@ struct Slot {
     state: RequestState,
 }
 
+struct ChunkSlot {
+    parts: VecDeque<Slot>,
+}
+
 enum RequestState {
     /// Couldn't find enough workers now.
     /// Retry whenever the stream is polled, or give up if this is the first slot.
@@ -114,8 +119,9 @@ enum RequestState {
     Paused(PausedState),
     /// Workers are allocated and queries to some of them are running. Waiting for the results.
     Pending(PendingRequests),
-    /// We've got a successful result from one of the workers but it didn't cover the whole chunk range.
-    /// A continuation request should be sent once we feed this result to the client.
+    /// We've got a successful result from one of the workers but it didn't cover the whole chunk
+    /// range. Depending on request settings, a continuation request is either scheduled eagerly
+    /// while polling or later when this result is fed to the client.
     Partial(PartialResult),
     /// Either a successful result has been received, or all the attempts have failed.
     Done(Result<ResponseChunk, RequestError>),
@@ -242,8 +248,8 @@ impl StreamController {
         // extract this field to be able to pass both its values and `&mut self` to the method
         let mut buffer = std::mem::take(&mut self.buffer);
         let mut updated = false;
-        for slot in buffer.iter_mut() {
-            updated |= self.poll_slot(slot, ctx).updated();
+        for chunk_slot in buffer.iter_mut() {
+            updated |= self.poll_chunk_slot(chunk_slot, ctx).updated();
         }
         self.buffer = buffer;
 
@@ -253,7 +259,7 @@ impl StreamController {
                 self.buffer
                     .data()
                     .iter()
-                    .map(|s| s.state.debug_symbol())
+                    .map(ChunkSlot::debug_symbol)
                     .collect::<String>()
             );
         }
@@ -268,6 +274,58 @@ impl StreamController {
         }
 
         result
+    }
+
+    fn poll_chunk_slot(
+        &mut self,
+        chunk_slot: &mut ChunkSlot,
+        ctx: &mut Context<'_>,
+    ) -> UpdateStatus {
+        let mut updated = false;
+        let mut idx = 0;
+        while idx < chunk_slot.parts.len() {
+            let slot_updated = {
+                // `idx` is bounded by the loop condition and this loop only appends new parts.
+                // If the invariant is ever broken, stop polling this chunk for now; the stream
+                // will be polled again and the debug assertion will point to the scheduling bug.
+                let Some(slot) = chunk_slot.parts.get_mut(idx) else {
+                    debug_assert!(false, "chunk part index should be in bounds");
+                    break;
+                };
+                self.poll_slot(slot, ctx).updated()
+            };
+            updated |= slot_updated;
+
+            if self.request.eager_continuations {
+                let next_data_range = {
+                    // Same invariant as above: no part is removed while polling a chunk slot.
+                    let Some(slot) = chunk_slot.parts.get_mut(idx) else {
+                        debug_assert!(false, "chunk part index should be in bounds");
+                        break;
+                    };
+                    slot.take_partial_continuation()
+                };
+                if let Some(next_data_range) = next_data_range {
+                    let next_slot = match self.start_querying_chunk(next_data_range, ctx) {
+                        Ok(slot) => slot,
+                        Err((slot, e)) => {
+                            tracing::debug!("Couldn't schedule continuation request: {e:?}");
+                            slot
+                        }
+                    };
+                    chunk_slot.parts.push_back(next_slot);
+                    updated = true;
+                }
+            }
+
+            idx += 1;
+        }
+
+        if updated {
+            UpdateStatus::Updated
+        } else {
+            UpdateStatus::NotUpdated
+        }
     }
 
     #[instrument(skip_all, level="debug", fields(chunk_index = slot.data_range.chunk_index))]
@@ -486,12 +544,22 @@ impl StreamController {
         &mut self,
         ctx: &mut Context<'_>,
     ) -> Poll<Option<Result<ResponseChunk, RequestError>>> {
-        let Some(slot) = self.buffer.pop_front() else {
-            return Poll::Ready(None);
+        let (mut chunk_slot, slot) = loop {
+            let Some(mut chunk_slot) = self.buffer.pop_front() else {
+                return Poll::Ready(None);
+            };
+            if let Some(slot) = chunk_slot.parts.pop_front() {
+                break (chunk_slot, slot);
+            }
         };
         let chunk_index = slot.data_range.chunk_index;
         let (result, read_range) = match slot.state {
-            RequestState::Done(result) => (Poll::Ready(Some(result)), slot.data_range.range),
+            RequestState::Done(result) => {
+                if !chunk_slot.parts.is_empty() {
+                    self.buffer.push_front(chunk_slot);
+                }
+                (Poll::Ready(Some(result)), slot.data_range.range)
+            }
             RequestState::NoWorkers => {
                 // We don't know how long we'll have to wait, so give up immediately
                 return Poll::Ready(Some(Err(RequestError::Unavailable)));
@@ -506,13 +574,15 @@ impl StreamController {
                     self.stats.throttled(duration);
                 }
                 let range = slot.data_range.range.clone();
-                self.buffer.push_front(slot);
+                chunk_slot.parts.push_front(slot);
+                self.buffer.push_front(chunk_slot);
                 (Poll::Pending, range)
             }
             RequestState::Pending(_) => {
                 // The query is still running, keep waiting
                 let range = slot.data_range.range.clone();
-                self.buffer.push_front(slot);
+                chunk_slot.parts.push_front(slot);
+                self.buffer.push_front(chunk_slot);
                 (Poll::Pending, range)
             }
             RequestState::Partial(PartialResult { data, next_range }) => {
@@ -527,7 +597,8 @@ impl StreamController {
                         slot
                     }
                 };
-                self.buffer.push_front(slot);
+                chunk_slot.parts.push_front(slot);
+                self.buffer.push_front(chunk_slot);
                 (Poll::Ready(Some(Ok(data))), read_range)
             }
         };
@@ -551,7 +622,7 @@ impl StreamController {
         if let Some(Slot {
             state: RequestState::Paused(_),
             ..
-        }) = self.buffer.back()
+        }) = self.buffer.back().and_then(ChunkSlot::back)
         {
             // Either the amount of compute units is low or the network is overloaded.
             // Don't send new queries until the existing ones complete.
@@ -577,7 +648,7 @@ impl StreamController {
             ) {
                 Ok(slot) => {
                     let paused = slot.is_paused();
-                    self.buffer.push_back(slot);
+                    self.buffer.push_back(ChunkSlot::new(slot));
                     self.next_chunk = self.get_next_chunk(&chunk);
                     if paused {
                         break;
@@ -590,7 +661,7 @@ impl StreamController {
                     if self.buffer.len() == 0 {
                         // Couldn't schedule a new request with no ongoing requests
                         // Return the error immediately
-                        self.buffer.push_back(slot);
+                        self.buffer.push_back(ChunkSlot::new(slot));
                     }
                     self.last_error = Some(e.to_string());
                     self.next_chunk = Some(chunk);
@@ -780,6 +851,45 @@ impl DataRange {
 impl Slot {
     fn is_paused(&self) -> bool {
         matches!(&self.state, RequestState::Paused(_))
+    }
+
+    fn take_partial_continuation(&mut self) -> Option<DataRange> {
+        let RequestState::Partial(_) = self.state else {
+            return None;
+        };
+
+        let state = std::mem::replace(&mut self.state, RequestState::NoWorkers);
+        let RequestState::Partial(PartialResult { data, next_range }) = state else {
+            unreachable!("slot state was checked to be partial")
+        };
+
+        let read_range = BlockRange::new(*self.data_range.range.start(), *next_range.start() - 1);
+        let next_data_range = self.data_range.clone().with_range(next_range);
+        self.data_range = self.data_range.clone().with_range(read_range);
+        self.state = RequestState::Done(Ok(data));
+        Some(next_data_range)
+    }
+}
+
+impl ChunkSlot {
+    fn new(slot: Slot) -> Self {
+        Self {
+            parts: VecDeque::from([slot]),
+        }
+    }
+
+    fn back(&self) -> Option<&Slot> {
+        self.parts.back()
+    }
+
+    fn debug_symbol(&self) -> char {
+        if self.parts.len() > 1 {
+            return '*';
+        }
+        self.parts
+            .front()
+            .map(|slot| slot.state.debug_symbol())
+            .unwrap_or('_')
     }
 }
 

--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -106,10 +106,15 @@ struct Slot {
     state: RequestState,
 }
 
-/// Represents a chunk's parts (possibly multiple consecutive DataRange requests).
-/// Invariant: the front contains the next part to emit (Done/Partial), newer continuations are appended to the back.
+struct BufferedResponse {
+    chunk_index: usize,
+    read_range: BlockRange,
+    result: Result<ResponseChunk, RequestError>,
+}
+
 struct ChunkSlot {
-    parts: VecDeque<Slot>,
+    pending_responses: VecDeque<BufferedResponse>,
+    active: Option<Slot>,
 }
 
 enum RequestState {
@@ -186,11 +191,6 @@ struct PendingPollSummary {
 enum PendingSlotPoll {
     Updated(RequestState),
     NotUpdated,
-}
-
-enum ContinuationPosition {
-    Front,
-    Back,
 }
 
 impl UpdateStatus {
@@ -289,41 +289,27 @@ impl StreamController {
         ctx: &mut Context<'_>,
     ) -> UpdateStatus {
         let mut updated = false;
-        let mut idx = 0;
-        while idx < chunk_slot.parts.len() {
-            let slot_updated = {
-                // `idx` is bounded by the loop condition and this loop only appends new parts.
-                // If the invariant is ever broken, stop polling this chunk for now; the stream
-                // will be polled again and the debug assertion will point to the scheduling bug.
-                let Some(slot) = chunk_slot.parts.get_mut(idx) else {
-                    debug_assert!(false, "chunk part index should be in bounds");
-                    break;
-                };
-                self.poll_slot(slot, ctx).updated()
-            };
-            updated |= slot_updated;
+
+        while let Some(slot) = chunk_slot.active.as_mut() {
+            updated |= self.poll_slot(slot, ctx).updated();
+
+            if let Some(response) = slot.take_completed_response() {
+                chunk_slot.pending_responses.push_back(response);
+                chunk_slot.active = None;
+                updated = true;
+                break;
+            }
 
             if self.request.eager_continuations {
-                let next_data_range = {
-                    // Same invariant as above: no part is removed while polling a chunk slot.
-                    let Some(slot) = chunk_slot.parts.get_mut(idx) else {
-                        debug_assert!(false, "chunk part index should be in bounds");
-                        break;
-                    };
-                    slot.take_partial_continuation_if_eager(self.request.eager_continuations)
-                };
-                if let Some(next_data_range) = next_data_range {
-                    let status = self.schedule_continuation(
-                        chunk_slot,
-                        next_data_range,
-                        ContinuationPosition::Back,
-                        ctx,
-                    );
-                    updated |= status.updated();
+                if let Some((response, next_data_range)) = slot.take_partial_continuation() {
+                    chunk_slot.pending_responses.push_back(response);
+                    self.schedule_continuation(chunk_slot, next_data_range, ctx);
+                    updated = true;
+                    continue;
                 }
             }
 
-            idx += 1;
+            break;
         }
 
         if updated {
@@ -337,9 +323,8 @@ impl StreamController {
         &mut self,
         chunk_slot: &mut ChunkSlot,
         next_data_range: DataRange,
-        position: ContinuationPosition,
         ctx: &mut Context<'_>,
-    ) -> UpdateStatus {
+    ) {
         let next_slot = match self.start_querying_chunk(next_data_range, ctx) {
             Ok(slot) => slot,
             Err((slot, e)) => {
@@ -347,12 +332,8 @@ impl StreamController {
                 slot
             }
         };
-        match position {
-            ContinuationPosition::Front => chunk_slot.parts.push_front(next_slot),
-            ContinuationPosition::Back => chunk_slot.parts.push_back(next_slot),
-        }
-        self.stats.observe_chunk_parts(chunk_slot.parts.len());
-        UpdateStatus::Updated
+        chunk_slot.active = Some(next_slot);
+        self.stats.observe_chunk_parts(chunk_slot.num_parts());
     }
 
     #[instrument(skip_all, level="debug", fields(chunk_index = slot.data_range.chunk_index))]
@@ -571,71 +552,88 @@ impl StreamController {
         &mut self,
         ctx: &mut Context<'_>,
     ) -> Poll<Option<Result<ResponseChunk, RequestError>>> {
-        let (mut chunk_slot, slot) = loop {
-            let Some(mut chunk_slot) = self.buffer.pop_front() else {
+        let mut chunk_slot = loop {
+            let Some(chunk_slot) = self.buffer.pop_front() else {
                 return Poll::Ready(None);
             };
-            if let Some(slot) = chunk_slot.parts.pop_front() {
-                break (chunk_slot, slot);
+            if !chunk_slot.is_empty() {
+                break chunk_slot;
             }
         };
-        let chunk_index = slot.data_range.chunk_index;
-        let (result, read_range) = match slot.state {
-            RequestState::Done(result) => {
-                if !chunk_slot.parts.is_empty() {
-                    self.buffer.push_front(chunk_slot);
-                }
-                (Poll::Ready(Some(result)), slot.data_range.range)
+
+        if let Some(response) = chunk_slot.pending_responses.pop_front() {
+            if !chunk_slot.is_empty() {
+                self.buffer.push_front(chunk_slot);
             }
+            return self.emit_buffered_response(response);
+        }
+
+        let Some(slot) = chunk_slot.active.take() else {
+            return Poll::Ready(None);
+        };
+
+        match slot.state {
+            RequestState::Done(result) => self.emit_buffered_response(BufferedResponse {
+                chunk_index: slot.data_range.chunk_index,
+                read_range: slot.data_range.range,
+                result,
+            }),
             RequestState::NoWorkers => {
                 // We don't know how long we'll have to wait, so give up immediately
-                return Poll::Ready(Some(Err(RequestError::Unavailable)));
+                Poll::Ready(Some(Err(RequestError::Unavailable)))
             }
             RequestState::Paused(ref s) => {
                 // All workers are rate-limited, try to pause and continue streaming
                 let duration = s.until.duration_since(Instant::now());
                 if duration > MAX_IDLE_TIME {
-                    return Poll::Ready(Some(Err(RequestError::BusyFor(duration))));
+                    Poll::Ready(Some(Err(RequestError::BusyFor(duration))))
                 } else {
                     // TODO: fix calculation in case we're polling the same paused slot multiple times
                     self.stats.throttled(duration);
+                    chunk_slot.active = Some(slot);
+                    self.buffer.push_front(chunk_slot);
+                    Poll::Pending
                 }
-                let range = slot.data_range.range.clone();
-                chunk_slot.parts.push_front(slot);
-                self.buffer.push_front(chunk_slot);
-                (Poll::Pending, range)
             }
             RequestState::Pending(_) => {
                 // The query is still running, keep waiting
-                let range = slot.data_range.range.clone();
-                chunk_slot.parts.push_front(slot);
+                chunk_slot.active = Some(slot);
                 self.buffer.push_front(chunk_slot);
-                (Poll::Pending, range)
+                Poll::Pending
             }
             RequestState::Partial(PartialResult { data, next_range }) => {
                 // Return the partial result and schedule the continuation query
+                let chunk_index = slot.data_range.chunk_index;
                 let read_range =
                     BlockRange::new(*slot.data_range.range.start(), *next_range.start() - 1);
                 let next_data_range = slot.data_range.with_range(next_range);
-                let _ = self.schedule_continuation(
-                    &mut chunk_slot,
-                    next_data_range,
-                    ContinuationPosition::Front,
-                    ctx,
-                );
+                self.schedule_continuation(&mut chunk_slot, next_data_range, ctx);
                 self.buffer.push_front(chunk_slot);
-                (Poll::Ready(Some(Ok(data))), read_range)
+                self.emit_buffered_response(BufferedResponse {
+                    chunk_index,
+                    read_range,
+                    result: Ok(data),
+                })
             }
-        };
+        }
+    }
+
+    fn emit_buffered_response(
+        &mut self,
+        response: BufferedResponse,
+    ) -> Poll<Option<Result<ResponseChunk, RequestError>>> {
+        let result = Poll::Ready(Some(response.result));
 
         if let Poll::Ready(Some(Ok(bytes))) = &result {
-            self.stats
-                .sent_response_chunk(*read_range.end() - *read_range.start() + 1, bytes.len());
+            self.stats.sent_response_chunk(
+                *response.read_range.end() - *response.read_range.start() + 1,
+                bytes.len(),
+            );
             tracing::trace!(
-                chunk_index,
+                chunk_index = response.chunk_index,
                 "Writing response blocks {}-{} ({} bytes)",
-                *read_range.start(),
-                *read_range.end(),
+                *response.read_range.start(),
+                *response.read_range.end(),
                 bytes.len()
             );
         }
@@ -647,7 +645,7 @@ impl StreamController {
         if let Some(Slot {
             state: RequestState::Paused(_),
             ..
-        }) = self.buffer.back().and_then(ChunkSlot::back)
+        }) = self.buffer.back().and_then(ChunkSlot::active)
         {
             // Either the amount of compute units is low or the network is overloaded.
             // Don't send new queries until the existing ones complete.
@@ -674,7 +672,7 @@ impl StreamController {
                 Ok(slot) => {
                     let paused = slot.is_paused();
                     let chunk_slot = ChunkSlot::new(slot);
-                    self.stats.observe_chunk_parts(chunk_slot.parts.len());
+                    self.stats.observe_chunk_parts(chunk_slot.num_parts());
                     self.buffer.push_back(chunk_slot);
                     self.next_chunk = self.get_next_chunk(&chunk);
                     if paused {
@@ -689,7 +687,7 @@ impl StreamController {
                         // Couldn't schedule a new request with no ongoing requests
                         // Return the error immediately
                         let chunk_slot = ChunkSlot::new(slot);
-                        self.stats.observe_chunk_parts(chunk_slot.parts.len());
+                        self.stats.observe_chunk_parts(chunk_slot.num_parts());
                         self.buffer.push_back(chunk_slot);
                     }
                     self.last_error = Some(e.to_string());
@@ -878,11 +876,24 @@ impl Slot {
         matches!(&self.state, RequestState::Paused(_))
     }
 
-    fn take_partial_continuation_if_eager(&mut self, eager: bool) -> Option<DataRange> {
-        eager.then(|| self.take_partial_continuation()).flatten()
+    fn take_completed_response(&mut self) -> Option<BufferedResponse> {
+        let RequestState::Done(_) = self.state else {
+            return None;
+        };
+
+        let state = std::mem::replace(&mut self.state, RequestState::NoWorkers);
+        let RequestState::Done(result) = state else {
+            unreachable!("slot state was checked to be done")
+        };
+
+        Some(BufferedResponse {
+            chunk_index: self.data_range.chunk_index,
+            read_range: self.data_range.range.clone(),
+            result,
+        })
     }
 
-    fn take_partial_continuation(&mut self) -> Option<DataRange> {
+    fn take_partial_continuation(&mut self) -> Option<(BufferedResponse, DataRange)> {
         let RequestState::Partial(_) = self.state else {
             return None;
         };
@@ -906,27 +917,42 @@ impl Slot {
             chunk_index: old.chunk_index,
         };
         self.state = RequestState::Done(Ok(data));
-        Some(next_data_range)
+        let response = self
+            .take_completed_response()
+            .expect("partial data should have become a completed response");
+        Some((response, next_data_range))
     }
 }
 
 impl ChunkSlot {
     fn new(slot: Slot) -> Self {
         Self {
-            parts: VecDeque::from([slot]),
+            pending_responses: VecDeque::new(),
+            active: Some(slot),
         }
     }
 
-    fn back(&self) -> Option<&Slot> {
-        self.parts.back()
+    fn active(&self) -> Option<&Slot> {
+        self.active.as_ref()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.pending_responses.is_empty() && self.active.is_none()
+    }
+
+    fn num_parts(&self) -> usize {
+        self.pending_responses.len() + usize::from(self.active.is_some())
     }
 
     fn debug_symbol(&self) -> char {
-        if self.parts.len() > 1 {
-            return '*';
+        if !self.pending_responses.is_empty() && self.active.is_some() {
+            return '+';
         }
-        self.parts
-            .front()
+        if !self.pending_responses.is_empty() {
+            return '#';
+        }
+        self.active
+            .as_ref()
             .map(|slot| slot.state.debug_symbol())
             .unwrap_or('_')
     }
@@ -1092,12 +1118,13 @@ mod tests {
     fn partial_slot_is_split_into_done_part_and_continuation_range() {
         let mut slot = partial_slot(100, 200, 120, b"first");
 
-        let continuation = slot.take_partial_continuation().unwrap();
+        let (response, continuation) = slot.take_partial_continuation().unwrap();
 
-        assert_eq!(slot.data_range.range, BlockRange::new(100, 120));
-        match slot.state {
-            RequestState::Done(Ok(data)) => assert_eq!(data, b"first"),
-            _ => panic!("partial data should become an emit-ready done state"),
+        assert_eq!(response.read_range, BlockRange::new(100, 120));
+        assert_eq!(response.chunk_index, 0);
+        match response.result {
+            Ok(data) => assert_eq!(data, b"first"),
+            Err(_) => panic!("partial data should become an emit-ready response"),
         }
         assert_eq!(continuation.range, BlockRange::new(121, 200));
         assert_eq!(continuation.chunk, test_chunk());
@@ -1120,49 +1147,48 @@ mod tests {
     }
 
     #[test]
-    fn lazy_partial_slot_keeps_continuation_until_output_path() {
-        let mut slot = partial_slot(100, 200, 120, b"first");
+    fn completed_slot_can_be_unwrapped_for_output() {
+        let mut slot = Slot {
+            data_range: data_range(100, 200),
+            state: RequestState::Done(Ok(b"complete".to_vec())),
+        };
 
-        assert!(slot.take_partial_continuation_if_eager(false).is_none());
-        assert_eq!(slot.data_range.range, BlockRange::new(100, 200));
-        match &slot.state {
-            RequestState::Partial(partial) => {
-                assert_eq!(partial.data, b"first");
-                assert_eq!(partial.next_range, BlockRange::new(121, 200));
-            }
-            _ => panic!("lazy path should keep partial state until it is emitted"),
+        let response = slot.take_completed_response().unwrap();
+
+        assert_eq!(response.read_range, BlockRange::new(100, 200));
+        assert_eq!(response.chunk_index, 0);
+        match response.result {
+            Ok(data) => assert_eq!(data, b"complete"),
+            Err(_) => panic!("completed slot should unwrap its result"),
         }
     }
 
     #[test]
-    fn chunk_slot_keeps_completed_part_before_continuation() {
+    fn chunk_slot_keeps_completed_response_before_active_continuation() {
         let mut chunk_slot = ChunkSlot::new(partial_slot(100, 200, 120, b"first"));
-        let continuation = chunk_slot
-            .parts
-            .front_mut()
+        let (response, continuation) = chunk_slot
+            .active
+            .as_mut()
             .unwrap()
             .take_partial_continuation()
             .unwrap();
-        chunk_slot.parts.push_back(Slot {
+        chunk_slot.pending_responses.push_back(response);
+        chunk_slot.active = Some(Slot {
             data_range: continuation,
             state: RequestState::NoWorkers,
         });
 
-        assert_eq!(chunk_slot.parts.len(), 2);
+        assert_eq!(chunk_slot.num_parts(), 2);
         assert_eq!(
-            chunk_slot.parts.front().unwrap().data_range.range,
+            chunk_slot.pending_responses.front().unwrap().read_range,
             BlockRange::new(100, 120)
         );
         assert_eq!(
-            chunk_slot.parts.back().unwrap().data_range.range,
+            chunk_slot.active.as_ref().unwrap().data_range.range,
             BlockRange::new(121, 200)
         );
         assert!(matches!(
-            chunk_slot.parts.front().unwrap().state,
-            RequestState::Done(Ok(_))
-        ));
-        assert!(matches!(
-            chunk_slot.parts.back().unwrap().state,
+            chunk_slot.active.as_ref().unwrap().state,
             RequestState::NoWorkers
         ));
     }
@@ -1190,44 +1216,62 @@ mod tests {
     }
 
     #[test]
-    fn chunk_slot_keeps_many_continuations_in_same_chunk_order() {
+    fn chunk_slot_keeps_pending_responses_before_active_slot() {
         let mut chunk_slot = ChunkSlot::new(Slot {
-            data_range: data_range(100, 120),
-            state: RequestState::Done(Ok(b"first".to_vec())),
+            data_range: data_range(141, 150),
+            state: RequestState::NoWorkers,
         });
         for i in 0..3 {
-            let start = 121 + i * 10;
-            chunk_slot.parts.push_back(Slot {
-                data_range: DataRange {
-                    range: BlockRange::new(start, start + 9),
-                    chunk: test_chunk(),
-                    chunk_index: 0,
-                },
-                state: RequestState::NoWorkers,
+            let start = 100 + i * 10;
+            chunk_slot.pending_responses.push_back(BufferedResponse {
+                chunk_index: 0,
+                read_range: BlockRange::new(start, start + 9),
+                result: Ok(Vec::new()),
             });
         }
 
-        let ranges: Vec<_> = chunk_slot
-            .parts
+        let mut ranges: Vec<_> = chunk_slot
+            .pending_responses
             .iter()
-            .map(|slot| slot.data_range.range.clone())
+            .map(|response| response.read_range.clone())
             .collect();
+        ranges.push(chunk_slot.active.as_ref().unwrap().data_range.range.clone());
         assert_eq!(
             ranges,
             vec![
-                BlockRange::new(100, 120),
-                BlockRange::new(121, 130),
-                BlockRange::new(131, 140),
+                BlockRange::new(100, 109),
+                BlockRange::new(110, 119),
+                BlockRange::new(120, 129),
                 BlockRange::new(141, 150),
             ]
         );
-        assert!(chunk_slot
-            .parts
-            .iter()
-            .all(|slot| slot.data_range.chunk == test_chunk()));
-        assert!(chunk_slot
-            .parts
-            .iter()
-            .all(|slot| slot.data_range.chunk_index == 0));
+        assert_eq!(chunk_slot.num_parts(), 4);
+        assert_eq!(
+            chunk_slot.active.as_ref().unwrap().data_range.chunk,
+            test_chunk()
+        );
+        assert_eq!(
+            chunk_slot.active.as_ref().unwrap().data_range.chunk_index,
+            0
+        );
+    }
+
+    #[test]
+    fn chunk_slot_debug_symbol_distinguishes_partial_and_completed_multi_part_slots() {
+        let mut chunk_slot = ChunkSlot::new(Slot {
+            data_range: data_range(121, 200),
+            state: RequestState::NoWorkers,
+        });
+        chunk_slot.pending_responses.push_back(BufferedResponse {
+            chunk_index: 0,
+            read_range: BlockRange::new(100, 120),
+            result: Ok(Vec::new()),
+        });
+
+        assert_eq!(chunk_slot.debug_symbol(), '+');
+
+        chunk_slot.active = None;
+
+        assert_eq!(chunk_slot.debug_symbol(), '#');
     }
 }

--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -117,6 +117,12 @@ struct ChunkSlot {
     active: Option<Slot>,
 }
 
+enum BufferedActiveSlot {
+    Nothing,
+    Completed,
+    Partial(DataRange),
+}
+
 enum RequestState {
     /// Couldn't find enough workers now.
     /// Retry whenever the stream is polled, or give up if this is the first slot.
@@ -293,23 +299,18 @@ impl StreamController {
         while let Some(slot) = chunk_slot.active.as_mut() {
             updated |= self.poll_slot(slot, ctx).updated();
 
-            if let Some(response) = slot.take_completed_response() {
-                chunk_slot.pending_responses.push_back(response);
-                chunk_slot.active = None;
-                updated = true;
-                break;
-            }
-
-            if self.request.eager_continuations {
-                if let Some((response, next_data_range)) = slot.take_partial_continuation() {
-                    chunk_slot.pending_responses.push_back(response);
+            match chunk_slot.buffer_active_response(self.request.eager_continuations) {
+                BufferedActiveSlot::Nothing => break,
+                BufferedActiveSlot::Completed => {
+                    updated = true;
+                    break;
+                }
+                BufferedActiveSlot::Partial(next_data_range) => {
                     self.schedule_continuation(chunk_slot, next_data_range, ctx);
                     updated = true;
                     continue;
                 }
             }
-
-            break;
         }
 
         if updated {
@@ -552,7 +553,7 @@ impl StreamController {
         &mut self,
         ctx: &mut Context<'_>,
     ) -> Poll<Option<Result<ResponseChunk, RequestError>>> {
-        let mut chunk_slot = loop {
+        let chunk_slot = loop {
             let Some(chunk_slot) = self.buffer.pop_front() else {
                 return Poll::Ready(None);
             };
@@ -561,11 +562,28 @@ impl StreamController {
             }
         };
 
-        if let Some(response) = chunk_slot.pending_responses.pop_front() {
-            if !chunk_slot.is_empty() {
-                self.buffer.push_front(chunk_slot);
+        let mut chunk_slot = match self.pop_buffered_response(chunk_slot) {
+            Ok(response) => return response,
+            Err(chunk_slot) => chunk_slot,
+        };
+
+        match chunk_slot.buffer_active_response(true) {
+            BufferedActiveSlot::Nothing => {}
+            BufferedActiveSlot::Completed => {
+                let response = self
+                    .pop_buffered_response(chunk_slot)
+                    .ok()
+                    .expect("completed active slot should have produced a buffered response");
+                return response;
             }
-            return self.emit_buffered_response(response);
+            BufferedActiveSlot::Partial(next_data_range) => {
+                self.schedule_continuation(&mut chunk_slot, next_data_range, ctx);
+                let response = self
+                    .pop_buffered_response(chunk_slot)
+                    .ok()
+                    .expect("partial active slot should have produced a buffered response");
+                return response;
+            }
         }
 
         let Some(slot) = chunk_slot.active.take() else {
@@ -573,11 +591,6 @@ impl StreamController {
         };
 
         match slot.state {
-            RequestState::Done(result) => self.emit_buffered_response(BufferedResponse {
-                chunk_index: slot.data_range.chunk_index,
-                read_range: slot.data_range.range,
-                result,
-            }),
             RequestState::NoWorkers => {
                 // We don't know how long we'll have to wait, so give up immediately
                 Poll::Ready(Some(Err(RequestError::Unavailable)))
@@ -601,21 +614,23 @@ impl StreamController {
                 self.buffer.push_front(chunk_slot);
                 Poll::Pending
             }
-            RequestState::Partial(PartialResult { data, next_range }) => {
-                // Return the partial result and schedule the continuation query
-                let chunk_index = slot.data_range.chunk_index;
-                let read_range =
-                    BlockRange::new(*slot.data_range.range.start(), *next_range.start() - 1);
-                let next_data_range = slot.data_range.with_range(next_range);
-                self.schedule_continuation(&mut chunk_slot, next_data_range, ctx);
-                self.buffer.push_front(chunk_slot);
-                self.emit_buffered_response(BufferedResponse {
-                    chunk_index,
-                    read_range,
-                    result: Ok(data),
-                })
+            RequestState::Done(_) | RequestState::Partial(_) => {
+                unreachable!("completed active slots should be buffered before emission")
             }
         }
+    }
+
+    fn pop_buffered_response(
+        &mut self,
+        mut chunk_slot: ChunkSlot,
+    ) -> Result<Poll<Option<Result<ResponseChunk, RequestError>>>, ChunkSlot> {
+        let Some(response) = chunk_slot.pending_responses.pop_front() else {
+            return Err(chunk_slot);
+        };
+        if !chunk_slot.is_empty() {
+            self.buffer.push_front(chunk_slot);
+        }
+        Ok(self.emit_buffered_response(response))
     }
 
     fn emit_buffered_response(
@@ -881,6 +896,8 @@ impl Slot {
             return None;
         };
 
+        // This slot is consumed by `ChunkSlot::buffer_active_response` immediately after this
+        // returns; `NoWorkers` is only a temporary placeholder for moving the partial state out.
         let state = std::mem::replace(&mut self.state, RequestState::NoWorkers);
         let RequestState::Done(result) = state else {
             unreachable!("slot state was checked to be done")
@@ -911,15 +928,12 @@ impl Slot {
             chunk: old.chunk.clone(),
             chunk_index: old.chunk_index,
         };
-        self.data_range = DataRange {
-            range: read_range,
-            chunk: old.chunk,
+
+        let response = BufferedResponse {
             chunk_index: old.chunk_index,
+            read_range,
+            result: Ok(data),
         };
-        self.state = RequestState::Done(Ok(data));
-        let response = self
-            .take_completed_response()
-            .expect("partial data should have become a completed response");
         Some((response, next_data_range))
     }
 }
@@ -942,6 +956,28 @@ impl ChunkSlot {
 
     fn num_parts(&self) -> usize {
         self.pending_responses.len() + usize::from(self.active.is_some())
+    }
+
+    fn buffer_active_response(&mut self, include_partial: bool) -> BufferedActiveSlot {
+        let Some(slot) = self.active.as_mut() else {
+            return BufferedActiveSlot::Nothing;
+        };
+
+        if let Some(response) = slot.take_completed_response() {
+            self.pending_responses.push_back(response);
+            self.active = None;
+            return BufferedActiveSlot::Completed;
+        }
+
+        if include_partial {
+            if let Some((response, next_data_range)) = slot.take_partial_continuation() {
+                self.pending_responses.push_back(response);
+                self.active = None;
+                return BufferedActiveSlot::Partial(next_data_range);
+            }
+        }
+
+        BufferedActiveSlot::Nothing
     }
 
     fn debug_symbol(&self) -> char {

--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -303,7 +303,7 @@ impl StreamController {
                         debug_assert!(false, "chunk part index should be in bounds");
                         break;
                     };
-                    slot.take_partial_continuation()
+                    slot.take_partial_continuation_if_eager(self.request.eager_continuations)
                 };
                 if let Some(next_data_range) = next_data_range {
                     let next_slot = match self.start_querying_chunk(next_data_range, ctx) {
@@ -776,11 +776,7 @@ impl StreamController {
             range.range.end(),
             lease,
         );
-        let query = if *range.range.start() == self.request.query.first_block() {
-            self.request.query.to_string()
-        } else {
-            self.request.query.without_parent_hash()
-        };
+        let query = query_for_range(&mut self.request.query, &range.range);
         let start_time = tokio::time::Instant::now();
 
         let priority = self.stream_index * self.priority_stride + range.chunk_index as u32;
@@ -851,6 +847,10 @@ impl DataRange {
 impl Slot {
     fn is_paused(&self) -> bool {
         matches!(&self.state, RequestState::Paused(_))
+    }
+
+    fn take_partial_continuation_if_eager(&mut self, eager: bool) -> Option<DataRange> {
+        eager.then(|| self.take_partial_continuation()).flatten()
     }
 
     fn take_partial_continuation(&mut self) -> Option<DataRange> {
@@ -991,6 +991,14 @@ fn parse_response(
     state
 }
 
+fn query_for_range(query: &mut crate::types::ParsedQuery, range: &BlockRange) -> String {
+    if *range.start() == query.first_block() {
+        query.to_string()
+    } else {
+        query.without_parent_hash()
+    }
+}
+
 fn retriable(result: &QueryResult) -> bool {
     match result {
         Ok(_) => false,
@@ -1008,5 +1016,137 @@ fn short_code(result: &RequestState) -> &'static str {
         RequestState::Done(Err(e)) => e.short_code(),
         RequestState::Partial(_) => "partial",
         RequestState::Pending(_) | RequestState::Paused(_) | RequestState::NoWorkers => "-",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::types::ParsedQuery;
+
+    use super::*;
+
+    fn test_chunk() -> DataChunk {
+        DataChunk::from_str("0000000000/0000000100-0000000200-abcde").unwrap()
+    }
+
+    fn data_range(start: u64, end: u64) -> DataRange {
+        DataRange {
+            range: BlockRange::new(start, end),
+            chunk: test_chunk(),
+            chunk_index: 0,
+        }
+    }
+
+    fn partial_slot(start: u64, end: u64, last_returned: u64, data: &[u8]) -> Slot {
+        Slot {
+            data_range: data_range(start, end),
+            state: RequestState::Partial(PartialResult {
+                data: data.to_vec(),
+                next_range: BlockRange::new(last_returned + 1, end),
+            }),
+        }
+    }
+
+    #[test]
+    fn partial_slot_is_split_into_done_part_and_continuation_range() {
+        let mut slot = partial_slot(100, 200, 120, b"first");
+
+        let continuation = slot.take_partial_continuation().unwrap();
+
+        assert_eq!(slot.data_range.range, BlockRange::new(100, 120));
+        match slot.state {
+            RequestState::Done(Ok(data)) => assert_eq!(data, b"first"),
+            _ => panic!("partial data should become an emit-ready done state"),
+        }
+        assert_eq!(continuation.range, BlockRange::new(121, 200));
+        assert_eq!(continuation.chunk, test_chunk());
+        assert_eq!(continuation.chunk_index, 0);
+    }
+
+    #[test]
+    fn non_partial_slot_does_not_schedule_continuation() {
+        let mut slot = Slot {
+            data_range: data_range(100, 200),
+            state: RequestState::Done(Ok(b"complete".to_vec())),
+        };
+
+        assert!(slot.take_partial_continuation().is_none());
+        assert_eq!(slot.data_range.range, BlockRange::new(100, 200));
+        match slot.state {
+            RequestState::Done(Ok(data)) => assert_eq!(data, b"complete"),
+            _ => panic!("non-partial state should be preserved"),
+        }
+    }
+
+    #[test]
+    fn lazy_partial_slot_keeps_continuation_until_output_path() {
+        let mut slot = partial_slot(100, 200, 120, b"first");
+
+        assert!(slot.take_partial_continuation_if_eager(false).is_none());
+        assert_eq!(slot.data_range.range, BlockRange::new(100, 200));
+        match &slot.state {
+            RequestState::Partial(partial) => {
+                assert_eq!(partial.data, b"first");
+                assert_eq!(partial.next_range, BlockRange::new(121, 200));
+            }
+            _ => panic!("lazy path should keep partial state until it is emitted"),
+        }
+    }
+
+    #[test]
+    fn chunk_slot_keeps_completed_part_before_continuation() {
+        let mut chunk_slot = ChunkSlot::new(partial_slot(100, 200, 120, b"first"));
+        let continuation = chunk_slot
+            .parts
+            .front_mut()
+            .unwrap()
+            .take_partial_continuation()
+            .unwrap();
+        chunk_slot.parts.push_back(Slot {
+            data_range: continuation,
+            state: RequestState::NoWorkers,
+        });
+
+        assert_eq!(chunk_slot.parts.len(), 2);
+        assert_eq!(
+            chunk_slot.parts.front().unwrap().data_range.range,
+            BlockRange::new(100, 120)
+        );
+        assert_eq!(
+            chunk_slot.parts.back().unwrap().data_range.range,
+            BlockRange::new(121, 200)
+        );
+        assert!(matches!(
+            chunk_slot.parts.front().unwrap().state,
+            RequestState::Done(Ok(_))
+        ));
+        assert!(matches!(
+            chunk_slot.parts.back().unwrap().state,
+            RequestState::NoWorkers
+        ));
+    }
+
+    #[test]
+    fn first_range_uses_original_query_and_continuation_drops_parent_hash() {
+        let query_json = r#"{
+            "type": "evm",
+            "fromBlock": 100,
+            "parentBlockHash": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "fields": {
+                "block": {
+                    "number": true
+                }
+            },
+            "includeAllBlocks": true
+        }"#;
+        let mut query = ParsedQuery::try_from(query_json.to_owned()).unwrap();
+
+        let first_query = query_for_range(&mut query, &BlockRange::new(100, 120));
+        let continuation_query = query_for_range(&mut query, &BlockRange::new(121, 200));
+
+        assert!(first_query.contains("parentBlockHash"));
+        assert!(!continuation_query.contains("parentBlockHash"));
     }
 }

--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -177,6 +177,8 @@ struct FinishedWorkerRequest {
     worker: PeerId,
 }
 
+type StartQueryingChunkError = (Box<Slot>, SendQueryError);
+
 impl Drop for RunningWorkerRequest {
     fn drop(&mut self) {
         self.resp.abort();
@@ -330,7 +332,7 @@ impl StreamController {
             Ok(slot) => slot,
             Err((slot, e)) => {
                 tracing::debug!("Couldn't schedule continuation request: {e:?}");
-                slot
+                *slot
             }
         };
         chunk_slot.active = Some(next_slot);
@@ -369,7 +371,7 @@ impl StreamController {
                 UpdateStatus::Updated
             }
             Err((s, e)) => {
-                *slot = s;
+                *slot = *s;
                 self.last_error = Some(e.to_string());
                 if matches!(slot.state, RequestState::NoWorkers) {
                     UpdateStatus::NotUpdated
@@ -562,26 +564,33 @@ impl StreamController {
             }
         };
 
-        let mut chunk_slot = match self.pop_buffered_response(chunk_slot) {
-            Ok(response) => return response,
-            Err(chunk_slot) => chunk_slot,
-        };
+        let mut chunk_slot = chunk_slot;
+        if let Some(response) = self.pop_buffered_response(&mut chunk_slot) {
+            if !chunk_slot.is_empty() {
+                self.buffer.push_front(chunk_slot);
+            }
+            return response;
+        }
 
         match chunk_slot.buffer_active_response(true) {
             BufferedActiveSlot::Nothing => {}
             BufferedActiveSlot::Completed => {
                 let response = self
-                    .pop_buffered_response(chunk_slot)
-                    .ok()
+                    .pop_buffered_response(&mut chunk_slot)
                     .expect("completed active slot should have produced a buffered response");
+                if !chunk_slot.is_empty() {
+                    self.buffer.push_front(chunk_slot);
+                }
                 return response;
             }
             BufferedActiveSlot::Partial(next_data_range) => {
                 self.schedule_continuation(&mut chunk_slot, next_data_range, ctx);
                 let response = self
-                    .pop_buffered_response(chunk_slot)
-                    .ok()
+                    .pop_buffered_response(&mut chunk_slot)
                     .expect("partial active slot should have produced a buffered response");
+                if !chunk_slot.is_empty() {
+                    self.buffer.push_front(chunk_slot);
+                }
                 return response;
             }
         }
@@ -622,15 +631,10 @@ impl StreamController {
 
     fn pop_buffered_response(
         &mut self,
-        mut chunk_slot: ChunkSlot,
-    ) -> Result<Poll<Option<Result<ResponseChunk, RequestError>>>, ChunkSlot> {
-        let Some(response) = chunk_slot.pending_responses.pop_front() else {
-            return Err(chunk_slot);
-        };
-        if !chunk_slot.is_empty() {
-            self.buffer.push_front(chunk_slot);
-        }
-        Ok(self.emit_buffered_response(response))
+        chunk_slot: &mut ChunkSlot,
+    ) -> Option<Poll<Option<Result<ResponseChunk, RequestError>>>> {
+        let response = chunk_slot.pending_responses.pop_front()?;
+        Some(self.emit_buffered_response(response))
     }
 
     fn emit_buffered_response(
@@ -701,7 +705,7 @@ impl StreamController {
                     if self.buffer.len() == 0 {
                         // Couldn't schedule a new request with no ongoing requests
                         // Return the error immediately
-                        let chunk_slot = ChunkSlot::new(slot);
+                        let chunk_slot = ChunkSlot::new(*slot);
                         self.stats.observe_chunk_parts(chunk_slot.num_parts());
                         self.buffer.push_back(chunk_slot);
                     }
@@ -736,7 +740,7 @@ impl StreamController {
         &mut self,
         range: DataRange,
         ctx: &mut Context<'_>,
-    ) -> Result<Slot, (Slot, SendQueryError)> {
+    ) -> Result<Slot, StartQueryingChunkError> {
         let block_range = self
             .request
             .query
@@ -762,7 +766,7 @@ impl StreamController {
                     data_range,
                     state: RequestState::NoWorkers,
                 };
-                Err((slot, err))
+                Err((Box::new(slot), err))
             }
             Err(err @ SendQueryError::Backoff(until)) => {
                 let mut slot = Slot {
@@ -770,7 +774,7 @@ impl StreamController {
                     state: RequestState::Paused(PausedState::new(until)),
                 };
                 self.poll_slot(&mut slot, ctx);
-                Err((slot, err))
+                Err((Box::new(slot), err))
             }
         }
     }
@@ -925,7 +929,7 @@ impl Slot {
         let read_range = BlockRange::new(*old.range.start(), *next_range.start() - 1);
         let next_data_range = DataRange {
             range: next_range,
-            chunk: old.chunk.clone(),
+            chunk: old.chunk,
             chunk_index: old.chunk_index,
         };
 

--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -351,6 +351,7 @@ impl StreamController {
             ContinuationPosition::Front => chunk_slot.parts.push_front(next_slot),
             ContinuationPosition::Back => chunk_slot.parts.push_back(next_slot),
         }
+        self.stats.observe_chunk_parts(chunk_slot.parts.len());
         UpdateStatus::Updated
     }
 
@@ -672,7 +673,9 @@ impl StreamController {
             ) {
                 Ok(slot) => {
                     let paused = slot.is_paused();
-                    self.buffer.push_back(ChunkSlot::new(slot));
+                    let chunk_slot = ChunkSlot::new(slot);
+                    self.stats.observe_chunk_parts(chunk_slot.parts.len());
+                    self.buffer.push_back(chunk_slot);
                     self.next_chunk = self.get_next_chunk(&chunk);
                     if paused {
                         break;
@@ -685,7 +688,9 @@ impl StreamController {
                     if self.buffer.len() == 0 {
                         // Couldn't schedule a new request with no ongoing requests
                         // Return the error immediately
-                        self.buffer.push_back(ChunkSlot::new(slot));
+                        let chunk_slot = ChunkSlot::new(slot);
+                        self.stats.observe_chunk_parts(chunk_slot.parts.len());
+                        self.buffer.push_back(chunk_slot);
                     }
                     self.last_error = Some(e.to_string());
                     self.next_chunk = Some(chunk);

--- a/src/endpoints/block_number_by_timestamp.rs
+++ b/src/endpoints/block_number_by_timestamp.rs
@@ -397,6 +397,7 @@ fn build_request(
         retries: config.default_retries,
         compression: Compression::Gzip,
         skip_parent_hash_validation: false,
+        eager_continuations: config.eager_continuations,
     }
 }
 

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -1014,6 +1014,7 @@ where
             retries,
             compression,
             skip_parent_hash_validation: config.skip_parent_hash_validation,
+            eager_continuations: config.eager_continuations,
         })
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -61,6 +61,8 @@ lazy_static::lazy_static! {
         Family::new_with_constructor(|| Histogram::new(exponential_buckets(1., 2.0, 30)));
     pub static ref STREAM_CHUNKS: Family<Labels, Histogram> =
         Family::new_with_constructor(|| Histogram::new(buckets(1., 20)));
+    pub static ref STREAM_MAX_CHUNK_PARTS: Family<Labels, Histogram> =
+        Family::new_with_constructor(|| Histogram::new(buckets(1., 20)));
     pub static ref STREAM_BYTES_PER_SECOND: Histogram = Histogram::new(exponential_buckets(100., 3.0, 20));
     pub static ref STREAM_BLOCKS_PER_SECOND: Family<Labels, Histogram> =
         Family::new_with_constructor(|| Histogram::new(exponential_buckets(1., 3.0, 20)));
@@ -137,10 +139,14 @@ pub fn report_stream_completed(
     let bytes = stats.response_bytes;
     let blocks = stats.response_blocks;
     let chunks = stats.chunks_downloaded;
+    let max_chunk_parts = stats.max_chunk_parts;
     STREAM_DURATIONS.get_or_create(&labels).observe(duration);
     STREAM_BYTES.get_or_create(&labels).observe(bytes as f64);
     STREAM_BLOCKS.get_or_create(&labels).observe(blocks as f64);
     STREAM_CHUNKS.get_or_create(&labels).observe(chunks as f64);
+    STREAM_MAX_CHUNK_PARTS
+        .get_or_create(&labels)
+        .observe(max_chunk_parts as f64);
     STREAM_BYTES_PER_SECOND.observe(bytes as f64 / duration);
     STREAM_BLOCKS_PER_SECOND
         .get_or_create(&labels)
@@ -269,6 +275,11 @@ pub fn register_metrics(registry: &mut Registry) {
         "stream_chunks",
         "Numbers of chunks per stream",
         STREAM_CHUNKS.clone(),
+    );
+    registry.register(
+        "stream_max_chunk_parts",
+        "Maximum number of response parts queued for a single chunk in a completed stream",
+        STREAM_MAX_CHUNK_PARTS.clone(),
     );
     registry.register(
         "stream_bytes_per_second",

--- a/src/network/storage.rs
+++ b/src/network/storage.rs
@@ -63,10 +63,6 @@ impl StorageClient {
         self.ignore_deprecated_workers = true;
     }
 
-    pub fn has_assignment(&self) -> bool {
-        self.assignment.read().is_some()
-    }
-
     pub fn num_workers(&self) -> usize {
         self.assignment
             .read()

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -14,6 +14,7 @@ pub struct StreamRequest {
     pub retries: u8,
     pub compression: Compression,
     pub skip_parent_hash_validation: bool,
+    pub eager_continuations: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -19,6 +19,7 @@ pub struct StreamStats {
     pub chunks_downloaded: u64,
     pub response_blocks: u64,
     pub response_bytes: u64,
+    pub max_chunk_parts: u64,
     pub start_time: Instant,
     pub last_log: Instant,
     pub throttled_for: Duration,
@@ -38,6 +39,7 @@ impl StreamStats {
             chunks_downloaded: 0,
             response_blocks: 0,
             response_bytes: 0,
+            max_chunk_parts: 1,
             start_time: now,
             last_log: now,
             throttled_for: Duration::from_secs(0),
@@ -54,6 +56,10 @@ impl StreamStats {
         self.response_bytes += bytes as u64;
     }
 
+    pub fn observe_chunk_parts(&mut self, parts: usize) {
+        self.max_chunk_parts = self.max_chunk_parts.max(parts as u64);
+    }
+
     pub fn throttled(&mut self, duration: Duration) {
         self.throttled_for += duration;
     }
@@ -63,6 +69,7 @@ impl StreamStats {
             tracing::info!(
                 queries_sent = self.queries_sent,
                 chunks_downloaded = self.chunks_downloaded,
+                max_chunk_parts = self.max_chunk_parts,
                 blocks_streamed = self.response_blocks,
                 bytes_streamed = self.response_bytes,
                 "Streaming..."
@@ -83,6 +90,7 @@ impl StreamStats {
             last_block = request.query.last_block(),
             queries_sent = self.queries_sent,
             chunks_downloaded = self.chunks_downloaded,
+            max_chunk_parts = self.max_chunk_parts,
             blocks_streamed = self.response_blocks,
             bytes_streamed = self.response_bytes,
             total_time = ?self.start_time.elapsed(),


### PR DESCRIPTION
## Summary

  This PR optimizes data-heavy archival stream queries where a worker response does not cover the full requested chunk range
  because it hits the response size limit.

  Previously, portal only scheduled a continuation request for a partial chunk after that partial response was streamed to the
  client. That made large single-chunk responses effectively sequential. This branch pipelines those continuations: when a
  partial result arrives, portal keeps the received part queued for ordered output and immediately schedules the next range for
  the same chunk.

  ## Changes

  - Replace the flat stream buffer with chunk-level slots containing ordered per-chunk parts.
  - Schedule partial chunk continuations eagerly while preserving response order.
  - Add `eager_continuations`, enabled by default, to allow reverting to lazy continuation behavior.
  - Fix query selection for first-chunk continuations so parent-hash validation is only used for the actual first requested
  block.
  - Add stream-controller unit tests for partial splitting, lazy behavior, ordering, and parent-hash query selection.
  - Add `stream_max_chunk_parts` metric to observe the maximum queued response parts for a single chunk in completed streams.

  ## Why

  Large queries, for example loading all Solana token balances, can produce responses that exceed the worker response limit for
  a single chunk. Without pipelining, each continuation waits for a full output round trip before the next query starts. Eager
  continuation scheduling overlaps worker execution with ordered client streaming and other in-flight chunk work.

  ## Verification

  - `cargo test controller::stream::tests`
  - `cargo test`