### PR TITLE
Wrong-range worker responses, property tests for stream scheduling, and the start of CT-2

### DIFF
--- a/harness/src/fixture.rs
+++ b/harness/src/fixture.rs
@@ -1,0 +1,153 @@
+//! Boot the whole IB-7 stub world plus the portal-under-test, so a conformance
+//! class is a file of assertions rather than a file of setup.
+//!
+//! Every CT class needs the same thing: stubs with ledgers, a toy world, a
+//! portal process, and a way to dump state when a run fails. CT-1 grew that
+//! inline; anything past it shares this.
+
+use std::time::Duration;
+
+use anyhow::Context;
+use tempfile::TempDir;
+
+use crate::portal::{Endpoints, PortalProcess};
+use crate::stubs::worker::{WorkerFaults, WorkerStub};
+use crate::{artifact, driver, dummy_chain, keys, portal, stubs, ToyWorld};
+
+pub struct Fixture {
+    pub world: ToyWorld,
+    pub base: String,
+    pub http: reqwest::Client,
+    pub portal: PortalProcess,
+    pub worker_ledgers: Vec<stubs::Ledger>,
+    /// Shared by every stub worker: a queued fault lands on whichever one the
+    /// portal picks, so tests don't depend on the routing choice (FV-1).
+    pub worker_faults: WorkerFaults,
+    pub hotblocks_ledger: stubs::Ledger,
+    pub publisher_ledger: stubs::Ledger,
+    _workers: Vec<WorkerStub>,
+    scratch: Option<TempDir>,
+}
+
+impl Fixture {
+    /// `workers` stub workers on the toy world. The portal pre-leases
+    /// 1 + retries distinct workers per chunk, so two is the minimum that lets
+    /// a reroute actually find somewhere to go.
+    pub async fn start(world: ToyWorld, workers: usize) -> anyhow::Result<Self> {
+        anyhow::ensure!(workers >= 1, "need at least one worker");
+        // Loopback p2p addresses are filtered as unreachable unless this is set.
+        std::env::set_var("PRIVATE_NETWORK", "1");
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| "info".into()),
+            )
+            .try_init();
+
+        let scratch_dir = tempfile::tempdir()?;
+        let scratch = scratch_dir.path().to_path_buf();
+
+        let endpoints = Endpoints {
+            publisher_port: crate::free_tcp_port(),
+            registry_port: crate::free_tcp_port(),
+            hotblocks_port: crate::free_tcp_port(),
+            http_port: crate::free_tcp_port(),
+        };
+        let worker_udp_ports: Vec<u16> = (0..workers).map(|_| crate::free_udp_port()).collect();
+
+        let worker_ids = (0..workers)
+            .map(|i| keys::generate(&scratch.join(format!("worker-{i}.key"))))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let portal_id = keys::generate(&scratch.join("portal.key"))?;
+        let worker_peers: Vec<_> = worker_ids.iter().map(|w| w.peer_id).collect();
+        let dummy_path = scratch.join("dummy_client.json");
+        std::fs::write(
+            &dummy_path,
+            dummy_chain::dummy_data_json(&worker_peers, portal_id.peer_id),
+        )?;
+
+        let artifact_gz = artifact::build_gzipped(&world, &worker_peers)?;
+        let publisher_ledger = stubs::publisher::start(
+            endpoints.publisher_port,
+            stubs::publisher::network_state_json(endpoints.publisher_port, "toy-assignment-1", 0),
+            artifact_gz,
+        )
+        .await?;
+        let _registry_ledger = stubs::registry::start(endpoints.registry_port, &world).await?;
+        let hotblocks_ledger =
+            stubs::hotblocks::start(endpoints.hotblocks_port, world.clone()).await?;
+
+        let worker_faults = WorkerFaults::none();
+        let mut worker_ledgers = Vec::new();
+        let mut stub_workers = Vec::new();
+        for (i, id) in worker_ids.iter().enumerate() {
+            let stub = stubs::worker::start(
+                world.clone(),
+                &scratch.join(format!("worker-{i}.key")),
+                id.keypair.clone(),
+                &dummy_path,
+                worker_udp_ports[i],
+                worker_faults.clone(),
+            )
+            .await
+            .with_context(|| format!("start stub worker {i}"))?;
+            worker_ledgers.push(stub.ledger.clone());
+            stub_workers.push(stub);
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await; // QUIC listeners up
+
+        let boot_nodes = worker_ids
+            .iter()
+            .zip(&worker_udp_ports)
+            .map(|(id, port)| format!("{} /ip4/127.0.0.1/udp/{port}/quic-v1", id.peer_id))
+            .collect::<Vec<_>>()
+            .join(",");
+        let config = portal::write_config(&scratch, &world, &endpoints)?;
+        let portal = portal::spawn(
+            &scratch,
+            &config,
+            &scratch.join("portal.key"),
+            &dummy_path,
+            &boot_nodes,
+            &endpoints,
+        )?;
+
+        Ok(Self {
+            base: portal.base_url.clone(),
+            world,
+            http: driver::client(),
+            portal,
+            worker_ledgers,
+            worker_faults,
+            hotblocks_ledger,
+            publisher_ledger,
+            _workers: stub_workers,
+            scratch: Some(scratch_dir),
+        })
+    }
+
+    pub async fn wait_ready(&mut self, timeout: Duration) -> anyhow::Result<()> {
+        self.portal.wait_ready(timeout).await
+    }
+
+    /// Total stub-worker queries answered, across every worker.
+    pub fn queries_answered(&self) -> usize {
+        self.worker_ledgers
+            .iter()
+            .map(|l| l.count_with_prefix("query "))
+            .sum()
+    }
+
+    /// Tear down, dumping the portal log and keeping the scratch dir when the
+    /// run failed — a conformance failure is worth more than a clean temp dir.
+    pub fn finish<T>(mut self, result: anyhow::Result<T>) -> anyhow::Result<T> {
+        if result.is_err() {
+            eprintln!("=== portal log tail ===\n{}", self.portal.log_tail(80));
+            if let Some(dir) = self.scratch.take() {
+                eprintln!("=== scratch kept at {} ===", dir.keep().display());
+            }
+        }
+        self.portal.terminate();
+        result
+    }
+}

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod artifact;
 pub mod driver;
 pub mod dummy_chain;
+pub mod fixture;
 pub mod keys;
 pub mod metrics_audit;
 pub mod model;

--- a/harness/src/stubs/worker.rs
+++ b/harness/src/stubs/worker.rs
@@ -5,14 +5,17 @@
 //! direct dial); the shared dummy-chain file registers it as an active worker.
 //! `PRIVATE_NETWORK=1` must be set or loopback addresses are unreachable.
 
+use std::collections::VecDeque;
 use std::io::Write;
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Context;
 use clap::Parser;
 use flate2::{write::GzEncoder, Compression};
 use futures::StreamExt;
 use libp2p_identity::Keypair;
+use sqd_messages::query_error;
 use sqd_network_transport::{
     AgentInfo, P2PTransportBuilder, TransportArgs, WorkerConfig, WorkerEvent,
 };
