### PR TITLE
Add missing timeouts on outbound HTTP requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3605,6 +3605,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -5264,6 +5267,17 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api 0.4.12",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
@@ -5284,6 +5298,20 @@ dependencies = [
  "redox_syscall 0.1.57",
  "rustc_version 0.2.3",
  "smallvec 0.6.14",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec 1.13.2",
  "winapi 0.3.9",
 ]
 
@@ -6554,6 +6582,15 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
@@ -6727,6 +6764,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.2.0",
+ "reqwest 0.12.12",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c73e4195a6bfbcb174b790d9b3407ab90646976c55de58a6515da25d851178"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures 0.3.31",
+ "getrandom 0.2.15",
+ "http 1.2.0",
+ "hyper 1.8.1",
+ "parking_lot 0.11.2",
+ "reqwest 0.12.12",
+ "reqwest-middleware",
+ "retry-policies",
+ "thiserror 1.0.69",
+ "tokio 1.48.0",
+ "tracing",
+ "wasm-timer",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6734,6 +6808,15 @@ checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "hostname 0.3.1",
  "quick-error",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
+dependencies = [
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -7843,6 +7926,8 @@ dependencies = [
  "prost 0.13.4",
  "rand 0.9.2",
  "reqwest 0.12.12",
+ "reqwest-middleware",
+ "reqwest-retry",
  "scopeguard",
  "semver 1.0.25",
  "sentry",
@@ -9330,6 +9415,21 @@ checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
  "futures-util",
  "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures 0.3.31",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ tracing-futures = { version = "0.2.5", features = ["tokio", "futures-03"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 url = { version = "2.5", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "fast-rng"] }
+reqwest-retry = "0.7"
+reqwest-middleware = "0.4"
 
 [dev-dependencies]
 proptest = "1.4.0"

--- a/src/datasets.rs
+++ b/src/datasets.rs
@@ -4,11 +4,14 @@ use crate::{
     utils::RwLock,
 };
 use anyhow::Context;
+use reqwest_middleware::ClientBuilder;
+use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{btree_map::Entry, BTreeMap},
     fs::File,
     io::BufReader,
+    time::Duration,
 };
 
 pub struct Datasets {
@@ -194,8 +197,20 @@ async fn load_yaml<T: serde::de::DeserializeOwned>(url: &str) -> anyhow::Result<
         serde_yaml::from_reader(reader).with_context(|| format!("failed to parse {path}"))
     } else {
         tracing::debug!("Fetching remote file from {}", url);
-        let response = reqwest::get(url).await?;
-        let text = response.text().await?;
+        // Retry transient failures (timeouts, connection errors, 5xx, 429) so a slow
+        // or flaky datasets/metadata endpoint can't fail startup (Datasets::load is
+        // `?`-propagated in main); a permanent 4xx still fails fast.
+        let client = ClientBuilder::new(
+            reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(5))
+                .timeout(Duration::from_secs(30))
+                .build()?,
+        )
+        .with(RetryTransientMiddleware::new_with_policy(
+            ExponentialBackoff::builder().build_with_max_retries(3),
+        ))
+        .build();
+        let text = client.get(url).send().await?.error_for_status()?.text().await?;
         serde_yaml::from_str(&text).with_context(|| format!("failed to parse {url}"))
     }
 }

--- a/src/hotblocks.rs
+++ b/src/hotblocks.rs
@@ -74,13 +74,16 @@ pub async fn build_client(config: &Config) -> anyhow::Result<HotblocksHandle> {
         }
     }
 
+    // Read (idle) timeout, not a total timeout: this client proxies streams, and a
+    // total deadline would truncate a stream drained slowly by a backpressured client.
     let mut builder = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .no_gzip()
         .no_deflate()
         .no_brotli()
         .no_zstd()
-        .connect_timeout(Duration::from_secs(1));
+        .connect_timeout(Duration::from_secs(1))
+        .read_timeout(Duration::from_secs(30));
 
     if let Some(client_id) = &config.client_id {
         let mut headers = reqwest::header::HeaderMap::new();

--- a/src/network/storage.rs
+++ b/src/network/storage.rs
@@ -51,6 +51,7 @@ impl StorageClient {
             latest_assignment_id: RwLock::new(None, "StorageClient::latest_assignment"),
             network_state_url,
             reqwest_client: reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(5))
                 .read_timeout(Duration::from_secs(5))
                 .user_agent(format!("SQD Portal/{}", env!("CARGO_PKG_VERSION")))
                 .build()


### PR DESCRIPTION
**Problem:** several outbound HTTP clients had no read/overall timeout, so a stalled upstream (connected, then silent) would hang the request forever. Worst offender: the hotblocks client, which set only `connect_timeout(1s)`.

## Fix — one timeout per client, matched to how it's used

| Site | Before | After |
|---|---|---|
| `hotblocks.rs` (incl. `stream` / `finalized-stream`) | `connect 1s` only | + `read_timeout 30s` |
| `datasets.rs` remote config (startup + refresh) | `reqwest::get`, no timeouts | `connect 5s` + `timeout 30s` + retries |
| `network/storage.rs` | `read 5s`, no connect bound | + `connect_timeout 5s` |

**hotblocks** uses a per-read (idle) timeout, not a total `.timeout()`: the client proxies streaming responses (`Body::from_stream(bytes_stream())`), and a total deadline would truncate a valid stream that a slow/backpressured downstream client drains past 30s. `read_timeout` fires only when the upstream goes silent — catches a dead upstream without capping healthy streams. Same pattern as `storage.rs`.

**datasets** wraps the client in `reqwest-retry` (`ExponentialBackoff`, 3 retries) so a slow/flaky config endpoint can't fail startup — `Datasets::load` is `?`-propagated in `main`. Retries transient failures (timeouts, connect, 5xx, 408, 429) with jitter; a permanent 4xx still fails fast.

**Deps:** adds `reqwest-retry` + `reqwest-middleware`, pinned to `0.7` / `0.4` (the reqwest-0.12 line) so no second `reqwest` major lands in the tree.

**Verification:** `cargo check`, `clippy --all-targets`, `cargo test --lib datasets` pass. Timeout/retry *firing* isn't covered by a test yet (needs a stalled mock upstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
