### PR TITLE
Make the default worker backoff configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7814,7 +7814,7 @@ dependencies = [
 
 [[package]]
 name = "sqd-portal"
-version = "0.11.0-rc3"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqd-portal"
-version = "0.11.0-rc3"
+version = "0.11.0"
 edition = "2021"
 default-run = "sqd-portal"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 use serde_with::serde_derive::Serialize;
-use serde_with::{serde_as, DurationSeconds};
+use serde_with::{serde_as, DurationMilliSeconds, DurationSeconds};
 use std::collections::BTreeMap;
 use std::time::Duration;
 use url::Url;
@@ -48,6 +48,15 @@ pub struct Config {
 
     #[serde(default = "default_default_timeout_quantile")]
     pub default_timeout_quantile: f32,
+
+    /// Backoff applied to a worker that reports overload or rate limiting
+    /// without specifying an explicit `retry_after_ms`.
+    #[serde_as(as = "DurationMilliSeconds<u64>")]
+    #[serde(
+        rename = "default_worker_backoff_ms",
+        default = "default_default_worker_backoff"
+    )]
+    pub default_worker_backoff: Duration,
 
     #[serde_as(as = "DurationSeconds")]
     #[serde(
@@ -225,6 +234,10 @@ fn default_default_retries() -> u8 {
 
 fn default_default_timeout_quantile() -> f32 {
     0.5
+}
+
+fn default_default_worker_backoff() -> Duration {
+    Duration::from_millis(1000)
 }
 
 fn default_chain_update_interval() -> Duration {

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -118,6 +118,7 @@ pub struct NetworkClient {
     verify_responses: bool,
     read_scheduler: Option<Arc<DownloadScheduler>>,
     transport_timeout: Duration,
+    default_worker_backoff: Duration,
 }
 
 pub struct NetworkClientBuilder {
@@ -195,6 +196,7 @@ impl NetworkClientBuilder {
             verify_responses: config.verify_worker_responses,
             read_scheduler,
             transport_timeout: config.transport_timeout,
+            default_worker_backoff: config.default_worker_backoff,
         });
 
         tokio::spawn(async move {
@@ -776,7 +778,7 @@ impl NetworkClient {
                                 self.network_state.report_query_error(peer_id);
                                 if retry_after_ms.is_none() {
                                     self.network_state
-                                        .hint_backoff(peer_id, Duration::from_millis(1000));
+                                        .hint_backoff(peer_id, self.default_worker_backoff);
                                 }
                                 Err(QueryError::Retriable("worker overloaded".to_owned()))
                             }
@@ -785,7 +787,7 @@ impl NetworkClient {
                                 self.network_state.report_query_success(peer_id, None);
                                 if retry_after_ms.is_none() {
                                     self.network_state
-                                        .hint_backoff(peer_id, Duration::from_millis(100));
+                                        .hint_backoff(peer_id, self.default_worker_backoff);
                                 }
                                 Err(QueryError::RateLimitExceeded)
                             }


### PR DESCRIPTION
The portal is frequently receiving `too_many_requests` from the workers. It can happen occasionally (in cases described in #116), but not that often.

I found that 97.5% of those errors are coming from just 2 workers.
<img width="2350" height="1312" alt="image" src="https://github.com/user-attachments/assets/3598cc36-0b87-4501-8191-2306cbde7d0a" />

I suspect that they're not correctly handling the rate limiting for some reason. Since we can't fully prevent such behaviour from the worker side, we can at least make such requests less frequent on the portal by backing off in case no backoff hint was provided with the response.