### PR TITLE
Fix duplicate chunk scheduling after a failed first-chunk attempt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7814,7 +7814,7 @@ dependencies = [
 
 [[package]]
 name = "sqd-portal"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqd-portal"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 default-run = "sqd-portal"
 

--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -708,9 +708,17 @@ impl StreamController {
                         let chunk_slot = ChunkSlot::new(*slot);
                         self.stats.observe_chunk_parts(chunk_slot.num_parts());
                         self.buffer.push_back(chunk_slot);
+                        // The pushed slot now owns this chunk. If the stream survives
+                        // (`pop_response` keeps slots paused for less than MAX_IDLE_TIME
+                        // alive), the slot is retried in place by `poll_deferred_slot`.
+                        // Re-queueing the chunk into `next_chunk` as well would schedule
+                        // a second slot for the same chunk once the backoff expires,
+                        // duplicating the chunk's data in the response.
+                        self.next_chunk = self.get_next_chunk(&chunk);
+                    } else {
+                        self.next_chunk = Some(chunk);
                     }
                     self.last_error = Some(e.to_string());
-                    self.next_chunk = Some(chunk);
                     break;
                 }
             }

--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -71,7 +71,7 @@ use tracing::{instrument, Instrument};
 
 use crate::{
     controller::timeouts::TimeoutManager,
-    network::{ChunkNotFound, NetworkClient, NoWorker, QueryResult, WorkerLease},
+    network::{ChunkNotFound, NetworkClient, NoWorker, QueryResult, StreamingNetwork, WorkerLease},
     types::{
         BlockRange, ChunkId, DataChunk, QueryError, RequestError, ResponseChunk, SendQueryError,
         StreamRequest,
@@ -81,9 +81,9 @@ use crate::{
 
 const MAX_IDLE_TIME: Duration = Duration::from_millis(1000);
 
-pub struct StreamController {
+pub struct StreamController<N: StreamingNetwork = NetworkClient> {
     request: StreamRequest,
-    network: Arc<NetworkClient>,
+    network: Arc<N>,
     buffer: SlidingArray<ChunkSlot>,
     next_chunk: Option<DataChunk>,
     timeouts: TimeoutManager,
@@ -207,10 +207,10 @@ impl UpdateStatus {
     }
 }
 
-impl StreamController {
+impl<N: StreamingNetwork> StreamController<N> {
     pub fn new(
         request: StreamRequest,
-        network: Arc<NetworkClient>,
+        network: Arc<N>,
         stream_index: u32,
         priority_stride: u32,
     ) -> Result<Self, RequestError> {
@@ -859,7 +859,7 @@ impl StreamController {
     }
 }
 
-impl Drop for StreamController {
+impl<N: StreamingNetwork> Drop for StreamController<N> {
     fn drop(&mut self) {
         let _enter = self.span.enter();
         self.stats
@@ -867,7 +867,7 @@ impl Drop for StreamController {
     }
 }
 
-impl futures::Stream for StreamController {
+impl<N: StreamingNetwork> futures::Stream for StreamController<N> {
     type Item = Result<ResponseChunk, RequestError>;
 
     fn poll_next(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -1321,5 +1321,126 @@ mod tests {
         chunk_slot.active = None;
 
         assert_eq!(chunk_slot.debug_symbol(), '#');
+    }
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use futures::{future::BoxFuture, StreamExt};
+
+    use crate::network::QuerySuccess;
+    use crate::types::{Compression, DatasetId, StreamRequest};
+
+    /// A single-chunk dataset whose workers are all in a backoff until
+    /// `backoff_until`; afterwards every query succeeds and returns the
+    /// queried range's full data.
+    struct MockNetwork {
+        chunk: DataChunk,
+        backoff_until: Instant,
+        queries_sent: AtomicUsize,
+    }
+
+    impl StreamingNetwork for MockNetwork {
+        fn find_chunk(
+            &self,
+            _dataset: &DatasetId,
+            _block: u64,
+        ) -> Result<DataChunk, ChunkNotFound> {
+            Ok(self.chunk.clone())
+        }
+
+        fn next_chunk(&self, _dataset: &DatasetId, _chunk: &DataChunk) -> Option<DataChunk> {
+            None
+        }
+
+        fn find_worker(&self, _dataset: &DatasetId, _block: u64) -> Result<WorkerLease, NoWorker> {
+            if Instant::now() < self.backoff_until {
+                return Err(NoWorker::Backoff(self.backoff_until));
+            }
+            Ok(WorkerLease::for_tests(PeerId::random()))
+        }
+
+        fn query_worker(
+            self: Arc<Self>,
+            _lease: WorkerLease,
+            _request_id: String,
+            _chunk_id: ChunkId,
+            block_range: BlockRange,
+            _query: String,
+            _compression: Compression,
+            _priority: Option<u32>,
+        ) -> BoxFuture<'static, QueryResult> {
+            self.queries_sent.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async move {
+                Ok(QuerySuccess {
+                    ok: sqd_messages::QueryOk {
+                        data: format!("data-{}-{}", block_range.start(), block_range.end())
+                            .into_bytes(),
+                        last_block: *block_range.end(),
+                    },
+                    ttfb: Duration::from_millis(1),
+                    transfer_time: Duration::from_millis(1),
+                    response_size: 10,
+                })
+            })
+        }
+    }
+
+    fn stream_request() -> StreamRequest {
+        let query_json = r#"{
+            "type": "evm",
+            "fromBlock": 100,
+            "toBlock": 150,
+            "fields": {"block": {"number": true}},
+            "includeAllBlocks": true
+        }"#;
+        StreamRequest {
+            dataset_id: DatasetId::from_url("test-dataset"),
+            dataset_name: "test-dataset".to_owned(),
+            query: ParsedQuery::try_from(query_json.to_owned()).unwrap(),
+            request_id: "test-request".to_owned(),
+            buffer_size: 10,
+            max_chunks: None,
+            timeout_quantile: 0.5,
+            retries: 1,
+            compression: Compression::Gzip,
+            skip_parent_hash_validation: false,
+            eager_continuations: false,
+        }
+    }
+
+    /// Regression test for the duplicated-response incident: a request whose
+    /// first chunk hits a short worker backoff (all workers rate-limited)
+    /// must still serve the chunk's data exactly once.
+    ///
+    /// Before the fix, the failed scheduling attempt left the chunk owned
+    /// both by the error slot in the buffer (retried in place once the
+    /// backoff expired) and by `next_chunk` (scheduled a second time by
+    /// `try_fill_slots`), so the chunk's full data was queried and emitted
+    /// twice within one stream.
+    #[tokio::test(start_paused = true)]
+    async fn chunk_hitting_short_backoff_is_served_exactly_once() {
+        let network = Arc::new(MockNetwork {
+            chunk: test_chunk(),
+            backoff_until: Instant::now() + Duration::from_millis(100),
+            queries_sent: AtomicUsize::new(0),
+        });
+        let mut controller =
+            StreamController::new(stream_request(), network.clone(), 0, 1).unwrap();
+
+        let mut responses = Vec::new();
+        while let Some(item) = controller.next().await {
+            responses.push(item.expect("stream should not fail"));
+        }
+
+        assert_eq!(
+            responses,
+            vec![b"data-100-150".to_vec()],
+            "the chunk's data must be served exactly once",
+        );
+        assert_eq!(
+            network.queries_sent.load(Ordering::SeqCst),
+            1,
+            "the chunk must be queried exactly once",
+        );
     }
 }

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -37,6 +37,66 @@ use crate::{
     types::{generate_query_id, DatasetId, QueryError},
 };
 
+/// The subset of [`NetworkClient`] that the stream controller depends on.
+///
+/// Abstracting it into a trait allows exercising the controller's chunk
+/// scheduling logic in tests with a mock network.
+pub trait StreamingNetwork: Send + Sync + 'static {
+    fn find_chunk(&self, dataset: &DatasetId, block: u64) -> Result<DataChunk, ChunkNotFound>;
+
+    fn next_chunk(&self, dataset: &DatasetId, chunk: &DataChunk) -> Option<DataChunk>;
+
+    fn find_worker(&self, dataset: &DatasetId, block: u64) -> Result<WorkerLease, NoWorker>;
+
+    #[allow(clippy::too_many_arguments)]
+    fn query_worker(
+        self: Arc<Self>,
+        lease: WorkerLease,
+        request_id: String,
+        chunk_id: ChunkId,
+        block_range: BlockRange,
+        query: String,
+        compression: Compression,
+        priority: Option<u32>,
+    ) -> futures::future::BoxFuture<'static, QueryResult>;
+}
+
+impl StreamingNetwork for NetworkClient {
+    fn find_chunk(&self, dataset: &DatasetId, block: u64) -> Result<DataChunk, ChunkNotFound> {
+        NetworkClient::find_chunk(self, dataset, block)
+    }
+
+    fn next_chunk(&self, dataset: &DatasetId, chunk: &DataChunk) -> Option<DataChunk> {
+        NetworkClient::next_chunk(self, dataset, chunk)
+    }
+
+    fn find_worker(&self, dataset: &DatasetId, block: u64) -> Result<WorkerLease, NoWorker> {
+        NetworkClient::find_worker(self, dataset, block)
+    }
+
+    fn query_worker(
+        self: Arc<Self>,
+        lease: WorkerLease,
+        request_id: String,
+        chunk_id: ChunkId,
+        block_range: BlockRange,
+        query: String,
+        compression: Compression,
+        priority: Option<u32>,
+    ) -> futures::future::BoxFuture<'static, QueryResult> {
+        Box::pin(NetworkClient::query_worker(
+            self,
+            lease,
+            request_id,
+            chunk_id,
+            block_range,
+            query,
+            compression,
+            priority,
+        ))
+    }
+}
+
 #[derive(Debug)]
 pub struct QuerySuccess {
     pub ok: QueryOk,

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -5,7 +5,8 @@ mod state;
 mod storage;
 
 pub use client::{
-    CurrentEpoch, NetworkClient, NetworkClientStatus, NotReady, QueryResult, Workers,
+    CurrentEpoch, NetworkClient, NetworkClientStatus, NotReady, QueryResult, QuerySuccess,
+    StreamingNetwork, Workers,
 };
 pub use contracts_state::Status;
 pub use priorities::{NoWorker, PrioritiesConfig, Priority};

--- a/src/network/state.rs
+++ b/src/network/state.rs
@@ -22,6 +22,18 @@ impl WorkerLease {
     pub fn worker(&self) -> PeerId {
         self.worker
     }
+
+    /// Creates a standalone lease backed by a fresh pool, for tests that
+    /// mock the network without a full [`NetworkState`].
+    #[cfg(test)]
+    pub(crate) fn for_tests(worker: PeerId) -> Self {
+        let pool = Arc::new(RwLock::new(
+            WorkersPool::new(PrioritiesConfig::default()),
+            "WorkerLease::for_tests pool",
+        ));
+        pool.write().lease(worker);
+        Self { pool, worker }
+    }
 }
 
 impl Drop for WorkerLease {


### PR DESCRIPTION
## Problem

Under production load, `/stream` sometimes emits the result **twice** in one response body: the full block sequence is served, then replayed from `fromBlock`. Confirmed by a captured corpus of 120 anomalous production responses (sha256-identical halves in the cleanest samples).

## Root cause

Double chunk ownership in `StreamController::try_fill_slots`. When scheduling a chunk fails with all its workers in a short backoff (< `MAX_IDLE_TIME` = 1s):

1. The error slot is pushed into the buffer **and** the same chunk is restored into `next_chunk` — two owners.
2. `pop_response` keeps the short-backoff paused slot alive instead of failing the request.
3. After the backoff expires, both owners schedule the chunk: `poll_deferred_slot` retries the slot in place, and `try_fill_slots` consumes the restored `next_chunk` as a second slot.
4. Both results are emitted — the chunk's data appears twice in a valid gzip body.

Introduced by 16cfd93 ("Don't panic on NoWorkers error", v0.6.0-rc5): before it the error arm discarded the slot, leaving a single owner. Surfaced now because recent overload-handling changes made sub-second all-workers-in-backoff windows routine.

## Fix

When the error slot is pushed into the buffer, it takes ownership and `next_chunk` advances past the chunk. The chunk is only re-queued when no slot was pushed (buffer non-empty).

## Testing

- Regression test `chunk_hitting_short_backoff_is_served_exactly_once`: drives the exact incident sequence (first chunk hits a short all-workers backoff, stream survives the pause) against a mock network via the new `StreamingNetwork` seam. It fails on the unfixed code with the chunk emitted twice and passes with the fix.
- `cargo test --lib`: 83 passed
- clippy/fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)






