### PR TITLE
Ignore unknown config fields and emit a warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7405,6 +7405,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7837,6 +7847,7 @@ dependencies = [
  "semver 1.0.25",
  "sentry",
  "serde",
+ "serde_ignored",
  "serde_json",
  "serde_with",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ scopeguard = "1.2"
 semver = "1"
 sentry = { version = "0.46.0", features = ["tracing", "tower"] }
 serde = { version = "1", features = ["derive"] }
+serde_ignored = "0.1"
 serde_json = "1.0"
 serde_with = "3.11"
 serde_yaml = "0.9"

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,6 @@ use crate::types::DatasetRef;
 
 #[serde_as]
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(deserialize_with = "parse_hostname")]
     pub hostname: String,
@@ -142,7 +141,7 @@ pub enum ServeMode {
 pub type DatasetsConfig = BTreeMap<String, DatasetConfigModel>;
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct DatasetConfigModel {
     pub aliases: Vec<String>,
     pub sqd_network: Option<DatasetRef>,
@@ -166,7 +165,12 @@ impl Config {
         let file = std::fs::File::open(config_path)?;
         let buf_reader = std::io::BufReader::new(file);
         let deser = serde_yaml::Deserializer::from_reader(buf_reader);
-        let config: Self = serde_yaml::with::singleton_map_recursive::deserialize(deser)?;
+        let mut warn_unknown = |path: serde_ignored::Path| {
+            tracing::warn!("ignoring unknown config field: {path}");
+        };
+        let config: Self = serde_yaml::with::singleton_map_recursive::deserialize(
+            serde_ignored::Deserializer::new(deser, &mut warn_unknown),
+        )?;
         config.validate()?;
         Ok(config)
     }
@@ -333,6 +337,34 @@ hostname: portal.example
 sqd_network:
   datasets: https://example.invalid/datasets.yaml
 "#;
+
+    #[test]
+    fn unknown_fields_are_reported_not_rejected() {
+        let yaml = format!(
+            "{MINIMAL_YAML}unknown_top_level: 123\n\
+             congestion:\n  min_window: 5\n  bogus_nested: true\n"
+        );
+        let deser = serde_yaml::Deserializer::from_str(&yaml);
+        let mut ignored = Vec::new();
+        let config: Config = serde_yaml::with::singleton_map_recursive::deserialize(
+            serde_ignored::Deserializer::new(deser, &mut |path: serde_ignored::Path| {
+                ignored.push(path.to_string());
+            }),
+        )
+        .expect("parse");
+
+        // Known fields still deserialize correctly alongside the unknown ones.
+        assert_eq!(config.congestion.min_window, 5);
+        // Both the top-level and the nested unknown field are reported with paths.
+        assert!(
+            ignored.contains(&"unknown_top_level".to_string()),
+            "missing top-level unknown field, got {ignored:?}"
+        );
+        assert!(
+            ignored.contains(&"congestion.bogus_nested".to_string()),
+            "missing nested unknown field, got {ignored:?}"
+        );
+    }
 
     #[test]
     fn shutdown_durations_default_when_omitted() {


### PR DESCRIPTION
Failing on an unknown field is risky because you can't safely roll back a non-breaking change without rolling back the config. Emitting a warning instead of crashing.