### PR TITLE
[net-86] remove star debug symbol

### DIFF
--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -932,8 +932,14 @@ impl ChunkSlot {
     }
 
     fn debug_symbol(&self) -> char {
-        if self.buffered.front().is_some() {
-            '*'
+        if !self.buffered.is_empty() && self.active.is_some() {
+            '+'
+        } else if let Some(response) = self.buffered.front() {
+            if response.result.is_ok() {
+                '#'
+            } else {
+                '!'
+            }
         } else if let Some(active) = &self.active {
             active.state.debug_symbol()
         } else {


### PR DESCRIPTION
### Summary

Restores the old stream debug-symbol semantics after chunk-level buffering made many ready states appear as *.

###   Changes

  - Removed the * buffer symbol.
  - Use + when a chunk has buffered output plus an active continuation.
  - Use # when the front buffered response is successful.
  - Use ! when the front buffered response is an error.
  - Keep falling back to the active slot symbol when nothing is buffered.

###   Validation

  - cargo fmt --check
  - cargo check
  - cargo test controller::stream::tests
  - cargo test
  - cargo clippy --all-targets --all-features
