### PR TITLE
Net 469 fix sentry

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,7 @@ async fn main() -> anyhow::Result<()> {
         .config
         .sentry_is_enabled
         .then(|| setup_sentry(&args.config, &args));
+
     setup_tracing(args.json_log, args.log_span_durations);
 
     let datasets = Arc::new(RwLock::new(Datasets::load(&args.config).await?, "datasets"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,9 +114,10 @@ async fn main() -> anyhow::Result<()> {
     let args = Cli::parse();
 
     // Initialize Sentry before tracing to integrate them
-    if args.config.sentry_is_enabled {
-        let _sentry_guard = setup_sentry(&args.config, &args);
-    }
+    let _sentry_guard = args
+        .config
+        .sentry_is_enabled
+        .then(|| setup_sentry(&args.config, &args));
     setup_tracing(args.json_log, args.log_span_durations);
 
     let datasets = Arc::new(RwLock::new(Datasets::load(&args.config).await?, "datasets"));


### PR DESCRIPTION
### Fix Sentry initialization lifetime.

Previously ClientInitGuard was created inside the if args.config.sentry_is_enabled block and dropped immediately after that block ended. Dropping the guard shuts down the Sentry client, so portals initialized Sentry during startup but disabled it before serving requests.

 ###  Validation:

  - cargo fmt --check
  - cargo check
  - tested with temporary sentry debug message
