### PR TITLE
Net 466 metrics split

### DIFF
--- a/src/endpoints/block_number_by_timestamp.rs
+++ b/src/endpoints/block_number_by_timestamp.rs
@@ -3,6 +3,7 @@ use std::{future::Future, sync::Arc};
 use axum::{
     extract::Path,
     http::{header, StatusCode},
+    response::{IntoResponse, Response},
     Extension,
 };
 use futures::{pin_mut, StreamExt};
@@ -21,6 +22,8 @@ use crate::{
     },
 };
 
+use super::stream::{DATA_SOURCE_HEADER, DATA_SOURCE_NETWORK_METRIC, DATA_SOURCE_REALTIME_METRIC};
+
 #[derive(Debug, Clone, serde::Serialize)]
 pub(crate) struct BlockNumberResponse {
     block_number: u64,
@@ -34,7 +37,7 @@ pub(crate) async fn get_blocknumber_by_timestamp(
     Extension(config): Extension<Arc<Config>>,
     Extension(hotblocks): Extension<Arc<HotblocksHandle>>,
     dataset: DatasetConfig,
-) -> Result<axum::Json<BlockNumberResponse>, (StatusCode, axum::Json<GenericError>)> {
+) -> Response {
     resolve(
         timestamp,
         &req,
@@ -45,8 +48,36 @@ pub(crate) async fn get_blocknumber_by_timestamp(
         &dataset,
     )
     .await
-    .map(|n| BlockNumberResponse { block_number: n }.into())
-    .map_err(BlockNumberLookupError::into_response)
+    .map(|resolved| {
+        (
+            [(DATA_SOURCE_HEADER, resolved.data_source.as_str())],
+            axum::Json(BlockNumberResponse {
+                block_number: resolved.block_number,
+            }),
+        )
+            .into_response()
+    })
+    .unwrap_or_else(BlockNumberLookupError::into_response)
+}
+
+pub struct ResolvedBlockNumber {
+    block_number: u64,
+    data_source: BlockNumberDataSource,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BlockNumberDataSource {
+    Network,
+    Hotblocks,
+}
+
+impl BlockNumberDataSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Network => DATA_SOURCE_NETWORK_METRIC,
+            Self::Hotblocks => DATA_SOURCE_REALTIME_METRIC,
+        }
+    }
 }
 
 /// Failure modes for resolving a block number by timestamp.
