### PR TITLE
chore: Log readiness check transitions for diagnostics

### DIFF
--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -1,5 +1,5 @@
 use std::future::IntoFuture;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
 use axum::http::Method;
@@ -45,7 +45,7 @@ use crate::{
     config::Config,
     controller::task_manager::TaskManager,
     hotblocks::HotblocksHandle,
-    network::{NetworkClient, NoWorker},
+    network::{NetworkClient, NoWorker, NotReady},
     types::{ChunkId, DatasetId, ParsedQuery, RequestError, StreamRequest},
     utils::logging,
 };
@@ -650,13 +650,53 @@ async fn get_readiness(
     Extension(client): Extension<Arc<NetworkClient>>,
     Extension(shutting_down): Extension<Arc<AtomicBool>>,
 ) -> impl IntoResponse {
-    if shutting_down.load(Ordering::Relaxed) {
-        return (StatusCode::SERVICE_UNAVAILABLE, "Shutting down").into_response();
+    // Stable discriminant per readiness *category*. `/ready` is polled
+    // continuously, so we log only when the category changes — entering a new
+    // state logs once (with live detail), while fluctuating connection counts
+    // within `InsufficientConnections` do not. Starts `READY` so a portal that
+    // never becomes ready still logs the reason on its first probe.
+    const READY: u8 = 0;
+    const SHUTTING_DOWN: u8 = 1;
+    const NO_WORKERS: u8 = 2;
+    const INSUFFICIENT_CONNECTIONS: u8 = 3;
+    static LAST_STATE: AtomicU8 = AtomicU8::new(READY);
+
+    let (state, code, body, reason): (u8, StatusCode, &str, Option<NotReady>) =
+        if shutting_down.load(Ordering::Relaxed) {
+            (
+                SHUTTING_DOWN,
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Shutting down",
+                None,
+            )
+        } else {
+            match client.readiness() {
+                Ok(()) => (READY, StatusCode::OK, "Ready", None),
+                Err(reason) => {
+                    let state = match reason {
+                        NotReady::NoWorkers => NO_WORKERS,
+                        NotReady::InsufficientConnections { .. } => INSUFFICIENT_CONNECTIONS,
+                    };
+                    (
+                        state,
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        "Not ready",
+                        Some(reason),
+                    )
+                }
+            }
+        };
+
+    if LAST_STATE.swap(state, Ordering::Relaxed) != state {
+        match (state, reason) {
+            (READY, _) => tracing::info!("readiness check now passing: portal is ready"),
+            (SHUTTING_DOWN, _) => tracing::info!("readiness check now failing: shutting down"),
+            (_, Some(reason)) => tracing::warn!("readiness check now failing: {reason}"),
+            (_, None) => {}
+        }
     }
-    if client.is_ready() {
-        return (StatusCode::OK, "Ready").into_response();
-    }
-    (StatusCode::SERVICE_UNAVAILABLE, "Not ready").into_response()
+
+    (code, body).into_response()
 }
 
 /// [INTERNAL] Dataset Height (deprecated)

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -212,6 +212,37 @@ impl NetworkClientBuilder {
     }
 }
 
+/// Why the portal is not ready to serve requests. The variant identifies the
+/// failure *category* (stable across fluctuating counts); `Display` renders the
+/// detailed, human-readable explanation used in logs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotReady {
+    /// No workers are known for any dataset yet (still bootstrapping).
+    NoWorkers,
+    /// Fewer than the required fraction of worker connections are established.
+    InsufficientConnections {
+        active: usize,
+        required: usize,
+        workers: usize,
+    },
+}
+
+impl std::fmt::Display for NotReady {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NotReady::NoWorkers => write!(f, "no workers known for any dataset yet"),
+            NotReady::InsufficientConnections {
+                active,
+                required,
+                workers,
+            } => write!(
+                f,
+                "not enough active connections: {active} active < {required} required ({workers} workers known)"
+            ),
+        }
+    }
+}
+
 impl NetworkClient {
     pub async fn builder(
         args: TransportArgs,
@@ -865,9 +896,28 @@ impl NetworkClient {
     }
 
     pub fn is_ready(&self) -> bool {
-        let num_workers = self.network_state.dataset_storage.num_workers();
-        let active_connections = self.transport_handle.active_connections() as usize;
-        num_workers > 0 && active_connections >= num_workers * 3 / 4
+        self.readiness().is_ok()
+    }
+
+    /// Returns `Ok(())` if the portal is ready to serve requests, or `Err` with a
+    /// typed reason it is not (for diagnostics / logging). The reason's `Display`
+    /// renders a human-readable message, while the variant itself can be compared
+    /// to detect state changes without treating fluctuating counts as new states.
+    pub fn readiness(&self) -> Result<(), NotReady> {
+        let workers = self.network_state.dataset_storage.num_workers();
+        let active = self.transport_handle.active_connections() as usize;
+        let required = workers * 3 / 4;
+        if workers == 0 {
+            return Err(NotReady::NoWorkers);
+        }
+        if active < required {
+            return Err(NotReady::InsufficientConnections {
+                active,
+                required,
+                workers,
+            });
+        }
+        Ok(())
     }
 
     fn signal_congestion(&self) {

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -4,7 +4,9 @@ mod priorities;
 mod state;
 mod storage;
 
-pub use client::{CurrentEpoch, NetworkClient, NetworkClientStatus, QueryResult, Workers};
+pub use client::{
+    CurrentEpoch, NetworkClient, NetworkClientStatus, NotReady, QueryResult, Workers,
+};
 pub use contracts_state::Status;
 pub use priorities::{NoWorker, PrioritiesConfig, Priority};
 pub use state::{NetworkState, WorkerLease};


### PR DESCRIPTION
## What is this PR about?

The /ready probe could fail silently for several reasons (no workers known, too few connections, or shutdown), making issues hard to investigate.

Return a typed NotReady reason from NetworkClient::readiness() and log only on category changes, tracked via a static AtomicU8 so each state is logged once on entry without spamming on fluctuating counts.