### PR TITLE
Net 227 available CU

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqd-portal"
-version = "0.9.9"
+version = "0.9.10"
 edition = "2021"
 
 [features]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -38,6 +38,7 @@ fn buckets(start: f64, count: usize) -> impl Iterator<Item = f64> {
 
 lazy_static::lazy_static! {
     pub static ref KNOWN_WORKERS: Gauge = Default::default();
+    pub static ref AVAILABLE_COMPUTE_UNITS: Gauge = Default::default();
 
     pub static ref HTTP_STATUS: Family<Labels, Counter> = Default::default();
     pub static ref HTTP_TTFB: Family<Labels, Histogram> =
@@ -223,6 +224,11 @@ pub fn register_metrics(registry: &mut Registry) {
         "known_workers",
         "Number of workers seen in the network",
         KNOWN_WORKERS.clone(),
+    );
+    registry.register(
+        "available_compute_units",
+        "Compute units available to this portal per epoch",
+        AVAILABLE_COMPUTE_UNITS.clone(),
     );
     registry.register(
         "streams_active",

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -288,6 +288,7 @@ impl NetworkClient {
                 epoch_started,
                 compute_units_per_epoch,
             );
+            metrics::AVAILABLE_COMPUTE_UNITS.set(compute_units_per_epoch as i64);
 
             if epoch != current_epoch {
                 tracing::info!("Epoch {epoch} started");


### PR DESCRIPTION
## Summary

  Expose the portal’s actual available Compute Units as a Prometheus metric.

  ## Changes

  - Added a new AVAILABLE_COMPUTE_UNITS gauge.
  - Registered it as portal_available_compute_units through the existing portal metrics prefix.
  - Updated the gauge from the existing contract refresh path using portal_compute_units_per_epoch(self.local_peer_id).
  - Applied cargo fmt to fix existing formatting differences.

  ## Validation

  - cargo fmt --check
  - cargo test --no-run
