### PR TITLE
Reject zero buffer_size and max_chunks query params

### DIFF
--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -549,6 +549,12 @@ where
             .map_err(IntoResponse::into_response)?;
 
         let buffer_size = match params.get("buffer_size").map(|v| v.parse()) {
+            Some(Ok(0)) => {
+                return Err(RequestError::BadRequest(
+                    "buffer_size must be greater than 0".to_string(),
+                )
+                .into_response())
+            }
             Some(Ok(value)) => value,
             Some(Err(e)) => {
                 return Err(
@@ -584,6 +590,12 @@ where
         };
         let max_chunks = match params.get("max_chunks") {
             Some(value) => match value.parse() {
+                Ok(0) => {
+                    return Err(RequestError::BadRequest(
+                        "max_chunks must be greater than 0".to_string(),
+                    )
+                    .into_response())
+                }
                 Ok(value) => Some(value),
                 Err(e) => {
                     return Err(


### PR DESCRIPTION
A request with ?buffer_size=0 or ?max_chunks=0 caused StreamController to yield no chunks, which panicked TaskManager::spawn_stream at the .expect("First chunk missing from the stream") call. Validate both params at the HTTP layer and return 400 Bad Request instead.