@@ -63,14 +94,14 @@ pub enum BlockNumberLookupError {
 
 impl BlockNumberLookupError {
     /// Convert a resolver error into the timestamp endpoint's HTTP response.
-    pub fn into_response(self) -> (StatusCode, axum::Json<GenericError>) {
+    pub fn into_response(self) -> Response {
         let (status, message) = match self {
             Self::NotFound(message) => (StatusCode::NOT_FOUND, message),
             Self::Internal(message) => (StatusCode::INTERNAL_SERVER_ERROR, message),
             Self::Unavailable(message) => (StatusCode::SERVICE_UNAVAILABLE, message),
         };
 
-        (status, GenericError { message }.into())
+        (status, axum::Json(GenericError { message })).into_response()
     }
 }
 
@@ -87,7 +118,7 @@ pub async fn resolve(
     config: &Config,
     hotblocks: &HotblocksHandle,
     dataset: &DatasetConfig,
-) -> Result<u64, BlockNumberLookupError> {
+) -> Result<ResolvedBlockNumber, BlockNumberLookupError> {
     get_blocknumber_by_timestamp_inner(
         dataset.network_id.is_some(),
         dataset.hotblocks.is_some(),
@@ -124,7 +155,7 @@ async fn get_blocknumber_by_timestamp_inner<
     has_hotblocks: bool,
     archive_lookup: ArchiveLookup,
     hotblocks_lookup: HotblocksLookup,
-) -> Result<u64, BlockNumberLookupError>
+) -> Result<ResolvedBlockNumber, BlockNumberLookupError>
 where
     ArchiveLookup: FnOnce() -> ArchiveFuture,
     ArchiveFuture: Future<Output = Result<u64, BlockNumberLookupError>>,
@@ -139,14 +170,24 @@ where
 
     if has_archive {
         match archive_lookup().await {
-            Ok(n) => return Ok(n),
+            Ok(block_number) => {
+                return Ok(ResolvedBlockNumber {
+                    block_number,
+                    data_source: BlockNumberDataSource::Network,
+                })
+            }
             Err(BlockNumberLookupError::NotFound(_)) => {}
             Err(e) => return Err(e),
         }
     }
 
     if has_hotblocks {
-        return hotblocks_lookup().await;
+        return hotblocks_lookup()
+            .await
+            .map(|block_number| ResolvedBlockNumber {
+                block_number,
+                data_source: BlockNumberDataSource::Hotblocks,
+            });
     }
 
     Err(BlockNumberLookupError::NotFound(
@@ -386,7 +427,8 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(result, 42);
+        assert_eq!(result.block_number, 42);
+        assert_eq!(result.data_source, BlockNumberDataSource::Network);
         assert_eq!(archive_calls.load(Ordering::Relaxed), 1);
         assert_eq!(hotblocks_calls.load(Ordering::Relaxed), 0);
     }
@@ -419,7 +461,8 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(result, 84);
+        assert_eq!(result.block_number, 84);
+        assert_eq!(result.data_source, BlockNumberDataSource::Hotblocks);
         assert_eq!(archive_calls.load(Ordering::Relaxed), 1);
         assert_eq!(hotblocks_calls.load(Ordering::Relaxed), 1);
     }
@@ -450,7 +493,8 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(result, 168);
+        assert_eq!(result.block_number, 168);
+        assert_eq!(result.data_source, BlockNumberDataSource::Hotblocks);
         assert_eq!(archive_calls.load(Ordering::Relaxed), 0);
         assert_eq!(hotblocks_calls.load(Ordering::Relaxed), 1);
     }

--- a/src/endpoints/stream.rs
+++ b/src/endpoints/stream.rs
@@ -189,7 +189,13 @@ async fn stream_from_network(
 
     let stream = match task_manager.spawn_stream(request).await {
         Ok(stream) => stream,
-        Err(e) => return e.into_response(),
+        Err(e) => {
+            let mut response = e.into_response();
+            response
+                .headers_mut()
+                .insert(DATA_SOURCE_HEADER, DATA_SOURCE_NETWORK);
+            return response;
+        }
     };
 
     let mut res = Response::builder().header(DATA_SOURCE_HEADER, DATA_SOURCE_NETWORK);
@@ -240,10 +246,8 @@ async fn stream_from_hotblocks(
         Err(e) => forward_hotblocks_response(Err(e)),
     };
 
-    if res.status().is_success() {
-        res.headers_mut()
-            .append(DATA_SOURCE_HEADER, DATA_SOURCE_REALTIME);
-    }
+    res.headers_mut()
+        .insert(DATA_SOURCE_HEADER, DATA_SOURCE_REALTIME);
     res
 }
 
@@ -343,9 +347,11 @@ async fn delayed_no_content_response_with_builder(
 const FINALIZED_NUMBER_HEADER: &str = "x-sqd-finalized-head-number";
 const FINALIZED_HASH_HEADER: &str = "x-sqd-finalized-head-hash";
 const HEAD_NUMBER_HEADER: &str = "x-sqd-head-number";
-const DATA_SOURCE_HEADER: &str = "x-sqd-data-source";
-const DATA_SOURCE_NETWORK: HeaderValue = HeaderValue::from_static("network");
-const DATA_SOURCE_REALTIME: HeaderValue = HeaderValue::from_static("real_time");
+pub(crate) const DATA_SOURCE_HEADER: &str = "x-sqd-data-source";
+pub(crate) const DATA_SOURCE_NETWORK_METRIC: &str = "network";
+pub(crate) const DATA_SOURCE_REALTIME_METRIC: &str = "real_time";
+const DATA_SOURCE_NETWORK: HeaderValue = HeaderValue::from_static(DATA_SOURCE_NETWORK_METRIC);
+const DATA_SOURCE_REALTIME: HeaderValue = HeaderValue::from_static(DATA_SOURCE_REALTIME_METRIC);
 
 #[cfg(test)]
 mod tests {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -101,10 +101,16 @@ pub fn report_backoff(worker: &PeerId) {
         .inc();
 }
 
-pub fn report_http_response(endpoint: String, status: StatusCode, seconds_to_first_byte: f64) {
+pub fn report_http_response(
+    endpoint: String,
+    status: StatusCode,
+    data_source: String,
+    seconds_to_first_byte: f64,
+) {
     let labels = vec![
         ("endpoint".to_owned(), endpoint.clone()),
         ("status".to_owned(), status.as_str().to_owned()),
+        ("data_source".to_owned(), data_source),
     ];
     HTTP_STATUS.get_or_create(&labels).inc();
     HTTP_TTFB

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -116,11 +116,7 @@ pub async fn middleware(req: Request, next: axum::middleware::Next) -> impl Into
         .headers()
         .get(crate::endpoints::stream::DATA_SOURCE_HEADER)
         .and_then(|value| value.to_str().ok())
-        .map(|value| match value {
-            crate::endpoints::stream::DATA_SOURCE_REALTIME_METRIC => "hotblocks",
-            crate::endpoints::stream::DATA_SOURCE_NETWORK_METRIC => "network",
-            other => other,
-        })
+        .map(data_source_metric_label)
         .unwrap_or(NO_DATA_SOURCE)
         .to_owned();
 
@@ -146,6 +142,14 @@ pub async fn middleware(req: Request, next: axum::middleware::Next) -> impl Into
     response
 }
 
+fn data_source_metric_label(data_source: &str) -> &str {
+    match data_source {
+        crate::endpoints::stream::DATA_SOURCE_REALTIME_METRIC => "hotblocks",
+        crate::endpoints::stream::DATA_SOURCE_NETWORK_METRIC => "network",
+        other => other,
+    }
+}
+
 pub trait MethodRouterExt {
     fn endpoint(self, endpoint: impl Into<String>) -> Self;
 }
@@ -156,6 +160,33 @@ where
 {
     fn endpoint(self, endpoint: impl Into<String>) -> Self {
         self.layer(EndpointAnnotationLayer::new(endpoint))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::data_source_metric_label;
+    use crate::endpoints::stream::{DATA_SOURCE_NETWORK_METRIC, DATA_SOURCE_REALTIME_METRIC};
+
+    #[test]
+    fn data_source_metric_label_keeps_network() {
+        assert_eq!(
+            data_source_metric_label(DATA_SOURCE_NETWORK_METRIC),
+            "network"
+        );
+    }
+
+    #[test]
+    fn data_source_metric_label_maps_real_time_to_hotblocks() {
+        assert_eq!(
+            data_source_metric_label(DATA_SOURCE_REALTIME_METRIC),
+            "hotblocks"
+        );
+    }
+
+    #[test]
+    fn data_source_metric_label_preserves_unrecognized_values() {
+        assert_eq!(data_source_metric_label("custom"), "custom");
     }
 }
 

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -12,6 +12,7 @@ use tracing::Instrument;
 use crate::{metrics, types::StreamRequest};
 
 const LOG_INTERVAL: Duration = Duration::from_secs(5);
+const NO_DATA_SOURCE: &str = "none";
 
 pub struct StreamStats {
     pub queries_sent: u64,
@@ -111,6 +112,17 @@ pub async fn middleware(req: Request, next: axum::middleware::Next) -> impl Into
         .get::<EndpointName>()
         .map(|e| e.0.clone())
         .unwrap_or_else(|| path.clone());
+    let data_source = response
+        .headers()
+        .get(crate::endpoints::stream::DATA_SOURCE_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| match value {
+            crate::endpoints::stream::DATA_SOURCE_REALTIME_METRIC => "hotblocks",
+            crate::endpoints::stream::DATA_SOURCE_NETWORK_METRIC => "network",
+            other => other,
+        })
+        .unwrap_or(NO_DATA_SOURCE)
+        .to_owned();
 
     span.in_scope(|| {
         tracing::info!(
@@ -124,7 +136,12 @@ pub async fn middleware(req: Request, next: axum::middleware::Next) -> impl Into
         );
     });
 
-    metrics::report_http_response(endpoint, response.status(), latency.as_secs_f64());
+    metrics::report_http_response(
+        endpoint,
+        response.status(),
+        data_source,
+        latency.as_secs_f64(),
+    );
 
     response
 }


### PR DESCRIPTION
### Summary

 Adds a data_source label to exported HTTP response metrics so requests routed to SQD Network and Hotblocks DB can be viewed
  separately.

### Changes

  - Added data_source to:
      - portal_http_status
      - portal_http_seconds_to_first_byte
  - Uses existing x-sqd-data-source response metadata to derive metric labels.
  - Reports stream requests as:
      - data_source="network" for SQD Network
      - data_source="hotblocks" for Hotblocks DB
      - data_source="none" when no data-source decision applies
  - Ensures stream error responses after routing still carry the selected data-source metadata.
  - Adds data-source attribution to /datasets/:dataset/timestamps/:timestamp/block, since it resolves through either archive/
    SQD Network or Hotblocks.
  - Adds unit coverage for timestamp source selection and metric label normalization.

  ### Testing

  - cargo fmt --check
  - cargo check
  - cargo test data_source_metric_label
  - cargo test block_number_by_timestamp