@@ -24,6 +27,66 @@ use crate::world::ToyWorld;
 struct StubCli {
     #[command(flatten)]
     transport: TransportArgs,
+}
+
+/// One row of the DC-1 worker-fault table (spec/09), injectable into a stub's
+/// next answer. `Overshoot`/`Undershoot`/`BadSignature` are the integrity
+/// family: the portal must discard them, reroute, and never deliver the data.
+#[derive(Debug, Clone)]
+pub enum WorkerFault {
+    /// Report a `last_block` this many blocks past the queried range end.
+    Overshoot(u64),
+    /// Report a `last_block` this many blocks below the queried range start.
+    Undershoot(u64),
+    /// Sign with a key that is not this worker's identity.
+    BadSignature,
+    /// Answer with a server-error verdict.
+    ServerError(String),
+    /// Answer "chunk not found" — the worker is still downloading it. Same
+    /// DC-1 row as ServerError, but the portal treats it as retriable.
+    NotFound(String),
+}
+
+/// A fault queue shared by every stub worker in a test, so a single queued
+/// fault lands on whichever worker the portal happens to pick (FV-1) — the
+/// alternative would be a test that only passes for one routing choice.
+#[derive(Clone, Default)]
+pub struct WorkerFaults {
+    queued: Arc<Mutex<VecDeque<WorkerFault>>>,
+    persistent: Arc<Mutex<Option<WorkerFault>>>,
+}
+
+impl WorkerFaults {
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    /// Apply `fault` to the next `count` answers, then behave.
+    pub fn queue(&self, fault: WorkerFault, count: usize) -> &Self {
+        let mut q = self.queued.lock().unwrap();
+        for _ in 0..count {
+            q.push_back(fault.clone());
+        }
+        self
+    }
+
+    /// Apply `fault` to every answer until cleared.
+    pub fn always(&self, fault: WorkerFault) -> &Self {
+        *self.persistent.lock().unwrap() = Some(fault);
+        self
+    }
+
+    pub fn clear(&self) {
+        self.queued.lock().unwrap().clear();
+        *self.persistent.lock().unwrap() = None;
+    }
+
+    fn next(&self) -> Option<WorkerFault> {
+        if let Some(f) = self.queued.lock().unwrap().pop_front() {
+            return Some(f);
+        }
+        self.persistent.lock().unwrap().clone()
+    }
 }
 
 pub struct WorkerStub {
@@ -38,6 +101,7 @@ pub async fn start(
     signing_keypair: Keypair,
     dummy_client_path: &Path,
     udp_port: u16,
+    faults: WorkerFaults,
 ) -> anyhow::Result<WorkerStub> {
     let listen_addr = format!("/ip4/127.0.0.1/udp/{udp_port}/quic-v1");
     let cli = StubCli::try_parse_from([
@@ -75,8 +139,9 @@ pub async fn start(
         while let Some(event) = events.next().await {
             match event {
                 WorkerEvent::Query { peer_id, query, resp_chan } => {
-                    tracing::info!(%peer_id, chunk = %query.chunk_id, "stub worker query");
-                    let result = answer(&world, &signing_keypair, &query, &ledger2);
+                    let fault = faults.next();
+                    tracing::info!(%peer_id, chunk = %query.chunk_id, ?fault, "stub worker query");
+                    let result = answer(&world, &signing_keypair, &query, &ledger2, fault);
                     if handle.send_query_result(result, resp_chan).is_err() {
                         tracing::warn!("query result queue full");
                     }
@@ -94,12 +159,27 @@ fn answer(
     keypair: &Keypair,
     query: &sqd_messages::Query,
     ledger: &Ledger,
+    fault: Option<WorkerFault>,
 ) -> sqd_messages::QueryResult {
     let range = query.block_range.unwrap_or(sqd_messages::Range { begin: 0, end: 0 });
     ledger.push(format!(
-        "query chunk={} range={}-{} dataset={}",
-        query.chunk_id, range.begin, range.end, query.dataset
+        "query chunk={} range={}-{} dataset={} fault={}",
+        query.chunk_id,
+        range.begin,
+        range.end,
+        query.dataset,
+        fault.as_ref().map_or("none".to_owned(), |f| format!("{f:?}")),
     ));
+
+    match &fault {
+        Some(WorkerFault::ServerError(m)) => {
+            return verdict_result(query, keypair, query_error::Err::ServerError(m.clone()))
+        }
+        Some(WorkerFault::NotFound(m)) => {
+            return verdict_result(query, keypair, query_error::Err::NotFound(m.clone()))
+        }
+        _ => {}
+    }
 
     let ds = world
         .datasets
@@ -130,15 +210,27 @@ fn answer(
         _ => return error_result(query, keypair, "unsupported compression"),
     };
 
+    let last_block = match &fault {
+        Some(WorkerFault::Overshoot(n)) => range.end + n,
+        Some(WorkerFault::Undershoot(n)) => range.begin.saturating_sub((*n).max(1)),
+        _ => range.end,
+    };
+
     let mut result = sqd_messages::QueryResult {
         query_id: query.query_id.clone(),
         result: Some(sqd_messages::query_result::Result::Ok(sqd_messages::QueryOk {
             data,
-            last_block: range.end,
+            last_block,
         })),
         ..Default::default()
     };
-    result.sign(keypair).expect("result signs");
+    // A wrong key produces a well-formed result that fails verification —
+    // signing is what the portal checks, not the identity that sent it.
+    let signer = match &fault {
+        Some(WorkerFault::BadSignature) => &Keypair::generate_ed25519(),
+        _ => keypair,
+    };
+    result.sign(signer).expect("result signs");
     result
 }
 
@@ -147,10 +239,18 @@ fn error_result(
     keypair: &Keypair,
     msg: &str,
 ) -> sqd_messages::QueryResult {
+    verdict_result(query, keypair, query_error::Err::ServerError(msg.to_string()))
+}
+
+fn verdict_result(
+    query: &sqd_messages::Query,
+    keypair: &Keypair,
+    err: query_error::Err,
+) -> sqd_messages::QueryResult {
     let mut result = sqd_messages::QueryResult {
         query_id: query.query_id.clone(),
         result: Some(sqd_messages::query_result::Result::Err(sqd_messages::QueryError {
-            err: Some(sqd_messages::query_error::Err::ServerError(msg.to_string())),
+            err: Some(err),
         })),
         ..Default::default()
     };

--- a/harness/tests/ct1_smoke.rs
+++ b/harness/tests/ct1_smoke.rs
@@ -133,6 +133,7 @@ async fn ct1_smoke() -> anyhow::Result<()> {
             id.keypair.clone(),
             &dummy_path,
             worker_udp_ports[i],
+            stubs::worker::WorkerFaults::none(),
         )
         .await?;
         worker_ledgers.push(stub.ledger.clone());

--- a/harness/tests/ct2_worker_faults.rs
+++ b/harness/tests/ct2_worker_faults.rs
@@ -1,0 +1,300 @@
+//! CT-2 — the DC-1 worker-fault rows of spec/09, end to end against the portal
+//! as a black box.
+//!
+//! Covers the integrity family (wrong-range in both directions, bad signature)
+//! and the transient family (not-found, server error). The property under test
+//! is the same for all of them: a bad response is *discarded and rerouted*,
+//! never delivered, and one misbehaving worker never fails a request that
+//! another worker could serve. Exhaustion is where the families diverge —
+//! all-integrity pages, anything with a transient attempt in it tells the client
+//! to come back (INV-22, FM-2, LIV-12, DC-1).
+
+use std::time::Duration;
+
+use anyhow::{ensure, Context};
+use harness::driver::Decoded;
+use harness::fixture::Fixture;
+use harness::stubs::worker::WorkerFault;
+use harness::{driver, ToyWorld};
+use serde_json::json;
+
+/// Chunk 2 of the toy world is blocks 40..=79. Starting above 0 is what makes
+/// an undershoot expressible at all — you cannot report below block 0.
+const FROM: u64 = 40;
+const TO: u64 = 79;
+
+fn query(from: u64, to: u64) -> serde_json::Value {
+    json!({
+        "type": "evm",
+        "fromBlock": from,
+        "toBlock": to,
+        "includeAllBlocks": true,
+        "fields": { "block": { "number": true, "hash": true } },
+    })
+}
+
+/// Wait until the pool serves a clean request again.
+///
+/// Integrity and error penalties are real, so a fault case leaves the toy
+/// world's two workers in cooldown; without this the next case would measure
+/// the cooldown ("no available workers") instead of the fault it injected.
+/// Doubles as the LIV-7 witness: penalties decay, they never latch.
+async fn await_pool_recovery(fx: &Fixture, label: &str) -> anyhow::Result<Decoded> {
+    fx.worker_faults.clear();
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    let mut last = None;
+    while std::time::Instant::now() < deadline {
+        let d = driver::stream(
+            &fx.http,
+            &fx.base,
+            "toy",
+            "finalized-stream",
+            &query(FROM, TO),
+            &format!("ct2-recover-{label}"),
+        )
+        .await?;
+        if d.status == 200 {
+            return Ok(d);
+        }
+        last = Some(d.status);
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    anyhow::bail!("pool never recovered before {label} (last status {last:?}) — LIV-7")
+}
+
+/// The full range, in order, exactly once — INV-20/21 on the delivered body.
+fn assert_complete(context: &str, d: &Decoded) -> anyhow::Result<()> {
+    ensure!(
+        d.status == 200,
+        "{context}: expected 200, got {} — body: {}",
+        d.status,
+        String::from_utf8_lossy(&d.body),
+    );
+    let got = d.block_numbers();
+    let want: Vec<u64> = (FROM..=TO).collect();
+    ensure!(
+        got == want,
+        "{context}: delivered blocks are not the exact requested range\n  got {} blocks: {:?}\n  want {} blocks",
+        got.len(),
+        got.iter().take(8).collect::<Vec<_>>(),
+        want.len(),
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ct2_worker_faults() -> anyhow::Result<()> {
+    let mut fx = Fixture::start(ToyWorld::standard(), 2).await?;
+    let result = run(&mut fx).await;
+    fx.finish(result)
+}
+
+async fn run(fx: &mut Fixture) -> anyhow::Result<()> {
+    fx.wait_ready(Duration::from_secs(60)).await?;
+    let (base, http) = (fx.base.clone(), fx.http.clone());
+
+    // Baseline: no faults. Establishes that the range is servable at all, so a
+    // later failure is attributable to the injected fault and not the world.
+    let baseline = driver::stream(
+        &http,
+        &base,
+        "toy",
+        "finalized-stream",
+        &query(FROM, TO),
+        "ct2-baseline",
+    )
+    .await?;
+    assert_complete("baseline", &baseline)?;
+
+    // --- One bad response must be rerouted, not fatal (DC-1, INV-22, REQ-43) ---
+    //
+    // One fault per case, landing on whichever worker the portal picks first.
+    // The second reserved worker must serve the range, and the client must not
+    // be able to tell that anything went wrong.
+    //
+    // `server-error` is the exception, and it is a *finding*, not a quirk of the
+    // test: DC-1 ("server error / not found → reroute") and spec/09 ("Erroring →
+    // mask via reroute") both require it, but the portal classifies a generic
+    // worker ServerError as terminal, so one erroring worker fails the whole
+    // request. Recorded as a deviation rather than asserted, so this suite stays
+    // green on known-violated behavior — see the gap register in spec/13.
+    let known_violated = ["server-error"];
+    let mut deviations = Vec::new();
+
+    for (label, fault) in [
+        ("overshoot", WorkerFault::Overshoot(10)),
+        ("undershoot", WorkerFault::Undershoot(10)),
+        ("bad-signature", WorkerFault::BadSignature),
+        (
+            "not-found",
+            WorkerFault::NotFound("still downloading".into()),
+        ),
+        ("server-error", WorkerFault::ServerError("scripted".into())),
+    ] {
+        await_pool_recovery(fx, label).await?;
+        fx.worker_faults.queue(fault, 1);
+
+        let before = fx.queries_answered();
+        let d = driver::stream(
+            &http,
+            &base,
+            "toy",
+            "finalized-stream",
+            &query(FROM, TO),
+            &format!("ct2-{label}"),
+        )
+        .await
+        .with_context(|| format!("{label}: stream request"))?;
+
+        ensure!(
+            fx.queries_answered() > before,
+            "{label}: no worker query was recorded — the fault never reached a worker"
+        );
+
+        let outcome = assert_complete(label, &d).and_then(|()| {
+            ensure!(
+                d.body == baseline.body,
+                "{label}: response differs from the unfaulted baseline"
+            );
+            Ok(())
+        });
+        match outcome {
+            Ok(()) => ensure!(
+                !known_violated.contains(&label),
+                "{label} is marked known-violated but now passes — \
+                 remove it from the list and close its gap"
+            ),
+            Err(e) if known_violated.contains(&label) => {
+                eprintln!("[known-violated] {e}");
+                deviations.push(label);
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    ensure!(
+        deviations == known_violated,
+        "known-violated set drifted: {deviations:?}"
+    );
+
+    // --- Exhaustion: every attempt equivocating pages (DC-1, FM-2) ---
+    //
+    // Both reserved workers misbehave for every attempt, so the reroute has
+    // nowhere left to go.
+    await_pool_recovery(fx, "integrity-exhaustion").await?;
+    fx.worker_faults.always(WorkerFault::Overshoot(10));
+    let before = fx.queries_answered();
+    let exhausted = driver::stream(
+        &http,
+        &base,
+        "toy",
+        "finalized-stream",
+        &query(FROM, TO),
+        "ct2-integrity-exhausted",
+    )
+    .await?;
+    ensure!(
+        exhausted.status >= 400,
+        "integrity exhaustion must fail, got {}",
+        exhausted.status
+    );
+    ensure!(
+        exhausted.block_numbers().is_empty(),
+        "equivocated data must never be delivered, got {:?}",
+        exhausted.block_numbers()
+    );
+    // Guard against the vacuous pass: "no available workers" is also an error
+    // with an empty body, and would prove nothing about exhaustion.
+    ensure!(
+        fx.queries_answered() >= before + 2,
+        "integrity exhaustion must exhaust real attempts, only {} were answered",
+        fx.queries_answered() - before
+    );
+    // The two families must be distinguishable: integrity exhaustion is an
+    // operator page, transient exhaustion is "come back later". Asserting only
+    // "some error" would let them collapse into one. NotFound is the transient
+    // case that actually reroutes, so this exhausts attempts rather than dying
+    // on the first response.
+    await_pool_recovery(fx, "transient-exhaustion").await?;
+    fx.worker_faults
+        .always(WorkerFault::NotFound("still downloading".into()));
+    let before = fx.queries_answered();
+    let transient = driver::stream(
+        &http,
+        &base,
+        "toy",
+        "finalized-stream",
+        &query(FROM, TO),
+        "ct2-transient-exhausted",
+    )
+    .await?;
+    ensure!(
+        transient.status >= 400,
+        "transient exhaustion must fail, got {}",
+        transient.status
+    );
+    ensure!(
+        fx.queries_answered() >= before + 2,
+        "transient exhaustion must exhaust real attempts, only {} were answered",
+        fx.queries_answered() - before
+    );
+    // Codes themselves are not asserted: the ADR-011 taxonomy is not integrated
+    // yet (GAP-16), so only the split is contract today.
+    eprintln!(
+        "[ct2] exhaustion split — integrity {} / transient {}",
+        exhausted.status, transient.status
+    );
+    ensure!(
+        exhausted.status != transient.status,
+        "integrity exhaustion ({}) must not be reported as a transient outage ({}) — \
+         DC-1 splits these into WORKER-FAILURE and RETRIES-EXHAUSTED",
+        exhausted.status,
+        transient.status,
+    );
+
+    // Mixed exhaustion follows the transient class, not the integrity one: if
+    // any attempt failed transiently a later retry can still succeed, so the
+    // client is told to come back rather than that the request is hopeless
+    // (DC-1). The equivocation is still counted against its worker — operator
+    // visibility does not ride on the response class.
+    await_pool_recovery(fx, "mixed-exhaustion").await?;
+    fx.worker_faults
+        .queue(WorkerFault::Overshoot(10), 1)
+        .queue(WorkerFault::NotFound("still downloading".into()), 1);
+    let before = fx.queries_answered();
+    let mixed = driver::stream(
+        &http,
+        &base,
+        "toy",
+        "finalized-stream",
+        &query(FROM, TO),
+        "ct2-mixed-exhausted",
+    )
+    .await?;
+    ensure!(
+        mixed.block_numbers().is_empty(),
+        "mixed exhaustion must deliver nothing, got {:?}",
+        mixed.block_numbers()
+    );
+    ensure!(
+        fx.queries_answered() >= before + 2,
+        "mixed exhaustion must consume both scripted faults, only {} answered",
+        fx.queries_answered() - before
+    );
+    ensure!(
+        mixed.status == transient.status,
+        "mixed exhaustion must take the transient class ({}), got {}",
+        transient.status,
+        mixed.status
+    );
+
+    // Recovery: penalties are not latched. Once the faults stop, the pool
+    // serves again (LIV-7).
+    let recovered = await_pool_recovery(fx, "final").await?;
+    assert_complete("recovered", &recovered)?;
+    ensure!(
+        recovered.body == baseline.body,
+        "recovered response differs from the unfaulted baseline"
+    );
+
+    Ok(())
+}

--- a/spec/05-dependencies.md
+++ b/spec/05-dependencies.md
@@ -31,7 +31,7 @@ alternatives exist.
 | server error / not found | reroute; cooldown P-WORKER-ERROR-COOLDOWN; exhausted ⇒ RETRIES-EXHAUSTED |
 | timeout / transport failure | reroute; cooldown P-WORKER-TIMEOUT-COOLDOWN; congestion signal; exhausted ⇒ RETRIES-EXHAUSTED |
 | rate-limit / overload verdict | honor backoff (worker's hint, default P-WORKER-BACKOFF); all candidates backing off longer than P-MAX-IDLE-TIME ⇒ OVERLOADED |
-| integrity failure (bad signature, wrong-range or undecodable result) | discard result, reroute (REQ-43); attempts exhausted on integrity failures ⇒ WORKER-FAILURE (pages — the network serves bad data or verification is broken) |
+| integrity failure (bad signature, wrong-range or undecodable result) | discard result, reroute (REQ-43); exhausted with *every* attempt an integrity failure ⇒ WORKER-FAILURE (pages — the network serves bad data or verification is broken); exhausted with any transient failure among the attempts ⇒ RETRIES-EXHAUSTED, since a later retry can still succeed and the class tells the client whether to come back. Equivocation stays operator-visible either way: it is counted per worker and alarmed regardless of the response class (OB-4/OB-9) |
 | no worker leasable for the chunk | DATA-UNAVAILABLE |
 
 *Degradation.* Per-worker penalties (ADR-004) — never a global circuit-break; the pool

--- a/spec/09-failure-model.md
+++ b/spec/09-failure-model.md
@@ -42,7 +42,7 @@ requests only; the publisher ⇒ freshness only; chain RPC ⇒ status only (REQ-
 | Erroring | mask via reroute + cooldown P-WORKER-ERROR-COOLDOWN |
 | Rate-limiting | mask via backoff honor; all-candidates-limited ⇒ fail-safe OVERLOADED |
 | Oversized response | fail-safe BAD-REQUEST (advise narrower query) |
-| Equivocating (bad signature / wrong-range data) | integrity: discard, reroute, count (REQ-43); never delivered; all attempts equivocating ⇒ fail-safe WORKER-FAILURE (pages) |
+| Equivocating (bad signature / wrong-range data) | integrity: discard, reroute, count (REQ-43); never delivered; all attempts equivocating ⇒ fail-safe WORKER-FAILURE (pages); equivocation mixed with transient failures ⇒ fail-safe RETRIES-EXHAUSTED, the equivocation still counted and alarmed (DC-1) |
 | Fork verdict (parent mismatch) | fail-safe CONFLICT (INV-23) |
 | All attempts exhausted transiently | fail-safe RETRIES-EXHAUSTED listing nothing sensitive; alarm-adjacent counter |
 

--- a/spec/13-conformance.md
+++ b/spec/13-conformance.md
@@ -1,14 +1,19 @@
 # 13 — Conformance & TDD plan
 
-**Mutable doc.** Statuses as of **2026-07-22** (0.11.9,
-`master@c9da0dd872fd28c1b9c5f598e9d8ff7e8d552b2d`). Statuses: **C** covered · **P** partial · **U**
+**Mutable doc.** Statuses as of **2026-07-25** (0.11.9,
+`master@15fcaeeea803b39e4985a7c91dada20203f411ef`). Statuses: **C** covered · **P** partial · **U**
 unchecked; *known-violated* / *known-suspect* where reality contradicts the property.
 The **Phase-0 harness exists** (`harness/` crate: IB-7 stubs with ledgers — including
 a real p2p worker stub on the pinned transport rev — toy world, reference model, the six
 validators, client driver, quiescence-gated gauge audit; CT-1 smoke green — GAP-14
 closed 2026-07-17). CT-1 exercises only success paths, so validators 1–5 run on every
-response and the 6th (error-envelope) is defined but not yet exercised. Coverage beyond
-the smoke is still inline unit tests; CT-2..CT-9 remain to be built per the build order.
+response and the 6th (error-envelope) is defined but not yet exercised.
+**CT-2 has started**: the worker stub is now a DC-1 fault injector (wrong-range both
+directions, bad signature, server-error and not-found verdicts) shared across workers so
+a fault lands wherever the portal routes, and `Fixture` boots the whole stub world for
+any class that needs it. `ct2_worker_faults` covers the worker-fault reroute rows and the
+exhaustion split; the rest of CT-2 and CT-3..CT-9 remain to be built per the build order.
+Coverage outside those two classes is still inline unit tests.
 
 ## Harness architecture
 
@@ -28,8 +33,10 @@ the smoke is still inline unit tests; CT-2..CT-9 remain to be built per the buil
 ```
 
 Stubs implement the input-side binding (IB-7) and are designed to double as **fault
-injectors** (delays, stalls, error verdicts, corrupt artifacts, reorgs, kill-mid-body);
-the Phase-0 stubs serve only the happy path — injector variants are built per each gap's
+injectors** (delays, stalls, error verdicts, corrupt artifacts, reorgs, kill-mid-body).
+The worker stub is the first one built out: faults are queued on a handle shared by every
+stub worker, so one queued fault lands on whichever worker the portal routes to and a
+test never depends on FV-1's choice. The remaining injectors are built per each gap's
 Next column (CT-2/CT-3). The scraper reads OP-8/OP-9 continuously; the comparator diffs responses against the
 reference model. **Quiescence** := no in-flight requests ∧ stub queues empty ∧ one
 P-HEARTBEAT-INTERVAL with no gauge movement. Gauge audits (INV-30, LIV-10) run only at
@@ -68,8 +75,9 @@ model(req, cfg, world) -> Response | ErrorClass:
 ```
 
 Chunk-failure sub-model: at most 1 + retries worker attempts per chunk (ledger-checked);
-transient exhaustion before the first record ⇒ RETRIES-EXHAUSTED, integrity exhaustion
-⇒ WORKER-FAILURE (DC-1), after the first record ⇒ truncation (FV-3).
+before the first record, exhaustion is RETRIES-EXHAUSTED unless *every* attempt was an
+integrity failure, which is WORKER-FAILURE (DC-1); after the first record ⇒ truncation
+(FV-3).
 
 **Free variables** — the only legitimate divergences from the model:
 
@@ -115,21 +123,21 @@ chunk-boundary records FV-6 licenses.
 6. Errors: type/code ∈ DEF-10; hint iff OVERLOADED — present on proxied overloads too,
    preserved or injected at the floor (ADR-014); no data alongside errors (INV-26).
 
-## Traceability matrix — properties (2026-07-22)
+## Traceability matrix — properties (2026-07-25)
 
 | Property | CT | Status | Note |
 |---|---|---|---|
 | INV-1, INV-2 | CT-3/2 | U | artifact-variant selection unit-tested only |
-| INV-3 | CT-3 | U | lease underflow guarded in debug builds only |
+| INV-3 | CT-3 | P | quiescent lease census asserted zero after every randomized scheduling case and after client disconnect (controller-level, mock network); CT-3 swarm still absent |
 | INV-4 | CT-1/3 | P | window grow/shrink/priority unit tests |
 | INV-5 | CT-3 | U | transient overshoot untested |
 | INV-10 | CT-4 | U | — |
 | INV-11 | CT-1 | U | clamping untested (GAP-8 adjacent) |
 | INV-12 | CT-3/6 | P | mapping unit-tested; cap never driven (GAP-4) |
 | INV-13 | CT-5 | P | resolver units; source marker asserted on both sources by the CT-1 smoke |
-| INV-20 | CT-1 | P | exactly-once regression + ordering units; CT-1 smoke oracle-diffs toy-world streams |
-| INV-21 | CT-1 | P | bounds validator green on smoke responses; no randomized worlds yet |
-| INV-22 | CT-1 | P | smoke diffs delivered records against the stub ledger (signed responses); rejection path untested |
+| INV-20 | CT-1 | P | exactly-once regression + ordering units; CT-1 smoke oracle-diffs toy-world streams; controller property test asserts gapless/monotonic/no-duplicate emission under randomized scheduling adversity |
+| INV-21 | CT-1/2 | P | bounds validator green on smoke responses; wrong-range worker responses are now rejected at the source seam and CT-2 proves they are never delivered; randomized worlds are controller-level only |
+| INV-22 | CT-1/2 | P | smoke diffs delivered records against the stub ledger (signed responses); CT-2 now drives the rejection path — wrong-range (both directions) and bad-signature responses are discarded, rerouted, and byte-identical output is delivered from another worker |
 | INV-23 | CT-2 | P | verdict parsing tested; flow untested; minimum 409 payload meets the invariant; richer ancestors remain a REQ-3 SHOULD shortfall (GAP-7); EMPTY-precedence at the head unverified (GAP-19) |
 | INV-24 | CT-5 | P | smoke asserts head markers against stub/artifact heads on success paths |
 | INV-25 | CT-2 | U | truncation never exercised |
@@ -140,23 +148,23 @@ chunk-boundary records FV-6 licenses.
 | INV-30 | CT-3/7 | U | gauge accounting was a past defect class |
 | INV-31 | CT-2 | P | shutdown flip e2e-tested; other conjuncts not; *known-violated* on staleness intent (GAP-2) |
 | INV-35 | CT-8 | U | — |
-| INV-36 | CT-4/9 | P | two crash regressions covered; latent panic (GAP-5) |
+| INV-36 | CT-4/9 | P | three crash regressions covered — the third, a worker reporting a last block past the queried range, panicked the stream task via an inverted continuation range; latent panic (GAP-5) |
 | INV-37 | CT-2 | U | — |
 | INV-40 | CT-2 | U | — |
 | LIV-1..LIV-4 | CT-1/2/6 | U | stall budget unmeasured |
 | LIV-5, LIV-6 | CT-2 | U | startup bound unmeasured (S5) |
-| LIV-7 | CT-2 | U | — |
+| LIV-7 | CT-2 | P | CT-2 waits for the pool to serve again between fault cases and after exhaustion; a latched penalty fails the run. Cooldown *durations* are unmeasured |
 | LIV-8 | CT-6 | P | regrowth unit-tested at scheduler level |
 | LIV-9 | CT-6 | U | — |
-| LIV-10 | CT-3 | U | cancellation-on-drop unit-approximated only |
+| LIV-10 | CT-3 | P | dropping a stream asserted to abort in-flight worker queries and return their leases; census slot and congestion permits are outside the controller and still unchecked |
 | LIV-11 | CT-2 | P | drain race + signal sequencing tested |
-| LIV-12 | CT-2 | U | *known-violated* for the artifact loop (log-only — GAP-2) |
+| LIV-12 | CT-2 | P | worker attempts bounded and exhaustion surfaced: CT-2 asserts integrity and transient exhaustion are distinguishable outcomes, not retry loops; *known-violated* for the artifact loop (log-only — GAP-2) |
 | FM-1 | CT-9 | P | see INV-36 |
-| FM-2 | CT-2 | P | the DC-4 replay classifier is unit-tested on both sides of the transient/integrity line (clean close, reset, the two non-replay exclusions — ADR-015); worker-side classification and every integrity path (corrupt artifact GAP-1, signature failure, contradictory data) are untested, and the integrity-exhaustion outcome is inside GAP-16 |
+| FM-2 | CT-2 | P | the DC-4 replay classifier is unit-tested on both sides of the transient/integrity line (clean close, reset, the two non-replay exclusions — ADR-015). Worker-side classification now exists and is CT-2-tested: wrong-range and bad-signature responses are integrity — discarded, rerouted, never delivered — and all-integrity exhaustion is a distinguishable outcome from transient exhaustion. Corrupt artifact (GAP-1) is still untested; the *taxonomy* of both exhaustion outcomes is inside GAP-16 |
 | FM-3 | CT-2/3 | U | per-dependency confinement never exercised: no outage tests (REQ-25), no isolation swarm (INV-35) |
 | SLI-1..SLI-6 | CT-6 | U | no benchmarks; baselines from incidents only |
 
-## Acceptance matrix — requirements (2026-07-22)
+## Acceptance matrix — requirements (2026-07-25)
 
 | REQ | Status | Note |
 |---|---|---|
@@ -175,7 +183,7 @@ chunk-boundary records FV-6 licenses.
 | REQ-14 | P | Internal-endpoint hiding tested |
 | REQ-15 | P | Plan extraction/rewrite units; no e2e |
 | REQ-20 | P | **Known-violated** — cap exhaustion is not exercised and current master misclassifies it (GAP-4); taxonomy target is GAP-16 |
-| REQ-21 | P | Two crash regressions; latent panic (GAP-5, INV-36) |
+| REQ-21 | P | Three crash regressions, the newest an inverted continuation range from an out-of-range worker response; latent panic (GAP-5, INV-36) |
 | REQ-22 | P | Real-time deadline units exist, including ADR-015's exclusion of read stalls from replay; **known-violated** because chain-RPC calls lack explicit deadlines (GAP-18), and because a replayed request can spend the read budget twice (ADR-015). The per-call bound is tested; a client request's total upstream spend is neither bounded nor tested |
 | REQ-23 | P | Shutdown flip tested; other conjuncts not; staleness unimplemented (GAP-2, INV-31); the container healthcheck probes a route that does not exist (GAP-10) |
 | REQ-24 | P | Drain race tested; in-flight behavior during drain untested (LIV-11); the P-KILL-GRACE conjunct is environmental — no in-process test can assert it |
@@ -187,12 +195,12 @@ chunk-boundary records FV-6 licenses.
 | REQ-32 | P | Internal hiding tested; drift (GAP-11) |
 | REQ-33 | C | Config warn/reject/defaults tested |
 | REQ-40 | P | Variant selection tested; effective-time & outage untested (INV-2, LIV-6); regression guard unimplemented (GAP-20) |
-| REQ-41 | U | Selection/penalties untested (LIV-7); FV-2 attempt bound ledger-checked by the smoke |
+| REQ-41 | P | FV-2 attempt bound ledger-checked by the smoke; CT-2 exercises reroute-on-failure and penalty decay (LIV-7). **Known-violated**: a generic worker server-error is classified terminal, so one erroring worker fails the request instead of rerouting (GAP-23). Cooldown durations and priority-group selection remain untested |
 | REQ-42 | P | Scheduler units; headroom refusal untested (INV-4, LIV-8), and its observable — shrink cause, download utilization, headroom-refusal counter (OB-7) — is unasserted |
-| REQ-43 | P | Positive path exercised by the smoke (signed stub responses verified and delivered); rejection path untested |
+| REQ-43 | P | Positive path exercised by the smoke (signed stub responses verified and delivered); CT-2 now drives the rejection path — a wrongly-signed response is not delivered and the attempt is retried elsewhere, meeting the acceptance criterion. Integrity failures are counted per worker but raise no OB-9 alarm state (GAP-24) |
 | REQ-44 | U | — |
 
-## Gap register — 2026-07-22
+## Gap register — 2026-07-25
 
 Priorities: P0 blocks the program · P1 active production risk · P2 correctness hole
 with plausible trigger · P3 polish. "Next" = cheapest failing-test-first entry.
@@ -218,9 +226,17 @@ with plausible trigger · P3 polish. "Next" = cheapest failing-test-first entry.
 | GAP-20 | No regression guard on artifact application: a republished older artifact (different identifier) would be re-applied | REQ-40, INV-2, DEF-4 (ADR-014) | P2 | CT-2: regressive publisher stub → assert not applied |
 | GAP-21 | Debug stream variant bypasses clamps without an operator gate | INV-11, REQ-8 (ADR-014; closed OQ-6) | P2 | config test: route absent unless the operator flag enables it |
 | GAP-22 | Pre-first-byte outcomes of the real-time source now have one denominator in `hotblocks_requests`, but no objective. `response` and `replay_response` obtained a response head; `replay_failed`, `timeout`, and `transport_failed` did not; cancellation remains visible without inventing an upstream result. SLI-4 is readiness availability and excludes deploys, SLI-6 counts truncated streams, and neither turns this counter into a request-success SLI | SLI set, OB-4 (ADR-015) | P2 | define a DC-4 response-head SLI over `hotblocks_requests`, with cancellations explicitly included or excluded by policy |
+| GAP-23 | A generic worker `ServerError` verdict is classified terminal, so the first erroring worker fails the whole request with no reroute — while `NotFound` and `ServerOverloaded` from the same worker *are* rerouted. DC-1 and the 09 worker table both put server errors in the reroute column. Found by the CT-2 injector on 2026-07-25; recorded as known-violated in `ct2_worker_faults` | REQ-41, DC-1, FM-3, LIV-12 | P1 | reclassify as retriable and drop the case from CT-2's known-violated list; the risk to weigh is added load on a fleet that is erroring |
+| GAP-24 | Integrity failures are counted per worker (`query_results{status="integrity"}`) but raise no alarm *state*: OB-9 lists signature-verification failures as an alarm, and FM-2 requires integrity faults to be "rejected and alarmed". A fleet quietly serving wrong-range data is visible only to someone already looking at the counter | OB-9, FM-2, REQ-43 | P2 | add the OB-9 alarm state over the integrity counter; assert the edge event in CT-2 |
 
 ### Closed findings
 
+- **Wrong-range worker responses** (closed 2026-07-25): a worker reporting a last block
+  past the queried range end produced an inverted continuation range and panicked the
+  stream task (a 500 for the client); one below the range start failed the whole stream
+  with no reroute. Both are now DC-1 integrity failures — discarded, counted, rerouted —
+  and CT-2 asserts the client cannot tell a single equivocating worker apart from a
+  healthy one. Building the CT-2 injector that proved it is what surfaced GAP-23.
 - **GAP-22, original claim** (closed 2026-07-21): the ADR-015 replay landed in the DC-4
   transport, with unit coverage for the clean close, the reset, the at-most-once bound,
   and the two non-replay exclusions (mid-body, read stall). Writing the reset case found
@@ -240,10 +256,12 @@ with plausible trigger · P3 polish. "Next" = cheapest failing-test-first entry.
 
 ## Build order
 
-- **Phase 1 — P1 gaps, failing tests first:** GAP-1/2/4/16/17 tests red → fixes;
-  GAP-3 probe + heap profile → refresh-copy fix.
-- **Phase 2 — correctness core:** full CT-1 oracle diffing; CT-2 fault matrix; CT-4
-  corpus; burn down P2 gaps.
+- **Phase 1 — P1 gaps, failing tests first:** GAP-1/2/4/16/17/23 tests red → fixes;
+  GAP-3 probe + heap profile → refresh-copy fix. GAP-23 already has its failing case
+  parked in `ct2_worker_faults`'s known-violated list.
+- **Phase 2 — correctness core:** full CT-1 oracle diffing; the rest of the CT-2 fault
+  matrix (DC-2/DC-3/DC-4 injectors, kill/restart) on the `Fixture` + worker-injector
+  scaffolding; CT-4 corpus; burn down P2 gaps.
 - **Phase 3 — robustness:** CT-3 swarms; CT-8 isolation; CT-9 fuzz; INV-30 audits.
 - **Phase 4 — performance regime:** CT-6 benchmarks S1–S6; ratify ⚠ SLO targets
   (OQ-3/OQ-4/OQ-9/OQ-10); commit baselines; CT-7 soak on a CI cadence.

--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -392,6 +392,17 @@ impl<N: StreamingNetwork> StreamController<N> {
                         ))));
                     }
                 };
+                let response = check_response_range(response, &data_range.range);
+                if let Err(QueryError::Integrity(reason)) = &response {
+                    tracing::warn!(
+                        "Discarding invalid response for range {}-{} from worker {}: {}",
+                        data_range.range.start(),
+                        data_range.range.end(),
+                        running.worker,
+                        reason,
+                    );
+                    self.network.report_integrity_failure(running.worker);
+                }
 
                 if retriable(&response) {
                     tracing::debug!(
@@ -448,18 +459,28 @@ impl<N: StreamingNetwork> StreamController<N> {
 
     fn all_attempts_failed(pending: &mut PendingRequests) -> RequestState {
         let mut errors = Vec::with_capacity(pending.requests.len());
+        let mut all_integrity = true;
         for request in pending.requests.drain(..) {
             let WorkerRequest::Finished(f) = request else {
                 unreachable!("all worker requests should be finished")
             };
+            let error = f.result.unwrap_err();
+            all_integrity &= matches!(error, QueryError::Integrity(_));
             // Format from the QueryError directly so every attempt is labeled with its
             // worker. Going through RequestError would drop the peer id for variants whose
             // Display is a fixed string (e.g. RateLimitExceeded, BaseBlockMismatch).
-            let error = format!("worker {}: {}", f.worker, f.result.unwrap_err());
-            errors.push(error);
+            errors.push(format!("worker {}: {}", f.worker, error));
         }
         let message = format!("All query attempts failed: {}", errors.join("; "));
-        RequestState::Done(Err(RequestError::InternalError(message)))
+        // Every attempt equivocating means the network is serving bad data or
+        // verification is broken — an operator problem, not a transient outage,
+        // so it pages rather than reporting the data temporarily unavailable
+        // (DC-1). A mix of transient and integrity failures stays transient.
+        RequestState::Done(Err(if all_integrity {
+            RequestError::Failure(message)
+        } else {
+            RequestError::InternalError(message)
+        }))
     }
 
     fn start_next_attempt(
@@ -1040,17 +1061,12 @@ fn parse_response(
     let state = if last_block == *range.end() {
         RequestState::Done(Ok(result.data))
     } else if last_block < *range.start() {
-        tracing::warn!(
-            "Got empty response for range {}-{} from worker {}",
+        // Unreachable: `check_response_range` rejects this before the response
+        // gets here. Kept because falling through would emit blocks below the
+        // requested start (INV-21) instead of failing.
+        RequestState::Done(Err(RequestError::Failure(format!(
+            "worker {worker} returned last block {last_block} below the first queried block {}",
             range.start(),
-            range.end(),
-            worker,
-        );
-        RequestState::Done(Err(RequestError::InternalError(format!(
-            "the last returned block is {} which is below the first queried block {} from {}",
-            last_block,
-            range.start(),
-            worker,
         ))))
     } else {
         RequestState::Partial(PartialResult {
@@ -1073,11 +1089,37 @@ fn parse_response(
     state
 }
 
+/// A misbehaving worker may report a `last_block` outside the range it was
+/// asked for, in either direction. The data is an opaque compressed blob, so it
+/// can't be trimmed to the range without decompressing and re-encoding it — and
+/// the continuation range derived from such a `last_block` is inverted (past the
+/// end) or re-covers blocks the client already has (below the start). Reject the
+/// whole response as an integrity failure: it is discarded, never delivered, and
+/// the next reserved worker serves the range (DC-1).
+fn check_response_range(response: QueryResult, range: &BlockRange) -> QueryResult {
+    let Ok(success) = &response else {
+        return response;
+    };
+    let last_block = success.ok.last_block;
+    let bound = if last_block > *range.end() {
+        format!("beyond the queried range end {}", range.end())
+    } else if last_block < *range.start() {
+        format!("below the first queried block {}", range.start())
+    } else {
+        return response;
+    };
+    Err(QueryError::Integrity(format!(
+        "worker returned last block {last_block} {bound}"
+    )))
+}
+
 fn retriable(result: &QueryResult) -> bool {
     match result {
         Ok(_) => false,
         Err(QueryError::BadRequest(_)) => false,
         Err(QueryError::Retriable(_)) => true,
+        // Rerouted like a transient failure; only the exhaustion class differs.
+        Err(QueryError::Integrity(_)) => true,
         Err(QueryError::Failure(_)) => false,
         Err(QueryError::RateLimitExceeded) => true,
         Err(QueryError::BaseBlockMismatch(_)) => false,
@@ -1285,6 +1327,8 @@ mod tests {
                 })
             })
         }
+
+        fn report_integrity_failure(&self, _worker: PeerId) {}
     }
 
     fn stream_request() -> StreamRequest {
@@ -1343,6 +1387,800 @@ mod tests {
             network.queries_sent.load(Ordering::SeqCst),
             1,
             "the chunk must be queried exactly once",
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Property-based tests: random scheduling adversity (worker backoffs,
+    // partial responses, retriable failures) must never break the stream's
+    // core invariants.
+    // ------------------------------------------------------------------
+
+    use std::collections::HashMap;
+    use std::sync::atomic::AtomicI64;
+    use std::sync::Mutex as StdMutex;
+
+    use proptest::prelude::*;
+
+    use crate::network::TestLeasePool;
+
+    /// Scripted outcome of one `find_worker` call.
+    #[derive(Debug, Clone)]
+    enum FindWorkerEvent {
+        Lease,
+        /// Expires while the stream is still allowed to wait (< MAX_IDLE_TIME).
+        ShortBackoff(u64),
+        /// Longer than MAX_IDLE_TIME: the stream gives up with `BusyFor`.
+        LongBackoff,
+        /// No workers at all: the stream gives up with `Unavailable`.
+        Unavailable,
+    }
+
+    /// Scripted outcome of one worker query.
+    #[derive(Debug, Clone)]
+    enum QueryEvent {
+        Full,
+        /// Serve only this percentage of the queried range, forcing a
+        /// continuation request for the remainder.
+        Partial(u8),
+        /// Misbehave: report this many blocks beyond the queried range end.
+        Overshoot(u64),
+        /// Misbehave in the other direction: report this many blocks below the
+        /// queried range start.
+        Undershoot(u64),
+        /// Serve the full range, but only after `ms` of (virtual) time. When
+        /// this exceeds the request timeout the controller fires a speculative
+        /// (hedged) query to another reserved worker while this one is still in
+        /// flight — the only way to drive the `is_speculative` path, since every
+        /// other event resolves instantly under the paused clock.
+        Slow(u64),
+        Retriable,
+        /// Never respond. Only used by the cancellation test; including it in
+        /// the random generator would (correctly) fail the liveness property,
+        /// because a slot whose every attempt hangs waits forever — in
+        /// production the transport read timeout, modeled here as `Retriable`,
+        /// breaks that wait.
+        Hang,
+    }
+
+    /// Decrements the live-query counter when the query future is dropped,
+    /// whether it completed or was aborted.
+    struct LiveQueryGuard(Arc<AtomicI64>);
+
+    impl LiveQueryGuard {
+        fn new(counter: &Arc<AtomicI64>) -> Self {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Self(counter.clone())
+        }
+    }
+
+    impl Drop for LiveQueryGuard {
+        fn drop(&mut self) {
+            self.0.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    /// A network where every `find_worker` / `query_worker` call consumes the
+    /// next scripted event; exhausted scripts default to success.
+    struct ScriptedNetwork {
+        chunks: Vec<DataChunk>,
+        lease_pool: TestLeasePool,
+        find_worker_script: StdMutex<VecDeque<FindWorkerEvent>>,
+        query_script: StdMutex<VecDeque<QueryEvent>>,
+        /// `(request_id, range)` of every in-range successful worker
+        /// execution (rejected overshoots don't count: their data is never
+        /// delivered, so re-executing their range is legal).
+        ok_ranges: StdMutex<Vec<(String, (u64, u64))>>,
+        /// Query futures currently alive (running or queued, not yet
+        /// completed nor aborted).
+        live_queries: Arc<AtomicI64>,
+        /// Workers the controller reported as returning contract-violating data.
+        integrity_failures: StdMutex<Vec<PeerId>>,
+    }
+
+    impl ScriptedNetwork {
+        fn new(
+            chunks: Vec<DataChunk>,
+            find_worker_script: Vec<FindWorkerEvent>,
+            query_script: Vec<QueryEvent>,
+        ) -> Arc<Self> {
+            Arc::new(Self {
+                chunks,
+                lease_pool: TestLeasePool::new(),
+                find_worker_script: StdMutex::new(find_worker_script.into()),
+                query_script: StdMutex::new(query_script.into()),
+                ok_ranges: StdMutex::new(Vec::new()),
+                live_queries: Arc::new(AtomicI64::new(0)),
+                integrity_failures: StdMutex::new(Vec::new()),
+            })
+        }
+    }
+
+    impl StreamingNetwork for ScriptedNetwork {
+        fn find_chunk(&self, _dataset: &DatasetId, block: u64) -> Result<DataChunk, ChunkNotFound> {
+            if block < *self.chunks[0].block_range().start() {
+                return Err(ChunkNotFound::BeforeFirst {
+                    first_block: *self.chunks[0].block_range().start(),
+                });
+            }
+            self.chunks
+                .iter()
+                .find(|c| c.block_range().contains(&block))
+                .cloned()
+                .ok_or(ChunkNotFound::AfterLast)
+        }
+
+        fn next_chunk(&self, _dataset: &DatasetId, chunk: &DataChunk) -> Option<DataChunk> {
+            let pos = self.chunks.iter().position(|c| c == chunk)?;
+            self.chunks.get(pos + 1).cloned()
+        }
+
+        fn find_worker(&self, _dataset: &DatasetId, _block: u64) -> Result<WorkerLease, NoWorker> {
+            let event = self
+                .find_worker_script
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or(FindWorkerEvent::Lease);
+            match event {
+                FindWorkerEvent::Lease => Ok(self.lease_pool.lease(PeerId::random())),
+                FindWorkerEvent::ShortBackoff(ms) => Err(NoWorker::Backoff(
+                    Instant::now() + Duration::from_millis(ms),
+                )),
+                FindWorkerEvent::LongBackoff => Err(NoWorker::Backoff(
+                    // Strictly past MAX_IDLE_TIME so the stream always gives up
+                    // with `BusyFor`, however that threshold is tuned.
+                    Instant::now() + MAX_IDLE_TIME + Duration::from_secs(1),
+                )),
+                FindWorkerEvent::Unavailable => Err(NoWorker::AllUnavailable),
+            }
+        }
+
+        fn query_worker(
+            self: Arc<Self>,
+            _lease: WorkerLease,
+            request_id: String,
+            _chunk_id: ChunkId,
+            block_range: BlockRange,
+            _query: String,
+            _compression: Compression,
+            _priority: Option<u32>,
+        ) -> BoxFuture<'static, QueryResult> {
+            let event = self
+                .query_script
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or(QueryEvent::Full);
+            let guard = LiveQueryGuard::new(&self.live_queries);
+            Box::pin(async move {
+                let _guard = guard;
+                let (start, end) = (*block_range.start(), *block_range.end());
+                let last = match event {
+                    QueryEvent::Hang => {
+                        futures::future::pending::<()>().await;
+                        unreachable!("pending future never resolves")
+                    }
+                    QueryEvent::Retriable => {
+                        return Err(QueryError::Retriable("scripted failure".to_owned()))
+                    }
+                    QueryEvent::Full => end,
+                    QueryEvent::Slow(ms) => {
+                        tokio::time::sleep(Duration::from_millis(ms)).await;
+                        end
+                    }
+                    QueryEvent::Overshoot(extra) => end + extra,
+                    QueryEvent::Undershoot(below) => start.saturating_sub(below.max(1)),
+                    QueryEvent::Partial(_) if start == end => end,
+                    QueryEvent::Partial(pct) => start + (end - start) * (pct as u64) / 100,
+                };
+                if (start..=end).contains(&last) {
+                    self.ok_ranges
+                        .lock()
+                        .unwrap()
+                        .push((request_id, (start, last)));
+                }
+                Ok(QuerySuccess {
+                    ok: sqd_messages::QueryOk {
+                        data: format!("{start}:{last}").into_bytes(),
+                        last_block: last,
+                    },
+                    ttfb: Duration::from_millis(1),
+                    transfer_time: Duration::from_millis(1),
+                    response_size: 10,
+                })
+            })
+        }
+
+        fn report_integrity_failure(&self, worker: PeerId) {
+            self.integrity_failures.lock().unwrap().push(worker);
+        }
+    }
+
+    /// The block range requested by one of the concurrent streams.
+    #[derive(Debug, Clone)]
+    struct StreamSpec {
+        from: u64,
+        to: u64,
+    }
+
+    #[derive(Debug, Clone)]
+    struct Scenario {
+        n_chunks: usize,
+        streams: Vec<StreamSpec>,
+        find_worker_script: Vec<FindWorkerEvent>,
+        query_script: Vec<QueryEvent>,
+        buffer_size: usize,
+        retries: u8,
+        max_stored_results_per_chunk: usize,
+        max_chunks: Option<usize>,
+    }
+
+    impl Scenario {
+        const CHUNK_SIZE: u64 = 100;
+        const FIRST_BLOCK: u64 = 100;
+
+        fn dataset_last_block(&self) -> u64 {
+            Self::FIRST_BLOCK + (self.n_chunks as u64) * Self::CHUNK_SIZE - 1
+        }
+
+        /// The last block a cleanly completed stream is expected to serve:
+        /// the requested end, capped by the dataset end and by `max_chunks`.
+        fn expected_end(&self, spec: &StreamSpec) -> u64 {
+            let mut end = spec.to.min(self.dataset_last_block());
+            if let Some(limit) = self.max_chunks {
+                let first_chunk = (spec.from - Self::FIRST_BLOCK) / Self::CHUNK_SIZE;
+                let limit_end =
+                    Self::FIRST_BLOCK + (first_chunk + limit as u64) * Self::CHUNK_SIZE - 1;
+                end = end.min(limit_end);
+            }
+            end
+        }
+
+        fn build_chunks(&self) -> Vec<DataChunk> {
+            (0..self.n_chunks)
+                .map(|i| {
+                    let first = Self::FIRST_BLOCK + (i as u64) * Self::CHUNK_SIZE;
+                    let last = first + Self::CHUNK_SIZE - 1;
+                    DataChunk::from_str(&format!("{first:010}/{first:010}-{last:010}-abcde"))
+                        .unwrap()
+                })
+                .collect()
+        }
+
+        fn request(&self, spec: &StreamSpec, stream_index: usize) -> StreamRequest {
+            let query_json = format!(
+                r#"{{
+                    "type": "evm",
+                    "fromBlock": {},
+                    "toBlock": {},
+                    "fields": {{"block": {{"number": true}}}},
+                    "includeAllBlocks": true
+                }}"#,
+                spec.from, spec.to
+            );
+            StreamRequest {
+                dataset_id: DatasetId::from_url("test-dataset"),
+                dataset_name: "test-dataset".to_owned(),
+                query: ParsedQuery::try_from(query_json).unwrap(),
+                request_id: format!("stream-{stream_index}"),
+                buffer_size: self.buffer_size,
+                max_stored_results_per_chunk: self.max_stored_results_per_chunk,
+                max_chunks: self.max_chunks,
+                timeout_quantile: 0.5,
+                retries: self.retries,
+                compression: Compression::Gzip,
+                skip_parent_hash_validation: false,
+            }
+        }
+    }
+
+    fn scenario_strategy() -> impl Strategy<Value = Scenario> {
+        let find_worker_event = prop_oneof![
+            3 => Just(FindWorkerEvent::Lease),
+            3 => (10u64..=300).prop_map(FindWorkerEvent::ShortBackoff),
+            1 => Just(FindWorkerEvent::LongBackoff),
+            1 => Just(FindWorkerEvent::Unavailable),
+        ];
+        let query_event = prop_oneof![
+            4 => Just(QueryEvent::Full),
+            2 => (10u8..=90).prop_map(QueryEvent::Partial),
+            2 => (200u64..=2500).prop_map(QueryEvent::Slow),
+            1 => (1u64..=20).prop_map(QueryEvent::Overshoot),
+            1 => (1u64..=20).prop_map(QueryEvent::Undershoot),
+            1 => Just(QueryEvent::Retriable),
+        ];
+        (1usize..=4)
+            .prop_flat_map(move |n_chunks| {
+                let total_blocks = (n_chunks as u64) * Scenario::CHUNK_SIZE;
+                (
+                    Just(n_chunks),
+                    prop::collection::vec((0..total_blocks, 0u64..300), 1..=3),
+                    prop::collection::vec(find_worker_event.clone(), 0..6),
+                    prop::collection::vec(query_event.clone(), 0..10),
+                    1usize..=10,
+                    0u8..=2,
+                    1usize..=4,
+                    prop::option::of(1usize..=4),
+                )
+            })
+            .prop_map(
+                |(n_chunks, streams, fw, q, buffer_size, retries, max_stored, max_chunks)| {
+                    Scenario {
+                        n_chunks,
+                        streams: streams
+                            .into_iter()
+                            .map(|(offset, span)| StreamSpec {
+                                from: Scenario::FIRST_BLOCK + offset,
+                                to: Scenario::FIRST_BLOCK + offset + span,
+                            })
+                            .collect(),
+                        find_worker_script: fw,
+                        query_script: q,
+                        buffer_size,
+                        retries,
+                        max_stored_results_per_chunk: max_stored,
+                        max_chunks,
+                    }
+                },
+            )
+    }
+
+    struct StreamOutcome {
+        /// (first_block, last_block) of every response chunk, in emission order.
+        emissions: Vec<(u64, u64)>,
+        error: Option<String>,
+    }
+
+    struct ScenarioOutcome {
+        streams: Vec<StreamOutcome>,
+        timed_out: bool,
+        ok_ranges: Vec<(String, (u64, u64))>,
+        leases_outstanding: usize,
+    }
+
+    async fn collect_stream<N: StreamingNetwork>(
+        request: StreamRequest,
+        network: Arc<N>,
+        stream_index: u32,
+    ) -> StreamOutcome {
+        let mut controller = StreamController::new(request, network, stream_index, 1).unwrap();
+        let mut emissions = Vec::new();
+        let mut error = None;
+        while let Some(item) = controller.next().await {
+            match item {
+                Ok(bytes) => {
+                    let text = String::from_utf8(bytes).unwrap();
+                    let (start, last) = text.split_once(':').unwrap();
+                    emissions.push((start.parse().unwrap(), last.parse().unwrap()));
+                }
+                Err(e) => {
+                    error = Some(e.to_string());
+                    break;
+                }
+            }
+        }
+        StreamOutcome { emissions, error }
+    }
+
+    fn run_scenario(scenario: &Scenario) -> ScenarioOutcome {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .start_paused(true)
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let network = ScriptedNetwork::new(
+                scenario.build_chunks(),
+                scenario.find_worker_script.clone(),
+                scenario.query_script.clone(),
+            );
+
+            let collect_all =
+                futures::future::join_all(scenario.streams.iter().enumerate().map(|(i, spec)| {
+                    collect_stream(scenario.request(spec, i), network.clone(), i as u32)
+                }));
+
+            // Virtual-time deadline: liveness. A stream stuck without timers
+            // would otherwise hang the auto-advancing paused clock forever.
+            match tokio::time::timeout(Duration::from_secs(3600), collect_all).await {
+                Ok(streams) => {
+                    // The controllers are dropped; give the runtime a few
+                    // turns to process the aborted query tasks so their
+                    // leases get returned.
+                    for _ in 0..8 {
+                        tokio::task::yield_now().await;
+                    }
+                    ScenarioOutcome {
+                        streams,
+                        timed_out: false,
+                        ok_ranges: network.ok_ranges.lock().unwrap().clone(),
+                        leases_outstanding: network.lease_pool.outstanding(),
+                    }
+                }
+                Err(_) => ScenarioOutcome {
+                    streams: Vec::new(),
+                    timed_out: true,
+                    ok_ranges: network.ok_ranges.lock().unwrap().clone(),
+                    leases_outstanding: network.lease_pool.outstanding(),
+                },
+            }
+        })
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 128, ..ProptestConfig::default() })]
+
+        /// Whatever adversity the network throws at the controller(s) —
+        /// backoffs, unavailability, partial / out-of-range / slow / failing
+        /// worker responses, chunk limits, several streams sharing the network
+        /// — every stream must emit a gapless, strictly increasing prefix of
+        /// its requested range, fully covering it on clean completion;
+        /// redundant successful execution of a range (via hedging) stays
+        /// bounded by the reserved fan-out; and no worker lease may leak.
+        #[test]
+        fn stream_invariants_hold_under_scheduling_adversity(scenario in scenario_strategy()) {
+            let outcome = run_scenario(&scenario);
+
+            // Liveness: every stream terminates (with data or an error).
+            prop_assert!(!outcome.timed_out, "streams did not terminate");
+
+            for (i, (spec, stream)) in scenario.streams.iter().zip(&outcome.streams).enumerate() {
+                // No duplicates, monotonically increasing, no gaps: each
+                // emission continues exactly where the previous one ended.
+                let mut expected_next = spec.from;
+                let bound = scenario.expected_end(spec);
+                for &(start, last) in &stream.emissions {
+                    prop_assert_eq!(
+                        start,
+                        expected_next,
+                        "stream {} emission must continue the stream exactly (emissions: {:?})",
+                        i,
+                        &stream.emissions
+                    );
+                    prop_assert!(last >= start, "emission range must not be inverted");
+                    // Bounds respect, asserted on the error path too: a stream
+                    // that overshoots and *then* fails would satisfy the
+                    // completeness check below vacuously.
+                    prop_assert!(
+                        last <= bound,
+                        "stream {} emitted block {} past its bound {} (emissions: {:?})",
+                        i,
+                        last,
+                        bound,
+                        &stream.emissions
+                    );
+                    expected_next = last + 1;
+                }
+
+                // Completeness: a stream that ended without an error must
+                // have served the whole requested range (capped by the
+                // dataset end and the max_chunks limit).
+                //
+                // Note what this cannot see: truncation is a legal outcome
+                // (ADR-001), so a controller that gives up while it still had
+                // reserved attempts left satisfies every assertion here. That
+                // property is carried by the deterministic skip-and-retry tests
+                // and by the CT-2 worker-fault matrix in `harness/`.
+                if stream.error.is_none() {
+                    prop_assert_eq!(
+                        expected_next,
+                        bound + 1,
+                        "stream {} clean completion must cover the full range (emissions: {:?})",
+                        i,
+                        &stream.emissions
+                    );
+                }
+            }
+
+            // Bounded redundant execution. Hedging sends the *same* range to
+            // more than one healthy worker at once (a speculative query races
+            // an in-flight one — it is not a retry of a *failed* attempt), so a
+            // range legitimately can be executed successfully more than once.
+            // What must hold is that this redundancy stays bounded by the
+            // reserved fan-out (`retries + 1`) and never runs away: the stream
+            // reserves at most that many workers per range and enters the
+            // query-sending phase for a range at most once. Single *delivery*
+            // to the client is guaranteed separately by the no-duplicate /
+            // gapless emission invariant above — the losing hedged responses
+            // are discarded, never emitted.
+            let max_executions = scenario.retries as usize + 1;
+            let mut ok_count = HashMap::new();
+            for executed in &outcome.ok_ranges {
+                *ok_count.entry(executed).or_insert(0usize) += 1;
+            }
+            for (executed, count) in ok_count {
+                prop_assert!(
+                    count <= max_executions,
+                    "{:?} was successfully executed {} times, over the hedging \
+                     fan-out of {} (all: {:?})",
+                    executed,
+                    count,
+                    max_executions,
+                    &outcome.ok_ranges
+                );
+            }
+
+            // No lease leaks: every worker slot taken is eventually returned.
+            prop_assert_eq!(
+                outcome.leases_outstanding,
+                0,
+                "worker leases leaked after all streams finished"
+            );
+        }
+    }
+
+    /// A wrong-range worker response — in either direction — must be rejected
+    /// as an integrity failure: discarded and rerouted, not trusted, and not
+    /// fatal to the stream on its own.
+    #[test]
+    fn wrong_range_response_is_rejected_as_integrity_failure() {
+        let success = |last_block| {
+            Ok(QuerySuccess {
+                ok: sqd_messages::QueryOk {
+                    data: b"data".to_vec(),
+                    last_block,
+                },
+                ttfb: Duration::from_millis(1),
+                transfer_time: Duration::from_millis(1),
+                response_size: 4,
+            })
+        };
+        let range = BlockRange::new(100, 150);
+
+        for (last_block, case) in [(151, "overshoot"), (99, "undershoot")] {
+            let rejected = check_response_range(success(last_block), &range);
+            assert!(
+                matches!(rejected, Err(QueryError::Integrity(_))),
+                "{case} must become an integrity error"
+            );
+            assert!(retriable(&rejected), "{case} must be rerouted");
+        }
+
+        for last_block in [100, 125, 150] {
+            assert!(
+                check_response_range(success(last_block), &range).is_ok(),
+                "in-range response {last_block} must pass through"
+            );
+        }
+    }
+
+    /// Exhaustion class: transient failures report the data as temporarily
+    /// unavailable, but attempts that all equivocate page instead (DC-1).
+    #[tokio::test(start_paused = true)]
+    async fn all_attempts_equivocating_pages_instead_of_reporting_an_outage() {
+        let scenario = |query_script: Vec<QueryEvent>| Scenario {
+            n_chunks: 1,
+            streams: vec![StreamSpec { from: 100, to: 150 }],
+            find_worker_script: Vec::new(),
+            query_script,
+            buffer_size: 10,
+            retries: 1,
+            max_stored_results_per_chunk: 1,
+            max_chunks: None,
+        };
+
+        // Both reserved workers overshoot: integrity exhaustion.
+        let all_bad = scenario(vec![QueryEvent::Overshoot(5), QueryEvent::Undershoot(5)]);
+        let network = ScriptedNetwork::new(
+            all_bad.build_chunks(),
+            Vec::new(),
+            all_bad.query_script.clone(),
+        );
+        let outcome =
+            collect_stream(all_bad.request(&all_bad.streams[0], 0), network.clone(), 0).await;
+        assert!(
+            outcome.emissions.is_empty(),
+            "equivocated data must never be delivered"
+        );
+        assert_eq!(
+            network.integrity_failures.lock().unwrap().len(),
+            2,
+            "every discarded response must be counted against its worker"
+        );
+
+        // One transient failure in the mix keeps the outcome transient.
+        let mixed = scenario(vec![QueryEvent::Retriable, QueryEvent::Overshoot(5)]);
+        let network =
+            ScriptedNetwork::new(mixed.build_chunks(), Vec::new(), mixed.query_script.clone());
+        let mixed_outcome =
+            collect_stream(mixed.request(&mixed.streams[0], 0), network.clone(), 0).await;
+        assert!(mixed_outcome.emissions.is_empty());
+        assert_ne!(
+            outcome.error, mixed_outcome.error,
+            "integrity exhaustion must not be reported as a transient outage"
+        );
+    }
+
+    /// The undershoot half of the wrong-range contract: a worker reporting a
+    /// last block below the queried start used to fail the whole stream.
+    #[tokio::test(start_paused = true)]
+    async fn undershooting_worker_response_is_skipped_and_retried() {
+        let scenario = Scenario {
+            n_chunks: 1,
+            streams: vec![StreamSpec { from: 100, to: 150 }],
+            find_worker_script: Vec::new(),
+            query_script: vec![QueryEvent::Undershoot(10)],
+            buffer_size: 10,
+            retries: 1,
+            max_stored_results_per_chunk: 1,
+            max_chunks: None,
+        };
+        let network = ScriptedNetwork::new(
+            scenario.build_chunks(),
+            Vec::new(),
+            scenario.query_script.clone(),
+        );
+
+        let outcome = collect_stream(
+            scenario.request(&scenario.streams[0], 0),
+            network.clone(),
+            0,
+        )
+        .await;
+
+        assert_eq!(
+            outcome.error, None,
+            "one bad worker must not fail the stream"
+        );
+        assert_eq!(
+            outcome.emissions,
+            vec![(100, 150)],
+            "the range must be served exactly once by the retry"
+        );
+        assert_eq!(
+            network.integrity_failures.lock().unwrap().len(),
+            1,
+            "the equivocating worker must be penalized"
+        );
+    }
+
+    /// A single misbehaving worker must not fail the stream: its response is
+    /// skipped and the range is served by the next reserved worker.
+    #[tokio::test(start_paused = true)]
+    async fn overshooting_worker_response_is_skipped_and_retried() {
+        let scenario = Scenario {
+            n_chunks: 1,
+            streams: vec![StreamSpec { from: 100, to: 150 }],
+            find_worker_script: Vec::new(),
+            query_script: vec![QueryEvent::Overshoot(10)],
+            buffer_size: 10,
+            retries: 1,
+            max_stored_results_per_chunk: 1,
+            max_chunks: None,
+        };
+        let network = ScriptedNetwork::new(
+            scenario.build_chunks(),
+            Vec::new(),
+            scenario.query_script.clone(),
+        );
+
+        let outcome = collect_stream(
+            scenario.request(&scenario.streams[0], 0),
+            network.clone(),
+            0,
+        )
+        .await;
+
+        assert_eq!(
+            outcome.error, None,
+            "one bad worker must not fail the stream"
+        );
+        assert_eq!(
+            outcome.emissions,
+            vec![(100, 150)],
+            "the range must be served exactly once by the retry"
+        );
+    }
+
+    /// Hedging (speculative queries) sends the *same* range to more than one
+    /// healthy worker at once, so a range can be executed successfully more
+    /// than once — that is by design, not a bug. What the stream must still
+    /// guarantee is that the client is *delivered* the range exactly once; the
+    /// losing hedged response is discarded, never emitted.
+    ///
+    /// Two workers are scripted to finish the same range at the same virtual
+    /// instant: the first (non-speculative) query lasts 1500ms, longer than
+    /// the 1000ms request timeout, so at t=1000 a speculative query is sent to
+    /// the second reserved worker; sleeping 500ms, it also completes at t=1500.
+    /// Both record an in-range success, so the range is executed twice.
+    #[test]
+    fn hedged_query_executes_twice_but_is_delivered_once() {
+        let scenario = Scenario {
+            n_chunks: 1,
+            streams: vec![StreamSpec { from: 100, to: 199 }],
+            find_worker_script: Vec::new(),
+            query_script: vec![QueryEvent::Slow(1500), QueryEvent::Slow(500)],
+            buffer_size: 1,
+            retries: 1,
+            max_stored_results_per_chunk: 1,
+            max_chunks: None,
+        };
+
+        let outcome = run_scenario(&scenario);
+
+        assert!(!outcome.timed_out, "stream must terminate");
+
+        // The range was genuinely executed by *both* healthy workers.
+        let executions = outcome
+            .ok_ranges
+            .iter()
+            .filter(|entry| entry.0 == "stream-0" && entry.1 == (100, 199))
+            .count();
+        assert_eq!(
+            executions, 2,
+            "hedging should have executed the range on both workers (all: {:?})",
+            outcome.ok_ranges
+        );
+
+        // Yet the client sees it exactly once, gapless and complete.
+        assert_eq!(
+            outcome.streams[0].error, None,
+            "hedging must not fail the stream"
+        );
+        assert_eq!(
+            outcome.streams[0].emissions,
+            vec![(100, 199)],
+            "the hedged range must be delivered exactly once"
+        );
+
+        // The aborted loser still returns its lease.
+        assert_eq!(outcome.leases_outstanding, 0, "worker leases leaked");
+    }
+
+    /// Dropping the stream (client disconnect) must abort the in-flight
+    /// worker queries and return their leases.
+    #[tokio::test(start_paused = true)]
+    async fn dropping_the_stream_aborts_in_flight_queries() {
+        let scenario = Scenario {
+            n_chunks: 2,
+            streams: vec![StreamSpec { from: 100, to: 299 }],
+            find_worker_script: Vec::new(),
+            query_script: vec![QueryEvent::Hang; 8],
+            buffer_size: 4,
+            retries: 1,
+            max_stored_results_per_chunk: 1,
+            max_chunks: None,
+        };
+        let network = ScriptedNetwork::new(
+            scenario.build_chunks(),
+            Vec::new(),
+            vec![QueryEvent::Hang; 8],
+        );
+        let mut controller = StreamController::new(
+            scenario.request(&scenario.streams[0], 0),
+            network.clone(),
+            0,
+            1,
+        )
+        .unwrap();
+
+        // One poll is enough to schedule the chunk queries; they all hang.
+        futures::future::poll_fn(|ctx| {
+            let _ = Pin::new(&mut controller).poll_next(ctx);
+            Poll::Ready(())
+        })
+        .await;
+        assert!(
+            network.live_queries.load(Ordering::SeqCst) > 0,
+            "queries should be in flight"
+        );
+
+        drop(controller);
+        // Aborts are processed by the runtime; give it a few turns.
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+
+        assert_eq!(
+            network.live_queries.load(Ordering::SeqCst),
+            0,
+            "dropping the stream must abort all in-flight worker queries"
+        );
+        assert_eq!(
+            network.lease_pool.outstanding(),
+            0,
+            "all worker leases must be returned"
         );
     }
 }

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -59,6 +59,11 @@ pub trait StreamingNetwork: Send + Sync + 'static {
         compression: Compression,
         priority: Option<u32>,
     ) -> futures::future::BoxFuture<'static, QueryResult>;
+
+    /// A response the controller rejected as contract-violating. The transport
+    /// can't catch these — only the caller knows the range it asked for — so the
+    /// penalty and the OB-4 counter are raised from here instead.
+    fn report_integrity_failure(&self, worker: PeerId);
 }
 
 impl StreamingNetwork for NetworkClient {
@@ -94,6 +99,11 @@ impl StreamingNetwork for NetworkClient {
             compression,
             priority,
         ))
+    }
+
+    fn report_integrity_failure(&self, worker: PeerId) {
+        metrics::report_query_result(&worker, "integrity");
+        self.network_state.report_query_error(worker);
     }
 }
 
@@ -763,9 +773,9 @@ impl NetworkClient {
                 QueryError::Failure(format!("portal tried to send invalid request: {e}"))
             }
             QueryFailure::InvalidResponse(e) => {
-                metrics::report_query_result(&peer_id, "invalid");
+                metrics::report_query_result(&peer_id, "integrity");
                 self.network_state.report_query_error(peer_id);
-                QueryError::Retriable(format!("couldn't decode response: {e}"))
+                QueryError::Integrity(format!("couldn't decode response: {e}"))
             }
             QueryFailure::Timeout(t) => {
                 metrics::report_query_result(&peer_id, "timeout");
@@ -805,9 +815,9 @@ impl NetworkClient {
 
         match result {
             Ok(q) if self.verify_responses && !verify_signature(&q, peer_id).await => {
-                metrics::report_query_result(&peer_id, "validation_error");
+                metrics::report_query_result(&peer_id, "integrity");
                 self.network_state.report_query_failure(peer_id);
-                Err(QueryError::Retriable(format!(
+                Err(QueryError::Integrity(format!(
                     "invalid worker signature from {peer_id}, result: {q:?}"
                 )))
             }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -10,5 +10,7 @@ pub use client::{
 };
 pub use contracts_state::Status;
 pub use priorities::{NoWorker, PrioritiesConfig, Priority};
+#[cfg(test)]
+pub(crate) use state::TestLeasePool;
 pub use state::{NetworkState, WorkerLease};
 pub use storage::{ChunkNotFound, StorageClient};

--- a/src/network/priorities.rs
+++ b/src/network/priorities.rs
@@ -149,6 +149,15 @@ impl WorkersPool {
         });
     }
 
+    /// The total number of currently leased query slots across all workers.
+    #[cfg(test)]
+    pub(crate) fn running_queries_total(&self) -> usize {
+        self.workers
+            .values()
+            .map(|stats| stats.running_queries as usize)
+            .sum()
+    }
+
     pub fn success(&mut self, worker: PeerId, throughput: Option<f64>) {
         self.modify(worker, |stats| {
             if let Some(t) = throughput {

--- a/src/network/state.rs
+++ b/src/network/state.rs
@@ -27,12 +27,40 @@ impl WorkerLease {
     /// mock the network without a full [`NetworkState`].
     #[cfg(test)]
     pub(crate) fn for_tests(worker: PeerId) -> Self {
-        let pool = Arc::new(RwLock::new(
-            WorkersPool::new(PrioritiesConfig::default()),
-            "WorkerLease::for_tests pool",
-        ));
-        pool.write().lease(worker);
-        Self { pool, worker }
+        TestLeasePool::new().lease(worker)
+    }
+}
+
+/// A shared lease pool for tests that mock the network without a full
+/// [`NetworkState`], allowing them to verify that every issued
+/// [`WorkerLease`] is eventually returned.
+#[cfg(test)]
+pub(crate) struct TestLeasePool {
+    pool: Arc<RwLock<WorkersPool>>,
+}
+
+#[cfg(test)]
+impl TestLeasePool {
+    pub fn new() -> Self {
+        Self {
+            pool: Arc::new(RwLock::new(
+                WorkersPool::new(PrioritiesConfig::default()),
+                "TestLeasePool::pool",
+            )),
+        }
+    }
+
+    pub fn lease(&self, worker: PeerId) -> WorkerLease {
+        self.pool.write().lease(worker);
+        WorkerLease {
+            pool: self.pool.clone(),
+            worker,
+        }
+    }
+
+    /// The number of leases issued and not yet dropped.
+    pub fn outstanding(&self) -> usize {
+        self.pool.read().running_queries_total()
     }
 }
 

--- a/src/types/errors.rs
+++ b/src/types/errors.rs
@@ -31,6 +31,12 @@ pub enum QueryError {
     BadRequest(String),
     #[error("{0}")]
     Retriable(String),
+    /// The response contradicts the query contract — bad signature, undecodable
+    /// body, or data outside the queried range. Rerouted like a transient
+    /// failure, but exhaustion pages instead of reporting a transient outage:
+    /// the network is serving bad data or verification is broken (DC-1, FM-2).
+    #[error("{0}")]
+    Integrity(String),
     #[error("{0}")]
     Failure(String),
     #[error("rate limit exceeded")]
@@ -53,6 +59,9 @@ impl RequestError {
             QueryError::BadRequest(s) => RequestError::BadRequest(s),
             QueryError::Retriable(s) => {
                 RequestError::InternalError(format!("received an error from worker {worker}: {s}"))
+            }
+            QueryError::Integrity(s) => {
+                RequestError::Failure(format!("worker {worker} returned invalid data: {s}"))
             }
             QueryError::Failure(s) => RequestError::Failure(format!("worker {worker} failed: {s}")),
             QueryError::RateLimitExceeded => RequestError::RateLimitExceeded,


### PR DESCRIPTION
## What

Two production fixes on the archival stream path, the randomized test that found the first one, and the start of the CT-2 conformance class that proved both end to end.

Rebased onto `master`, so the spec suite (`spec/`) and the harness are in scope; matrices and the gap register are updated in the same change, per spec/13's own rule.

## Production: wrong-range worker responses are integrity failures

A worker may report a `last_block` outside the range it was asked for. Both directions were broken, differently:

- **past the range end** — the continuation range was computed as `last_block + 1 ..= range.end()`, i.e. start above end. Inverted range, panic in the stream task, 500 for the client.
- **below the range start** — failed the whole stream with a terminal error, without trying any of the other reserved workers. One misbehaving worker killed the request.

Both are the same DC-1 row ("bad signature, wrong-range or undecodable result"). The response body is an opaque compressed blob, so it cannot be trimmed to the range without decoding and re-encoding it; the response is therefore discarded whole. New `QueryError::Integrity` — rerouted like a transient failure, but a different exhaustion class. Bad signatures and undecodable bodies were reclassified into it too, since DC-1 names them in the same row.

Because the controller is the only layer that knows the range it asked for, the check lives there and reports back through a new `StreamingNetwork::report_integrity_failure`, which penalises the worker (so the reroute avoids it) and counts it as `query_results{status="integrity"}` (OB-4).

### Exhaustion split

`WORKER-FAILURE` (500, pages) only when *every* attempt equivocated; anything with a transient failure in it stays `RETRIES-EXHAUSTED` (503). The class answers the client's question — "can a retry help?" — and if any attempt was transient, it can. Operator visibility does not ride on the class: each discarded response is counted per worker regardless.

DC-1 and spec/09 disagreed on this case ("attempts exhausted on integrity failures" vs "all attempts equivocating"). Rather than register the ambiguity, both documents are reconciled onto the reading above, which is also what 09 already said.

## Property test

`StreamController` against a scripted mock network under randomized adversity: worker backoffs (short and past `MAX_IDLE_TIME`), `AllUnavailable`, partial responses forcing continuations, slow responses that outlive the request timeout and trigger hedging, wrong-range responses in both directions, retriable failures, 1–3 concurrent streams, random `buffer_size` / `retries` / `max_stored_results_per_chunk` / `max_chunks`. 128 cases in ~80 ms on a paused clock.

Asserted every run: gapless strictly-increasing emission; completeness on clean termination; **bounds respect on the error path too** (a stream that overshoots and *then* fails would otherwise satisfy completeness vacuously); redundant execution bounded by the reserved fan-out; termination; no lease leaks.

**What it cannot see, stated plainly:** truncation is legal (ADR-001, FV-3), so a controller that gives up while reserved attempts remain satisfies every assertion above. Verified by mutation — disabling the undershoot rejection leaves this test green. Those guarantees are carried by the deterministic tests and by CT-2, and the limitation is recorded in the test itself.

### Hedging

A speculative query races an in-flight, not-yet-failed request, so a range can legitimately execute successfully on more than one worker. The invariant is that redundancy stays bounded by the reserved fan-out (`retries + 1`); single *delivery* is guaranteed separately by the gapless-emission invariant — the losing response is discarded, never emitted.

## CT-2 — the conformance class

A unit-level mock cannot prove any of the above against the real portal, so this starts CT-2 on the existing Phase-0 harness:

- **`WorkerFaults`** — fault queue **shared by every stub worker**, so one queued fault lands on whichever worker the portal routes to and a test never depends on FV-1's choice. Faults: `Overshoot`, `Undershoot`, `BadSignature`, `ServerError`, `NotFound`.
- **`Fixture`** — boots the whole IB-7 stub world plus the portal process. CT-1 had this inline; everything past it shares it.
- **`ct2_worker_faults`** — reroute rows, exhaustion split (observed: integrity 500 / transient 503), mixed exhaustion, and penalty decay between cases, which doubles as the LIV-7 witness.

Every exhaustion case guards against a vacuous pass by asserting attempts were actually consumed — "no available workers" is also an error with an empty body, and the first run of this test passed that way before the guard was added.

## Finding: worker `ServerError` is terminal (GAP-23, P1)

The CT-2 injector found, on its first run, that a generic worker `ServerError` verdict is classified non-retriable: the first erroring worker fails the whole request with no reroute — while `NotFound` and `ServerOverloaded` from the same worker *are* rerouted. DC-1 and the 09 worker table both put server errors in the reroute column.

Not fixed here, because it changes retry load against a fleet that is already erroring and belongs in its own change. Recorded as **GAP-23** and parked in CT-2's `known_violated` list, so the suite stays green on known-violated behaviour and fails loudly if the set drifts either way.

Worth noting for whoever picks it up: the protocol has a separate `Err::BadRequest` verdict for "your query is bad", and the code already penalises the worker on `ServerError` (`report_query_error`) while refusing to reroute — i.e. it is already classified as the worker's fault, just not acted on as one.

## Spec

- `05-dependencies.md`, `09-failure-model.md` — DC-1 / worker-fault rows reconciled on the mixed-exhaustion case.
- `13-conformance.md` — INV-3, LIV-7, LIV-10, LIV-12 move U→P; INV-20/21/22, FM-2, INV-36, REQ-21/41/43 notes updated; wrong-range added to closed findings; **GAP-23** (server-error reroute) and **GAP-24** (integrity counted but no OB-9 alarm state) registered.

`tools/spec-lint.py`: 0 errors, 0 warnings.

## Verification

```
cargo test --lib     97 passed
ct1_smoke            ok      (unchanged, still green)
ct2_worker_faults    ok      integrity 500 / transient 503
spec-lint            0 errors · 0 warnings
cargo fmt --check    clean
cargo clippy         no new warnings
```

Mutation-checked: disabling either half of the wrong-range rejection turns the deterministic tests and CT-2 red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
