### PR TITLE
Error taxonomy for the portal API

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,6 +48,49 @@ jobs:
       - name: Run tests
         run: cargo test --all-features
 
+  harness:
+    # The conformance suites of spec/13. Its own job, and its own crate: the harness
+    # is not a workspace member, so `cargo test` at the root never reaches it.
+    name: Conformance harness
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || !github.event.pull_request.draft
+    steps:
+      - name: Cache protoc
+        id: cache-protoc
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/protoc
+          key: protoc-${{ env.PROTOC_VERSION }}-${{ runner.arch }}
+
+      - name: Install protoc (if not cached)
+        if: steps.cache-protoc.outputs.cache-hit != 'true'
+        run: |
+          set -euxo pipefail
+          mkdir -p ~/.local/protoc
+          curl -L -o /tmp/protoc.zip \
+            "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${ARCH}.zip"
+          unzip -q /tmp/protoc.zip -d ~/.local/protoc
+
+      - name: Add protoc to PATH
+        run: echo "$HOME/.local/protoc/bin" >> "$GITHUB_PATH"
+
+      - uses: actions/checkout@v4
+      - uses: dsherret/rust-toolchain-file@v1
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            harness
+
+      - name: Build the portal under test
+        # The stubs run it as a black box; the harness looks for target/debug/sqd-portal.
+        run: cargo build --all-features
+
+      - name: Run conformance suites
+        run: cargo test --manifest-path harness/Cargo.toml
+        env:
+          PORTAL_BIN: ${{ github.workspace }}/target/debug/sqd-portal
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7853,6 +7853,7 @@ dependencies = [
  "flate2",
  "futures 0.3.31",
  "hex-literal",
+ "http-body 1.0.1",
  "hyper 1.8.1",
  "itertools 0.12.1",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ dotenv = "0.15"
 flate2 = "1.0.33"
 futures = "0.3"
 hex-literal = "0.4.1"
+# size_hint() on a response body: tells a framework rejection apart from a stream without
+# polling it. Already in the tree via axum.
+http-body = "1"
 # ADR-015 fault classification; reqwest's error API can't see a pre-head connection death.
 hyper = "1"
 itertools = "0.12"

--- a/docs/openapi/02-blockchain-forks.md
+++ b/docs/openapi/02-blockchain-forks.md
@@ -61,6 +61,11 @@ If the client tries to resume at `fromBlock = N+2` with `parentBlockHash = hash(
 
 ```json
 {
+  "error": {
+    "type": "invalid_request_error",
+    "code": "base_block_mismatch",
+    "message": "Base block mismatch"
+  },
   "previousBlocks": [
     {
       "number": 21780872,
@@ -74,8 +79,10 @@ If the client tries to resume at `fromBlock = N+2` with `parentBlockHash = hash(
 }
 ```
 
+- `error` is the standard error object every failing response carries. Match on `error.code`
+  (`base_block_mismatch` here) rather than on `error.message`, which is prose and may change.
 - `previousBlocks` is a single array of `{ number, hash }` pairs from the **current canonical chain** at and below the
-  conflict point.
+  conflict point. It stays at the **top level**, beside `error`, so the recovery walk below is unchanged.
 - The array length is arbitrary, but is **guaranteed to contain at least the parent of the requested `fromBlock`**.
 - Order: most recent first (canonical chain descending from the conflict point).
 

--- a/harness/src/stubs/worker.rs
+++ b/harness/src/stubs/worker.rs
@@ -45,6 +45,10 @@ pub enum WorkerFault {
     /// Answer "chunk not found" — the worker is still downloading it. Same
     /// DC-1 row as ServerError, but the portal treats it as retriable.
     NotFound(String),
+    /// Refuse for capacity: the rate-limit verdict.
+    TooManyRequests,
+    /// Refuse for capacity: the overload verdict. One DC-1 row with the above.
+    ServerOverloaded,
 }
 
 /// A fault queue shared by every stub worker in a test, so a single queued
@@ -177,6 +181,12 @@ fn answer(
         }
         Some(WorkerFault::NotFound(m)) => {
             return verdict_result(query, keypair, query_error::Err::NotFound(m.clone()))
+        }
+        Some(WorkerFault::TooManyRequests) => {
+            return verdict_result(query, keypair, query_error::Err::TooManyRequests(()))
+        }
+        Some(WorkerFault::ServerOverloaded) => {
+            return verdict_result(query, keypair, query_error::Err::ServerOverloaded(()))
         }
         _ => {}
     }

--- a/harness/src/validators.rs
+++ b/harness/src/validators.rs
@@ -1,10 +1,10 @@
 //! The structural validators of spec/13. Validators 1–5 run on every stream
-//! response via `validate_stream`; validator 6 (`validate_error`) covers error
-//! envelopes and is not yet exercised by the Phase-0 smoke (no error-path request).
+//! response via `validate_stream`; validator 6 (`validate_error`) runs on every
+//! error response and is exercised by CT-2's fault cases.
 //! `errors` are hard conformance failures; `warnings` cover surfaces the gap
-//! register already knows are not integrated on current master (GAP-16 error
-//! envelope, ADR-014's 204 metadata) — reported, not fatal, so the Phase-0
-//! smoke stays green while the gaps stay visible.
+//! register already knows are not integrated on current master (ADR-014's 204
+//! metadata) — reported, not fatal, so the suites stay green while the gaps stay
+//! visible.
 
 use crate::driver::Decoded;
 use crate::model::{Expect, StreamReq};
@@ -25,28 +25,31 @@ impl Verdict {
     }
 }
 
-const KNOWN_CODES: &[&str] = &[
-    "malformed_request",
-    "unknown_dataset",
-    "not_found",
-    "base_block_mismatch",
-    "no_data",
-    "overloaded",
-    "no_workers",
-    "retries_exhausted",
-    "upstream_unavailable",
-    "not_ready",
-    "worker_failure",
-    "internal_error",
-    "unclassified",
+/// DEF-10's closed vocabulary bound to IB-5: `(code, type, permitted statuses)`.
+/// An empty status list means the binding leaves it contextual, and only 5xx is legal.
+///
+/// Transcribed from the spec rather than imported from the portal: a validator sharing
+/// the implementation's table would agree with it by construction, including where both
+/// are wrong. `no_data` is absent because a 204 is a success and carries no code.
+const TAXONOMY: &[(&str, &str, &[u16])] = &[
+    ("malformed_request", "invalid_request_error", &[400]),
+    ("method_not_allowed", "invalid_request_error", &[405]),
+    ("unknown_dataset", "invalid_request_error", &[404]),
+    ("not_found", "invalid_request_error", &[404]),
+    ("base_block_mismatch", "invalid_request_error", &[409]),
+    // 529 for a Portal-local refusal; a proxied one keeps the upstream's status.
+    ("overloaded", "rate_limit_error", &[429, 529]),
+    ("no_workers", "availability_error", &[503]),
+    ("retries_exhausted", "availability_error", &[503]),
+    // 502 locally; a proxied upstream failure retains its own 5xx.
+    ("upstream_unavailable", "availability_error", &[]),
+    ("not_ready", "availability_error", &[503]),
+    ("worker_failure", "api_error", &[500]),
+    ("internal_error", "api_error", &[500]),
+    ("unclassified", "api_error", &[]),
 ];
 
-pub fn validate_stream(
-    world: &ToyWorld,
-    req: &StreamReq,
-    expect: &Expect,
-    d: &Decoded,
-) -> Verdict {
+pub fn validate_stream(world: &ToyWorld, req: &StreamReq, expect: &Expect, d: &Decoded) -> Verdict {
     let mut v = Verdict::default();
 
     // 1 — body decodes under its declared encoding, line by line (INV-25).
@@ -55,7 +58,12 @@ pub fn validate_stream(
     }
 
     match expect {
-        Expect::Stream { records, head, finalized_head, source } => {
+        Expect::Stream {
+            records,
+            head,
+            finalized_head,
+            source,
+        } => {
             if d.status != 200 {
                 v.err(format!("expected 200, got {}", d.status));
                 return v;
@@ -68,7 +76,10 @@ pub fn validate_stream(
             }
             for w in numbers.windows(2) {
                 if w[1] <= w[0] {
-                    v.err(format!("validator2: not strictly ascending: {} then {}", w[0], w[1]));
+                    v.err(format!(
+                        "validator2: not strictly ascending: {} then {}",
+                        w[0], w[1]
+                    ));
                 }
             }
 
@@ -76,7 +87,10 @@ pub fn validate_stream(
             let expected_last = records.last().and_then(|r| r["header"]["number"].as_u64());
             for n in &numbers {
                 if *n < req.from {
-                    v.err(format!("validator3: record {n} below fromBlock {}", req.from));
+                    v.err(format!(
+                        "validator3: record {n} below fromBlock {}",
+                        req.from
+                    ));
                 }
                 if let Some(last) = expected_last {
                     if *n > last {
@@ -130,7 +144,10 @@ pub fn validate_stream(
 
             let _ = world;
         }
-        Expect::Empty { head, finalized_head } => {
+        Expect::Empty {
+            head,
+            finalized_head,
+        } => {
             if d.status != 204 {
                 v.err(format!("expected 204 EMPTY, got {}", d.status));
                 return v;
@@ -166,7 +183,10 @@ fn check_head_headers(
         Some(Err(_)) => push("head number unparsable".to_string()),
         None => push("missing x-sqd-head-number".to_string()),
     }
-    match d.header("x-sqd-finalized-head-number").map(|s| s.parse::<u64>()) {
+    match d
+        .header("x-sqd-finalized-head-number")
+        .map(|s| s.parse::<u64>())
+    {
         Some(Ok(f)) if f == finalized_head.0 => {}
         Some(Ok(f)) => push(format!("finalized head {f}, expected {}", finalized_head.0)),
         Some(Err(_)) => push("finalized head unparsable".to_string()),
@@ -180,7 +200,8 @@ fn check_head_headers(
     // Coherence is a hard rule regardless of provenance (validator 5).
     if let (Some(Ok(h)), Some(Ok(f))) = (
         d.header("x-sqd-head-number").map(|s| s.parse::<u64>()),
-        d.header("x-sqd-finalized-head-number").map(|s| s.parse::<u64>()),
+        d.header("x-sqd-finalized-head-number")
+            .map(|s| s.parse::<u64>()),
     ) {
         if f > h {
             v.err(format!("validator5: finalized {f} > head {h}"));
@@ -188,30 +209,169 @@ fn check_head_headers(
     }
 }
 
-/// Validator 6 on error responses: ADR-011 envelope, closed vocabulary.
-/// GAP-16: current master does not emit the envelope — warnings for now.
+/// Validator 6 on error responses: the ADR-011 envelope against the whole of DEF-10 and
+/// IB-5 — code in the vocabulary, the type *bound to that code*, a status the binding
+/// permits, and the hint rule. Checking the code alone left `type` free-form, so a
+/// response could name a type outside the axis, or pair a code with the wrong one, and
+/// still pass (INV-26).
 pub fn validate_error(d: &Decoded) -> Verdict {
     let mut v = Verdict::default();
     if d.status < 400 {
         v.err(format!("expected an error status, got {}", d.status));
         return v;
     }
-    match serde_json::from_slice::<serde_json::Value>(&d.body) {
-        Ok(body) => {
-            let t = body["error"]["type"].as_str();
-            let c = body["error"]["code"].as_str();
-            match (t, c) {
-                (Some(_), Some(code)) if KNOWN_CODES.contains(&code) => {}
-                _ => v.warn(format!(
-                    "GAP-16: error body is not the ADR-011 envelope: {}",
-                    String::from_utf8_lossy(&d.body)
-                )),
-            }
-        }
-        Err(_) => v.warn(format!(
-            "GAP-16: error body is not JSON: {}",
+    let Ok(body) = serde_json::from_slice::<serde_json::Value>(&d.body) else {
+        v.err(format!(
+            "validator6: error body is not JSON: {}",
             String::from_utf8_lossy(&d.body)
+        ));
+        return v;
+    };
+
+    let Some(code) = body["error"]["code"].as_str() else {
+        v.err(format!(
+            "validator6: error body is not the ADR-011 envelope: {}",
+            String::from_utf8_lossy(&d.body)
+        ));
+        return v;
+    };
+    let Some(&(_, want_type, statuses)) = TAXONOMY.iter().find(|(c, _, _)| *c == code) else {
+        v.err(format!(
+            "validator6: {code} is outside the DEF-10 vocabulary"
+        ));
+        return v;
+    };
+
+    match body["error"]["type"].as_str() {
+        Some(t) if t == want_type => {}
+        other => v.err(format!(
+            "validator6: {code} is bound to {want_type}, got {other:?}"
         )),
     }
+    if !statuses.is_empty() && !statuses.contains(&d.status) {
+        v.err(format!(
+            "validator6: IB-5 binds {code} to {statuses:?}, got {}",
+            d.status
+        ));
+    } else if statuses.is_empty() && d.status < 500 {
+        v.err(format!(
+            "validator6: {code} is a contextual 5xx, got {}",
+            d.status
+        ));
+    }
+    if !body["error"]["message"]
+        .as_str()
+        .is_some_and(|m| !m.is_empty())
+    {
+        v.err(format!("validator6: {code} does not explain itself"));
+    }
+
+    // INV-26: OVERLOADED always says how long to wait, DATA-UNAVAILABLE never does.
+    let hint = d.header("retry-after");
+    match code {
+        "overloaded" => match hint.map(|h| h.trim().parse::<u64>()) {
+            Some(Ok(seconds)) if seconds >= 1 => {}
+            other => v.err(format!(
+                "validator6: overloaded needs a usable hint, got {other:?}"
+            )),
+        },
+        "no_workers" if hint.is_some() => {
+            v.err(format!(
+                "validator6: no_workers must carry no hint, got {hint:?}"
+            ));
+        }
+        _ => {}
+    }
     v
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn response(status: u16, body: &str, hint: Option<&str>) -> Decoded {
+        let mut headers = HashMap::new();
+        if let Some(hint) = hint {
+            headers.insert("retry-after".to_owned(), hint.to_owned());
+        }
+        Decoded {
+            status,
+            headers,
+            body: body.as_bytes().to_vec(),
+            lines: Vec::new(),
+            decode_errors: Vec::new(),
+        }
+    }
+
+    fn envelope(t: &str, code: &str) -> String {
+        format!(r#"{{"error":{{"type":"{t}","code":"{code}","message":"m"}}}}"#)
+    }
+
+    /// The validator is the gate the CI job rests on, so its own holes are invisible:
+    /// accepting the code alone let a type outside the axis — or bound to a different
+    /// code — pass, and the suite would have stayed green through it.
+    #[test]
+    fn a_type_outside_its_code_is_rejected() {
+        let banana = response(529, &envelope("banana", "overloaded"), Some("1"));
+        assert!(!validate_error(&banana).errors.is_empty());
+
+        let crossed = response(500, &envelope("availability_error", "internal_error"), None);
+        assert!(!validate_error(&crossed).errors.is_empty());
+
+        let ok = response(500, &envelope("api_error", "internal_error"), None);
+        assert!(
+            validate_error(&ok).errors.is_empty(),
+            "{:?}",
+            validate_error(&ok).errors
+        );
+    }
+
+    /// IB-5 fixes the status per code, so a right code on a wrong status is still a
+    /// contract break — and `unclassified` may be any 5xx but never a 4xx.
+    #[test]
+    fn a_status_outside_its_binding_is_rejected() {
+        let wrong = response(
+            500,
+            &envelope("invalid_request_error", "malformed_request"),
+            None,
+        );
+        assert!(!validate_error(&wrong).errors.is_empty());
+
+        let proxied = response(429, &envelope("rate_limit_error", "overloaded"), Some("30"));
+        assert!(validate_error(&proxied).errors.is_empty());
+
+        let contextual = response(503, &envelope("api_error", "unclassified"), None);
+        assert!(validate_error(&contextual).errors.is_empty());
+        let as_4xx = response(400, &envelope("api_error", "unclassified"), None);
+        assert!(!validate_error(&as_4xx).errors.is_empty());
+    }
+
+    /// INV-26 is an iff: the overload owes a usable hint, DATA-UNAVAILABLE owes none.
+    #[test]
+    fn the_hint_rule_runs_both_ways() {
+        for hint in [None, Some("0"), Some("Wed, 21 Oct 2015 07:28:00 GMT")] {
+            let d = response(529, &envelope("rate_limit_error", "overloaded"), hint);
+            assert!(!validate_error(&d).errors.is_empty(), "{hint:?}");
+        }
+        let with_hint = response(
+            503,
+            &envelope("availability_error", "no_workers"),
+            Some("5"),
+        );
+        assert!(!validate_error(&with_hint).errors.is_empty());
+    }
+
+    #[test]
+    fn an_unknown_code_and_a_silent_message_are_rejected() {
+        let unknown = response(500, &envelope("api_error", "kaboom"), None);
+        assert!(!validate_error(&unknown).errors.is_empty());
+
+        let silent = response(
+            500,
+            r#"{"error":{"type":"api_error","code":"internal_error","message":""}}"#,
+            None,
+        );
+        assert!(!validate_error(&silent).errors.is_empty());
+    }
 }

--- a/harness/tests/ct2_worker_faults.rs
+++ b/harness/tests/ct2_worker_faults.rs
@@ -62,6 +62,21 @@ async fn await_pool_recovery(fx: &Fixture, label: &str) -> anyhow::Result<Decode
     anyhow::bail!("pool never recovered before {label} (last status {last:?}) — LIV-7")
 }
 
+/// The ADR-011 code, after validator 6 has passed on the envelope carrying it.
+fn error_code(context: &str, d: &Decoded) -> anyhow::Result<String> {
+    let verdict = harness::validators::validate_error(d);
+    ensure!(
+        verdict.errors.is_empty(),
+        "{context}: {:?}",
+        verdict.errors
+    );
+    let body: serde_json::Value = serde_json::from_slice(&d.body)?;
+    Ok(body["error"]["code"]
+        .as_str()
+        .context("validated envelope has a code")?
+        .to_owned())
+}
+
 /// The full range, in order, exactly once — INV-20/21 on the delivered body.
 fn assert_complete(context: &str, d: &Decoded) -> anyhow::Result<()> {
     ensure!(
@@ -129,6 +144,8 @@ async fn run(fx: &mut Fixture) -> anyhow::Result<()> {
             "not-found",
             WorkerFault::NotFound("still downloading".into()),
         ),
+        ("too-many-requests", WorkerFault::TooManyRequests),
+        ("server-overloaded", WorkerFault::ServerOverloaded),
         ("server-error", WorkerFault::ServerError("scripted".into())),
     ] {
         await_pool_recovery(fx, label).await?;
@@ -237,19 +254,56 @@ async fn run(fx: &mut Fixture) -> anyhow::Result<()> {
         "transient exhaustion must exhaust real attempts, only {} were answered",
         fx.queries_answered() - before
     );
-    // Codes themselves are not asserted: the ADR-011 taxonomy is not integrated
-    // yet (GAP-16), so only the split is contract today.
-    eprintln!(
-        "[ct2] exhaustion split — integrity {} / transient {}",
-        exhausted.status, transient.status
+    // The codes are the contract, not just the fact that the statuses differ: a
+    // client branches on them, and asserting only "some error" lets the classes
+    // collapse into one.
+    ensure!(
+        error_code("integrity exhaustion", &exhausted)? == "worker_failure",
+        "integrity exhaustion must page as WORKER-FAILURE, got {}",
+        error_code("integrity exhaustion", &exhausted)?
     );
     ensure!(
-        exhausted.status != transient.status,
-        "integrity exhaustion ({}) must not be reported as a transient outage ({}) — \
-         DC-1 splits these into WORKER-FAILURE and RETRIES-EXHAUSTED",
-        exhausted.status,
-        transient.status,
+        error_code("transient exhaustion", &transient)? == "retries_exhausted",
+        "transient exhaustion must be RETRIES-EXHAUSTED, got {}",
+        error_code("transient exhaustion", &transient)?
     );
+
+    // Every attempt refusing for capacity is congestion, not an outage: OVERLOADED
+    // with the hint INV-26 owes the client. As a transient exhaustion it answered a
+    // bare 503, which is the 2026-07 refusal storm's shape (ADR-007/012).
+    for (label, fault) in [
+        ("too-many-requests", WorkerFault::TooManyRequests),
+        ("server-overloaded", WorkerFault::ServerOverloaded),
+    ] {
+        await_pool_recovery(fx, label).await?;
+        fx.worker_faults.always(fault);
+        let before = fx.queries_answered();
+        let refused = driver::stream(
+            &http,
+            &base,
+            "toy",
+            "finalized-stream",
+            &query(FROM, TO),
+            &format!("ct2-{label}-exhausted"),
+        )
+        .await?;
+        ensure!(
+            fx.queries_answered() >= before + 2,
+            "{label}: exhaustion must consume real attempts, only {} answered",
+            fx.queries_answered() - before
+        );
+        ensure!(
+            error_code(label, &refused)? == "overloaded",
+            "{label}: capacity exhaustion must be OVERLOADED, got {} at {}",
+            error_code(label, &refused)?,
+            refused.status
+        );
+        ensure!(
+            refused.status == 529,
+            "{label}: OVERLOADED answers 529, got {}",
+            refused.status
+        );
+    }
 
     // Mixed exhaustion follows the transient class, not the integrity one: if
     // any attempt failed transiently a later retry can still succeed, so the
@@ -281,10 +335,9 @@ async fn run(fx: &mut Fixture) -> anyhow::Result<()> {
         fx.queries_answered() - before
     );
     ensure!(
-        mixed.status == transient.status,
-        "mixed exhaustion must take the transient class ({}), got {}",
-        transient.status,
-        mixed.status
+        error_code("mixed exhaustion", &mixed)? == "retries_exhausted",
+        "mixed exhaustion must take the transient class, got {}",
+        error_code("mixed exhaustion", &mixed)?
     );
 
     // Recovery: penalties are not latched. Once the faults stop, the pool

--- a/spec/02-requirements.md
+++ b/spec/02-requirements.md
@@ -112,12 +112,13 @@ at P-BUFFER-MAX; absent parameters default to P-BUFFER-DEFAULT. (Two advertised
 parameters are currently accepted and ignored: GAP-8, OQ-1.)
 
 **REQ-9 — Request correlation.** [MUST]
-Every response carries a request identifier: the client's, if supplied, else a generated
-one. The identifier is echoed in the response, attached to logs, and propagated to
-upstream calls, so one identifier traces a request end to end. Any byte sequence a
-client supplies as an identifier is safe (REQ-21).
-*Acceptance:* a supplied `x-request-id` is echoed verbatim and appears in Portal logs
-for that request; absent one, a unique identifier is generated and echoed.
+Every response carries a request identifier: the client's, if supplied as ASCII text,
+else a generated one. A valid client identifier is echoed in the response, attached to
+logs, and propagated to upstream calls, so one identifier traces a request end to end.
+A non-ASCII `x-request-id` is malformed input and is rejected safely (REQ-21).
+*Acceptance:* a supplied ASCII `x-request-id` is echoed verbatim and appears in Portal
+logs for that request; a non-ASCII value receives a 400 `malformed_request` response
+with a generated identifier; absent one, a unique identifier is generated and echoed.
 
 ## Discovery & metadata (10–16)
 
@@ -314,7 +315,8 @@ artifact on any fetch or validation failure. First applied assignment gates read
 (REQ-23).
 *Acceptance:* a new artifact with a future effective time is not visible in routing
 until that time; killing the publisher leaves serving unaffected for the duration of
-the outage (staleness intent: ADR-013).
+the outage (staleness intent: ADR-013). Cutting over together assumes the workers wait
+too, which they do not today (OQ-11).
 
 **REQ-41 — Worker selection and penalties.** [MUST]
 Chunk queries go to the most promising worker holding the chunk: healthy and fast
@@ -379,6 +381,7 @@ Deliberately left open — tests and clients must not pin these:
 | OQ-7 | A stream body without a first block silently defaults to block 0, while the API description marks it required — reject instead? | REQ-7 | portal team |
 | OQ-9 | Ratify a global P-BUFFERED-BYTES-BUDGET and its accounting/admission semantics. | REQ-27, GAP-17 | portal team |
 | OQ-10 | Ratify the draft SLO target parameters and their benchmark gating policy. | 11 SLO table | portal team |
+| OQ-11 | REQ-40's fleet-cutover premise assumes workers also honor `effective_from`; workers currently apply assignments immediately (recorded in the worker suite's open questions, `worker-rs/spec/02`), so each publication opens a window of routing to reshuffling workers (transient `no_workers`/`retries_exhausted` churn). Size the window for worker convergence, or have workers delay too? | REQ-40, REQ-41 | network team |
 
 Closed: **OQ-6** (should the clamp-bypassing debug stream variant be exposed unconditionally,
 or gated behind an operator flag?) — resolved by ADR-014: the variant is gated behind an

--- a/spec/03-data-model.md
+++ b/spec/03-data-model.md
@@ -104,9 +104,8 @@ additional public values.
 
 | Spec outcome | Wire `type` / `code` | Meaning |
 |---|---|---|
-| BAD-REQUEST | `invalid_request_error` / `malformed_request` | DEF-7 violation or bad parameter |
+| BAD-REQUEST | `invalid_request_error` / `malformed_request` or `method_not_allowed` | DEF-7 violation, bad parameter, or a verb the surface does not serve |
 | NOT-FOUND | `invalid_request_error` / `unknown_dataset` or `not_found` | Alias/surface absent, or lookup has no result |
-| EMPTY | `availability_error` / `no_data` | Successful bodyless poll result (INV-27) |
 | CONFLICT | `invalid_request_error` / `base_block_mismatch` | Parent-hash mismatch (DEF-9) |
 | OVERLOADED | `rate_limit_error` / `overloaded` | Capacity refusal with retry hint |
 | DATA-UNAVAILABLE | `availability_error` / `no_workers` | No worker holds the data |
@@ -115,6 +114,11 @@ additional public values.
 | NOT-READY | `availability_error` / `not_ready` | Readiness probe declines traffic |
 | WORKER-FAILURE | `api_error` / `worker_failure` | Worker results violated an owned integrity invariant and rerouting was exhausted (DC-1) |
 | INTERNAL | `api_error` / `internal_error` or `unclassified` | Portal invariant failed or a failure escaped classification |
+
+EMPTY is deliberately absent: a bodyless poll result is the correct answer to a range
+that is not produced yet (INV-27), not a failure, so it carries no `type` and no `code`.
+It is bound by IB-4 and observed as `status="204"`, which is exactly what a code on it
+would have restated.
 
 Exact statuses and envelope exceptions are fixed by IB-5. No dependency-specific body
 or code extends this set.

--- a/spec/05-dependencies.md
+++ b/spec/05-dependencies.md
@@ -30,12 +30,14 @@ alternatives exist.
 | parent-hash mismatch verdict | CONFLICT (real-time mode only — finalized-mode queries carry no parent hash, REQ-3) |
 | server error / not found | reroute; cooldown P-WORKER-ERROR-COOLDOWN; exhausted ⇒ RETRIES-EXHAUSTED |
 | timeout / transport failure | reroute; cooldown P-WORKER-TIMEOUT-COOLDOWN; congestion signal; exhausted ⇒ RETRIES-EXHAUSTED |
-| rate-limit / overload verdict | honor backoff (worker's hint, default P-WORKER-BACKOFF); all candidates backing off longer than P-MAX-IDLE-TIME ⇒ OVERLOADED |
+| rate-limit / overload verdict | honor backoff (worker's hint, default P-WORKER-BACKOFF); all candidates backing off longer than P-MAX-IDLE-TIME ⇒ OVERLOADED, as does an exhausted run in which *every* attempt returned one of these two verdicts — the refusal is congestion whether it arrives before the query or as its answer |
 | integrity failure (bad signature, wrong-range or undecodable result) | discard result, reroute (REQ-43); exhausted with *every* attempt an integrity failure ⇒ WORKER-FAILURE (pages — the network serves bad data or verification is broken); exhausted with any transient failure among the attempts ⇒ RETRIES-EXHAUSTED, since a later retry can still succeed and the class tells the client whether to come back. Equivocation stays operator-visible either way: it is counted per worker and alarmed regardless of the response class (OB-4/OB-9) |
 | no worker leasable for the chunk | DATA-UNAVAILABLE |
 
 *Degradation.* Per-worker penalties (ADR-004) — never a global circuit-break; the pool
 degrades worker-by-worker. Health state is in-memory (DEF-12) and resets on restart.
+Which penalty class a fault draws is meant to follow its cost; today it does not always,
+and the divergence can take the whole pool out at once (GAP-27).
 
 ## DC-2 — Assignment publisher
 
@@ -78,8 +80,8 @@ IB-4/IB-5).
 |---|---|
 | connect/transport failure before the response head | one replay (ADR-015); still failing ⇒ UPSTREAM-FAILURE (recorded) |
 | read stall past deadline | UPSTREAM-FAILURE, never replayed (recorded — a stalled upstream must never be invisible, REQ-22) |
-| upstream 429 / 503 / 529 | OVERLOADED / `overloaded`; preserve public retry/header semantics, injecting `Retry-After` = P-RETRY-AFTER-MIN when the upstream omitted it (INV-26, ADR-014) |
-| other upstream 5xx | UPSTREAM-FAILURE / `upstream_unavailable`; preserve public headers, never the upstream body |
+| upstream 429 / 529 | OVERLOADED / `overloaded`; preserve public retry/header semantics, injecting `Retry-After` = P-RETRY-AFTER-MIN when the upstream omitted it (INV-26, ADR-014) |
+| upstream 503 and other 5xx | UPSTREAM-FAILURE / `upstream_unavailable`; preserve public headers — including a `Retry-After` the upstream sent — but never invent one, and never the upstream body. 503 is unavailability, not congestion: the ADR-007 line, applied to the dependency (ADR-014) |
 | other upstream 4xx (unmatched) | BAD-REQUEST / `malformed_request` (ADR-011 unmatched-4xx rule); status normalized to 400, upstream body never leaked |
 | upstream conflict | CONFLICT / `base_block_mismatch`; preserve `previousBlocks`, add Portal envelope |
 | requested range below upstream retention (gap) | EMPTY after P-NO-DATA-DELAY |

--- a/spec/09-failure-model.md
+++ b/spec/09-failure-model.md
@@ -61,8 +61,8 @@ requests only; the publisher ⇒ freshness only; chain RPC ⇒ status only (REQ-
 |---|---|
 | Down / connect refused / connection closed before the response head | mask one replay (ADR-015); still failing ⇒ fail-safe UPSTREAM-FAILURE; archival traffic and readiness unaffected (FM-3) |
 | Stalled read | fail-safe UPSTREAM-FAILURE within P-HOTBLOCKS-READ-TIMEOUT, never replayed, recorded (ADR-010) |
-| Upstream 429 / 503 / 529 | fail-safe `overloaded` envelope; public headers retained, `Retry-After` injected at P-RETRY-AFTER-MIN when absent (INV-26); upstream body never leaked (ADR-011) |
-| Other erroring 5xx | fail-safe `upstream_unavailable` envelope; public headers retained, upstream body never leaked (ADR-011) |
+| Upstream 429 / 529 | fail-safe `overloaded` envelope; public headers retained, `Retry-After` injected at P-RETRY-AFTER-MIN when absent (INV-26); upstream body never leaked (ADR-011) |
+| Upstream 503 and other erroring 5xx | fail-safe `upstream_unavailable` envelope; public headers retained — a `Retry-After` the upstream sent is passed on, none is invented — upstream body never leaked (ADR-011, ADR-014) |
 | Erroring 4xx (unmatched) | fail-safe `malformed_request` envelope at 400; upstream body never leaked (DC-4) |
 | Mid-proxy failure | truncate per INV-25; never replayed — a replay past the response head would duplicate a prefix (ADR-003, ADR-015) |
 | Retention gap | fail-safe EMPTY (INV-27) |

--- a/spec/12-observability.md
+++ b/spec/12-observability.md
@@ -15,7 +15,12 @@ idle-input (EMPTY polling) from a stalled service: a stream with no heartbeat
 progress past P-STALL-BUDGET ⚠ is the LIV-2 witness.
 
 **OB-3 — Operation metrics.** Responses counted by operation × ADR-011 error type/code
-(or success) × serving source, with latency histograms. The source label is `network`,
+(or success) × serving source, with latency histograms. The taxonomy rides as the
+`error_code`/`error_type` labels (prefixed: a bare `type` label says nothing on a
+metric), attached to **4xx/5xx only** — a 2xx carries neither, so the routine 204 that
+is the steady state of every polling client cannot inflate an availability alert
+(INV-30). A failure reaching the middleware unclassified is still counted, as
+`unclassified`. The source label is `network`,
 `real_time`, or `none` for pre-routing failures; it does not imply a response header.
 **Truncations count separately** from completions (SLI-6 is computed from this);
 refusals by code distinguish `overloaded` from `no_workers` — the 2026-07 storm was

--- a/spec/13-conformance.md
+++ b/spec/13-conformance.md
@@ -1,19 +1,26 @@
 # 13 — Conformance & TDD plan
 
-**Mutable doc.** Statuses as of **2026-07-25** (0.11.9,
+**Mutable doc.** Statuses as of **2026-07-27** (0.11.9,
 `master@15fcaeeea803b39e4985a7c91dada20203f411ef`). Statuses: **C** covered · **P** partial · **U**
 unchecked; *known-violated* / *known-suspect* where reality contradicts the property.
 The **Phase-0 harness exists** (`harness/` crate: IB-7 stubs with ledgers — including
 a real p2p worker stub on the pinned transport rev — toy world, reference model, the six
 validators, client driver, quiescence-gated gauge audit; CT-1 smoke green — GAP-14
 closed 2026-07-17). CT-1 exercises only success paths, so validators 1–5 run on every
-response and the 6th (error-envelope) is defined but not yet exercised.
+response there; the 6th (error-envelope) is exercised by CT-2, the sole path by which it
+reads an error code.
 **CT-2 has started**: the worker stub is now a DC-1 fault injector (wrong-range both
 directions, bad signature, server-error and not-found verdicts) shared across workers so
 a fault lands wherever the portal routes, and `Fixture` boots the whole stub world for
-any class that needs it. `ct2_worker_faults` covers the worker-fault reroute rows and the
+any class that needs it. Caveat: production workers pin a newer transport rev whose
+server was rewritten (stream-based accept with silent drop at buffer capacity); the stub
+speaks the portal's older pinned rev, so the production server's drop paths are not
+exercised — re-verify on the next dependency bump. `ct2_worker_faults` covers the worker-fault reroute rows and the
 exhaustion split; the rest of CT-2 and CT-3..CT-9 remain to be built per the build order.
 Coverage outside those two classes is still inline unit tests.
+Both suites run on every pull request: the harness is a separate crate, so it needs a
+build of the portal and a job of its own — a status this document cites has to be one
+something re-checks.
 
 ## Harness architecture
 
@@ -120,10 +127,11 @@ chunk-boundary records FV-6 licenses.
    ∈ {network, real_time}; the coverage cursor — the last delivered record — agrees with
    the ledger (INV-24, INV-13, DEF-8, INV-29). 204 EMPTY carries head markers, and a source marker iff a source was
    selected (retention-gap case). Pre-routing failures have no source marker.
-6. Errors: type/code ∈ DEF-10; hint iff OVERLOADED — present on proxied overloads too,
-   preserved or injected at the floor (ADR-014); no data alongside errors (INV-26).
+6. Errors: type/code ∈ DEF-10; a hint on every OVERLOADED — on proxied ones too,
+   preserved or injected at the floor — never on DATA-UNAVAILABLE, and on no other class
+   unless the upstream sent one (ADR-014); no data alongside errors (INV-26).
 
-## Traceability matrix — properties (2026-07-25)
+## Traceability matrix — properties (2026-07-27)
 
 | Property | CT | Status | Note |
 |---|---|---|---|
@@ -138,13 +146,13 @@ chunk-boundary records FV-6 licenses.
 | INV-20 | CT-1 | P | exactly-once regression + ordering units; CT-1 smoke oracle-diffs toy-world streams; controller property test asserts gapless/monotonic/no-duplicate emission under randomized scheduling adversity |
 | INV-21 | CT-1/2 | P | bounds validator green on smoke responses; wrong-range worker responses are now rejected at the source seam and CT-2 proves they are never delivered; randomized worlds are controller-level only |
 | INV-22 | CT-1/2 | P | smoke diffs delivered records against the stub ledger (signed responses); CT-2 now drives the rejection path — wrong-range (both directions) and bad-signature responses are discarded, rerouted, and byte-identical output is delivered from another worker |
-| INV-23 | CT-2 | P | verdict parsing tested; flow untested; minimum 409 payload meets the invariant; richer ancestors remain a REQ-3 SHOULD shortfall (GAP-7); EMPTY-precedence at the head unverified (GAP-19) |
+| INV-23 | CT-2 | P | verdict parsing tested; flow untested; minimum 409 payload meets the invariant; richer ancestors remain a REQ-3 SHOULD shortfall (GAP-7); EMPTY-precedence at the head unverified (GAP-19); verdict detection is exact-string parsing of worker messages (GAP-25) |
 | INV-24 | CT-5 | P | smoke asserts head markers against stub/artifact heads on success paths |
 | INV-25 | CT-2 | U | truncation never exercised |
-| INV-26 | CT-5 | P | **Known-violated** — current master still emits legacy/mixed and proxied error bodies (GAP-16); ADR-011 target is not yet integrated |
+| INV-26 | CT-5 | C | CT-5 asserts the envelope, status, type/code and hint presence across the local and proxied emitters, including the 409 sibling, the OVERLOADED hint floor, replacement of an unusable upstream hint (0, non-numeric, HTTP-date), the classes that get no invented hint (upstream 503/500), a wrong verb keeping 405 with its `Allow`, and normalization of the router's other rejections |
 | INV-27 | CT-1 | P | gap detection tested; proxied 204 smoke-tested; delay untested |
 | INV-28 | CT-3 | U | — |
-| INV-29 | CT-1 | P | boundary emission asserted by the CT-1 selective-tail resume on both sources; the network multi-chunk case exercises the per-chunk granularity FV-6 licenses. Interior boundary records are not audited, and the EMPTY case (no block evaluated) is untested |
+| INV-29 | CT-1 | P | boundary emission asserted by the CT-1 selective-tail resume on both sources; the network multi-chunk case exercises the per-chunk granularity FV-6 licenses. Interior boundary records are not audited, and the EMPTY case (no block evaluated) is untested. Boundary pinning is a worker-engine behavior — re-prove before adopting new engine/format fields on a dependency bump |
 | INV-30 | CT-3/7 | U | gauge accounting was a past defect class |
 | INV-31 | CT-2 | P | shutdown flip e2e-tested; other conjuncts not; *known-violated* on staleness intent (GAP-2) |
 | INV-35 | CT-8 | U | — |
@@ -164,7 +172,7 @@ chunk-boundary records FV-6 licenses.
 | FM-3 | CT-2/3 | U | per-dependency confinement never exercised: no outage tests (REQ-25), no isolation swarm (INV-35) |
 | SLI-1..SLI-6 | CT-6 | U | no benchmarks; baselines from incidents only |
 
-## Acceptance matrix — requirements (2026-07-25)
+## Acceptance matrix — requirements (2026-07-27)
 
 | REQ | Status | Note |
 |---|---|---|
@@ -176,10 +184,10 @@ chunk-boundary records FV-6 licenses.
 | REQ-6 | U | Truncation never exercised (INV-25) |
 | REQ-7 | U | No tests over the rejection table (INV-10) |
 | REQ-8 | U | Clamping untested; params ignored (GAP-8, INV-11) |
-| REQ-9 | P | Non-ASCII id regression; response echo e2e-tested by the smoke — which found the propagate layer attached to the empty router (dead); fixed 2026-07-17. Upstream propagation untested |
+| REQ-9 | P | Non-ASCII id rejection regression; response echo e2e-tested by the smoke — which found the propagate layer attached to the empty router (dead); fixed 2026-07-17. Upstream propagation untested |
 | REQ-10, REQ-11 | P | Catalog listing + archival head (number and hash) asserted by the smoke |
 | REQ-12 | U | — |
-| REQ-13 | P | Direction/fallback units exist, but timestamp overload mapping and the ADR-011 envelope are not integrated (GAP-4, GAP-16) |
+| REQ-13 | P | The ADR-011 envelope is integrated on the timestamp surface; a classified refusal reaches the client whole (529 with its hint, or 503 `no_workers`) rather than flattened, and a real-time refusal runs through the same upstream classifier the stream proxy uses, so a 429 stays an overload with its hint instead of surfacing as a 500. A local upstream failure answers 502 per IB-5; the beyond-frontier 404 remains (GAP-4) |
 | REQ-14 | P | Internal-endpoint hiding tested |
 | REQ-15 | P | Plan extraction/rewrite units; no e2e |
 | REQ-20 | P | **Known-violated** — cap exhaustion is not exercised and current master misclassifies it (GAP-4); taxonomy target is GAP-16 |
@@ -195,12 +203,12 @@ chunk-boundary records FV-6 licenses.
 | REQ-32 | P | Internal hiding tested; drift (GAP-11) |
 | REQ-33 | C | Config warn/reject/defaults tested |
 | REQ-40 | P | Variant selection tested; effective-time & outage untested (INV-2, LIV-6); regression guard unimplemented (GAP-20) |
-| REQ-41 | P | FV-2 attempt bound ledger-checked by the smoke; CT-2 exercises reroute-on-failure and penalty decay (LIV-7). **Known-violated**: a generic worker server-error is classified terminal, so one erroring worker fails the request instead of rerouting (GAP-23). Cooldown durations and priority-group selection remain untested |
+| REQ-41 | P | FV-2 attempt bound ledger-checked by the smoke; CT-2 exercises reroute-on-failure and penalty decay (LIV-7) across five verdicts, the two capacity ones included — an exhausted run of those answers OVERLOADED with its hint rather than a bare transient outage. **Known-violated**: a generic worker server-error is classified terminal, so one erroring worker fails the request instead of rerouting (GAP-23). Cooldown durations and priority-group selection remain untested |
 | REQ-42 | P | Scheduler units; headroom refusal untested (INV-4, LIV-8), and its observable — shrink cause, download utilization, headroom-refusal counter (OB-7) — is unasserted |
 | REQ-43 | P | Positive path exercised by the smoke (signed stub responses verified and delivered); CT-2 now drives the rejection path — a wrongly-signed response is not delivered and the attempt is retried elsewhere, meeting the acceptance criterion. Integrity failures are counted per worker but raise no OB-9 alarm state (GAP-24) |
 | REQ-44 | U | — |
 
-## Gap register — 2026-07-25
+## Gap register — 2026-07-27
 
 Priorities: P0 blocks the program · P1 active production risk · P2 correctness hole
 with plausible trigger · P3 polish. "Next" = cheapest failing-test-first entry.
@@ -210,7 +218,7 @@ with plausible trigger · P3 polish. "Next" = cheapest failing-test-first entry.
 | GAP-1 | Assignment artifact adopted with no structural validation; a corrupt blob can panic the refresh path or leave the Portal ready on garbage routing | REQ-26, INV-36, FM-2 (ADR-002) | P1 | CT-2: truncated-artifact stub → assert reject + alarm + prior artifact kept |
 | GAP-2 | Artifact staleness unbounded and invisible: fetch failures log-only; readiness ignores age | REQ-23/40, INV-31 ⚠, LIV-12, OB-6/9 (ADR-013, OQ-3) | P1 | age gauge; readiness-degradation test past P-ASSIGNMENT-MAX-AGE |
 | GAP-3 | Refresh holds old + new artifacts resident (HZ-1, ~2× P-ASSIGNMENT-SIZE) and first-byte waits are unmetered (HZ-2). Baseline: 2026-07-17 OOM-kill restart storm on 0.11.8 | REQ-27, PF-1, SLI-5 (OQ-4) | P1 | RSS-during-refresh probe under S4; heap profile to pin the dominant term |
-| GAP-4 | Current master does not implement the stream-cap refusal contract: cap exhaustion yields a 503/no mandatory hint, timestamp handling does not preserve the overload outcome, and a beyond-frontier timestamp still returns 404 where ADR-014 fixes it as the 204 EMPTY outcome | REQ-20, REQ-13, INV-12, PF-6 | P1 | CT-3: occupy P-MAX-STREAMS; assert 529 + hint and admitted-stream integrity |
+| GAP-4 | Current master does not implement the stream-cap refusal contract: cap exhaustion yields a 503/no mandatory hint, and a beyond-frontier timestamp still returns 404 where ADR-014 fixes it as the 204 EMPTY outcome. The timestamp surface no longer flattens the overload outcome — it carries the classified refusal whole, so a congested resolve answers 529 with its hint rather than 503 `upstream_unavailable` | REQ-20, REQ-13, INV-12, PF-6 | P1 | CT-3: occupy P-MAX-STREAMS; assert 529 + hint and admitted-stream integrity |
 | GAP-5 | Latent panic on an empty stream ("first chunk missing") — known trigger fenced only | REQ-21, INV-36 | P2 | replace panic with error; empty-yield test |
 | GAP-6 | Worker-labeled metric cardinality and name interning grow without eviction | REQ-30, OB cardinality rule, HZ-6 | P2 | CT-7 series-count audit across churn |
 | GAP-7 | Archival-path CONFLICT payload has only one entry. It meets the REQ-3/INV-23 MUST minimum but not REQ-3's richer-ancestor SHOULD | REQ-3 SHOULD | P2 | CT-5 contract test on the 409 body |
@@ -219,7 +227,8 @@ with plausible trigger · P3 polish. "Next" = cheapest failing-test-first entry.
 | GAP-11 | Served API description drift: undocumented route/header, stale examples, size-doc conflict | REQ-32, IB-2/4 | P3 | CT-5 description-vs-router sweep |
 | GAP-12 | Download-priority key wraps at ~43 M streams (HZ-4) | REQ-42 fairness | P3 | widen key; wrap-boundary unit test |
 | GAP-13 | ADR-009 accepted but portal-side injection unimplemented — decision drift | OQ-5 | P3 | schedule or supersede |
-| GAP-16 | Current master exposes legacy/mixed error bodies and passes real-time error bodies through. ADR-011's closed type/code envelope is not integrated; its 409 and readiness exceptions also need CT-5 proof against IB-5 when the taxonomy change lands, together with ADR-014's amendments (proxied-hint injection, unmatched-4xx normalization, EMPTY head metadata, integrity-exhaustion WORKER-FAILURE) | DEF-10, INV-26, IB-5, REQ-7/13/20 | P1 | CT-5 table-driven local + proxied error-shape/status tests |
+| GAP-16 | ADR-011's envelope is integrated and CT-5-covered on both emitters, with proxied-hint injection and clamping, unmatched-4xx normalization to 400, upstream bodies neither published nor read, framework rejections normalized at the middleware onto their bound status and with their endpoint label preserved, one upstream classifier shared by the stream proxy and the timestamp route, and `/ready` declining with the IB-6 envelope. Responses that never reach the routed middleware are normalized, logged and counted by an outer layer — an unmatched *route*, which a `route_layer` cannot see, and the decompression layer's 415, which every encoding but `gzip` earns — under a constant `endpoint` label, the path being client-supplied there. Remaining: EMPTY head metadata from ADR-014; and an unmatched proxied 4xx is indistinguishable from a genuine 400 on the metric, so there is no signal for an upstream returning a status the Portal does not model | INV-26, OB-3, REQ-13 | P2 | ADR-014 remainder |
+| GAP-28 | A proxied 409 whose body carries no usable `previousBlocks` — absent, empty, wrong-shaped, or past the read cap — still answers 409. The list is now typed and non-empty, so nothing unusable is published, and the refusal is logged at `error`; but the client receives a status IB-5's normative recovery procedure cannot be run against. Refusing it as `unclassified` instead is the open contract call | IB-5, INV-23, REQ-3 | P2 | decide the status; CT-5 already pins the current shape |
 | GAP-17 | Count caps imply a multi-terabyte theoretical buffer ceiling and no global byte budget or accounting exists; the congestion waiter queue is unbounded on the same path (HZ-9) | REQ-27, PF-1, OQ-9 | P1 | add byte meter/admission test; set P-BUFFERED-BYTES-BUDGET |
 | GAP-18 | Chain-RPC calls have no explicit deadline despite accepted ADR-010 | REQ-22, DC-5, HZ-8 | P2 | stalled-RPC stub → assert bounded call and loop recovery |
 | GAP-19 | Conflict detection is not known to precede the beyond-frontier EMPTY: a real-time continuation at the head with a stale parent may poll empty instead of getting 409 (the pre-ADR-014 oracle ordered EMPTY first; master unverified) | REQ-3, INV-23, INV-27 (ADR-014) | P2 | CT-2: reorg-at-head stub world → assert 409 precedence |
@@ -228,6 +237,9 @@ with plausible trigger · P3 polish. "Next" = cheapest failing-test-first entry.
 | GAP-22 | Pre-first-byte outcomes of the real-time source now have one denominator in `hotblocks_requests`, but no objective. `response` and `replay_response` obtained a response head; `replay_failed`, `timeout`, and `transport_failed` did not; cancellation remains visible without inventing an upstream result. SLI-4 is readiness availability and excludes deploys, SLI-6 counts truncated streams, and neither turns this counter into a request-success SLI | SLI set, OB-4 (ADR-015) | P2 | define a DC-4 response-head SLI over `hotblocks_requests`, with cancellations explicitly included or excluded by policy |
 | GAP-23 | A generic worker `ServerError` verdict is classified terminal, so the first erroring worker fails the whole request with no reroute — while `NotFound` and `ServerOverloaded` from the same worker *are* rerouted. DC-1 and the 09 worker table both put server errors in the reroute column. Found by the CT-2 injector on 2026-07-25; recorded as known-violated in `ct2_worker_faults` | REQ-41, DC-1, FM-3, LIV-12 | P1 | reclassify as retriable and drop the case from CT-2's known-violated list; the risk to weigh is added load on a fleet that is erroring |
 | GAP-24 | Integrity failures are counted per worker (`query_results{status="integrity"}`) but raise no alarm *state*: OB-9 lists signature-verification failures as an alarm, and FM-2 requires integrity faults to be "rejected and alarmed". A fleet quietly serving wrong-range data is visible only to someone already looking at the counter | OB-9, FM-2, REQ-43 | P2 | add the OB-9 alarm state over the integrity counter; assert the edge event in CT-2 |
+| GAP-25 | DC-1's parent-hash-mismatch and oversized-result verdicts are detected by exact-string parsing of worker `server_error` messages (`unexpected base block: …`, `Response too large`); the worker contract declares message strings unstable, and the worker's second oversize string (`query result too large`) already misses the parse and lands in the terminal generic-failure path (GAP-23). Blocked on a stable worker-side verdict surface (tracked in the worker suite: `worker-rs/spec/13`, anchor-verdict gap) | DC-1, REQ-3, INV-23 | P2 | CT-2: worker stub emits a reworded mismatch string — today the client gets a terminal error instead of 409; flips to a hard gate when the stable surface lands |
+| GAP-26 | No aggregate deadline bounds a worker attempt: connect is a 10 s crate default (P-WORKER-CONNECT-TIMEOUT, not operator-bound), first byte 60 s, and the body is read in 1 s-stall-bounded reads with no total bound — DC-1's single "request deadline P-TRANSPORT-TIMEOUT" is not what runs, and the transport's `request_timeout` is set but unused on this path | DC-1, REQ-22, HZ-2 | P2 | stub worker trickles a body at just under the per-read stall bound indefinitely; assert the attempt is bounded |
+| GAP-27 | Penalty classification diverges from ADR-004's cost rationale: an instant stream reset (the worker's documented flood-shed posture) draws the 300 s timeout-class cooldown plus a congestion signal, and integrity penalties are split (bad signature 300 s vs undecodable/wrong-range 30 s) though DC-1 treats them as one class — a brief worker-side flood can push the whole pool to AllUnavailable | REQ-41, DC-1, LIV-7 | P2 | CT-2: instant-reset injector; assert the cooldown class matches observed cost and the pool recovers within the error-cooldown window |
 
 ### Closed findings
 

--- a/spec/14-interface-binding.md
+++ b/spec/14-interface-binding.md
@@ -5,9 +5,13 @@ encodings — as *observable contract*, still no internals. **Anything not speci
 here is unspecified: clients and tests must not pin it** (IB-8).
 
 **IB-1 — Transport generalities.** HTTP/1.1+; permissive CORS (any origin/method/
-header). Request bodies may be gzip-compressed. Every response carries `x-request-id`
-(client's value echoed verbatim if supplied — any bytes tolerated, REQ-21 — else a
-generated UUID). Stream responses are chunked `application/jsonl`, compressed:
+header), exposing `Retry-After`, `x-request-id` and the `x-sqd-*` stream metadata —
+allowing an origin does not make a response header readable, and the CORS-safelisted set
+contains none of ours, so a browser client would otherwise see the status and nothing
+else. Request bodies may be gzip-compressed. Every response carries `x-request-id`
+(client's value echoed verbatim when it is ASCII; a non-ASCII value is rejected with
+400 `malformed_request` and a generated UUID; an absent value also gets a generated
+UUID). Stream responses are chunked `application/jsonl`, compressed:
 `Content-Encoding: gzip` by default, `zstd` when the client offers it via
 `Accept-Encoding` (or `X-Forwarded-Accept-Encoding`).
 
@@ -63,23 +67,29 @@ ADR-011. Completion vs truncation is not distinguished in-band (ADR-001, OQ-2).
 
 **IB-5 — Error mapping.** Each body-bearing error uses the ADR-011 envelope
 `{"error":{"type":…, "code":…, "message":…, "param"?:…, "request_id"?:…}}`.
-`message` is not stable; clients match `type` and `code`. The exact closed mapping is:
+`message` is not stable; clients match `type` and `code`. `request_id` appears on 5xx
+only; every response carries the same id as `x-request-id` (REQ-9, ADR-011). The exact
+closed mapping is:
 
 | Wire `type` / `code` | Status | Body / headers |
 |---|---|---|
 | `invalid_request_error` / `malformed_request` | 400 | envelope; `param` only for parameter validation |
+| `invalid_request_error` / `method_not_allowed` | 405 | envelope; `Allow` preserved. The one rejection status that is *not* normalized to 400: the request is well-formed, the verb is the fault, and `Allow` is the recovery a 400 has nowhere to carry |
 | `invalid_request_error` / `unknown_dataset` | 404 | envelope |
 | `invalid_request_error` / `not_found` | 404 | envelope |
-| `invalid_request_error` / `base_block_mismatch` | 409 | envelope plus top-level `previousBlocks` (≥ 1 entry, ascending, ending at the parent height; archival path currently lacks the richer-ancestor SHOULD — GAP-7) |
-| `availability_error` / `no_data` | 204 | no body; head-marker headers per IB-4; after ≥ P-NO-DATA-DELAY. Also the beyond-frontier outcome of OP-5 (ADR-014) |
-| `rate_limit_error` / `overloaded` | 529 for Portal-local refusal; a proxied 429/503/529 retains its public status | `Retry-After` always present and ≥ P-RETRY-AFTER-MIN (INV-26): Portal-set locally, preserved from the upstream when proxied, injected at P-RETRY-AFTER-MIN when the upstream omitted it (ADR-014); other public upstream headers preserved |
+| `invalid_request_error` / `base_block_mismatch` | 409 | envelope plus top-level `previousBlocks` (≥ 1 entry, ascending, ending at the parent height; archival path currently lacks the richer-ancestor SHOULD — GAP-7). A proxied list is typed and non-empty or it is not published at all (GAP-28) |
+| `rate_limit_error` / `overloaded` | 529 for Portal-local refusal; a proxied 429/529 retains its public status | `Retry-After` always present and ≥ P-RETRY-AFTER-MIN (INV-26): Portal-set locally, preserved from the upstream when proxied *and* readable as seconds at or above the floor, replaced at P-RETRY-AFTER-MIN otherwise — omitted, `0`, non-numeric, or the RFC's HTTP-date form, which this header is not documented to carry (ADR-014); other public upstream headers preserved |
 | `availability_error` / `no_workers` | 503 | envelope; no `Retry-After` |
 | `availability_error` / `retries_exhausted` | 503 | envelope |
-| `availability_error` / `upstream_unavailable` | 502 for a local upstream failure; proxied upstream failures retain their status | envelope; public upstream headers retained |
+| `availability_error` / `upstream_unavailable` | 502 for a local upstream failure; proxied upstream failures retain their status, **503 among them** — it is unavailability, not congestion (ADR-007, ADR-014) | envelope; public upstream headers retained, a `Retry-After` the upstream sent included; none is invented, since a hint on a dependency that is down rather than busy just aims the client back at it. A refusal the Portal already classified is carried whole, not re-labelled here: capacity and congestion are the Portal's own faults, not the upstream's |
 | `availability_error` / `not_ready` | 503 | envelope |
 | `api_error` / `worker_failure` | 500 | envelope |
 | `api_error` / `internal_error` | 500 | envelope |
 | `api_error` / `unclassified` | contextual 5xx | envelope; must be counted and investigated |
+
+EMPTY (204) is not in this table: it is a success, not a refusal, and carries no
+`type`/`code`. It is bound by IB-4 — no body, head-marker headers, emitted after
+≥ P-NO-DATA-DELAY, and the beyond-frontier outcome of OP-5 (ADR-014).
 
 Client recovery from 409 (normative): scan `previousBlocks` newest-first for the last
 block also on the client's chain; re-request from its number + 1 with its hash as

--- a/spec/15-parameters.md
+++ b/spec/15-parameters.md
@@ -27,7 +27,8 @@ assumes, not knobs it owns.
 
 | Parameter | Role (where used) | Observed | Target |
 |---|---|---|---|
-| P-TRANSPORT-TIMEOUT | Worker query request deadline (REQ-41) | 60 s | 60 s |
+| P-TRANSPORT-TIMEOUT | Worker query request deadline (REQ-41); binds first-byte wait — an aggregate per-attempt bound is intent, not implemented (GAP-26) | 60 s | 60 s |
+| P-WORKER-CONNECT-TIMEOUT | Worker stream connect deadline — transport crate default, not operator-bound today (GAP-26) | 10 s | 10 s |
 | P-HOTBLOCKS-CONNECT-TIMEOUT | Real-time source connect deadline (REQ-22) | 1 s | 1 s |
 | P-HOTBLOCKS-READ-TIMEOUT | Real-time source per-read deadline; must stay < P-CLIENT-TIMEOUT (REQ-22, ADR-010). A replayed request spends it twice (ADR-015) | 20 s | 20 s |
 | P-CLIENT-TIMEOUT | *Environmental:* the request deadline callers default to (ADR-010) | 30 s | ≥ 30 s assumed |
@@ -88,7 +89,7 @@ assumes, not knobs it owns.
 |---|---|---|---|
 | P-SLO-STREAM-TTFB-P99 | ⚠ Stream time-to-first-byte p99 (SLI-1, S1) | unmeasured | ⚠ 5 s (draft) |
 | P-SLO-METADATA-TTFB-P99 | ⚠ Head/metadata time-to-first-byte p99 (SLI-1, S1) | unmeasured | ⚠ 1 s (draft) |
-| P-SLO-REFUSAL-CORRECTNESS | Refusals with correct ADR-011 code and required hint (SLI-3) | **violated** — bare 503s at 314 rps in the 2026-07 storm; ADR-011/012 integration pending on master (GAP-4/GAP-16) | 100% (INV-26) |
+| P-SLO-REFUSAL-CORRECTNESS | Refusals with correct ADR-011 code and required hint (SLI-3) | ADR-011 integrated and CT-5-gated: every refusal carries a code, and OVERLOADED carries a hint at or above the floor on both emitters. Capacity exhaustion at every layer — cap refusal, worker backoff, and an exhausted run of worker capacity verdicts — answers 529 with a hint | 100% (INV-26) |
 | P-SLO-AVAILABILITY | ⚠ Monthly readiness availability (SLI-4) | unmeasured | ⚠ 99.9% (draft) |
 | P-SLO-MEMORY-HEADROOM | ⚠ Peak RSS / P-MEMORY-BUDGET cap (SLI-5) | unmeasured | ⚠ 0.8 (draft) |
 | P-SLO-COMPLETION-INTEGRITY | ⚠ Complete stream fraction (SLI-6, S1) | unmeasured | ⚠ 0.99 (draft) |

--- a/spec/decisions/ADR-011-error-taxonomy.md
+++ b/spec/decisions/ADR-011-error-taxonomy.md
@@ -22,10 +22,16 @@ specific `code` for client handling.
 | `availability_error` | yes | Data or a dependency is temporarily unavailable | no |
 | `api_error` | no | A Portal-owned invariant failed | yes |
 
-The closed code vocabulary is `malformed_request`, `unknown_dataset`, `not_found`,
-`base_block_mismatch`, `no_data`, `overloaded`, `no_workers`, `retries_exhausted`,
-`upstream_unavailable`, `not_ready`, `worker_failure`, `internal_error`, and
-`unclassified`. A code has exactly one type; its status mapping is fixed by IB-5.
+The closed code vocabulary is `malformed_request`, `method_not_allowed`,
+`unknown_dataset`, `not_found`, `base_block_mismatch`, `overloaded`, `no_workers`,
+`retries_exhausted`, `upstream_unavailable`, `not_ready`, `worker_failure`,
+`internal_error`, and `unclassified`. A code has exactly one type; its status mapping is
+fixed by IB-5.
+
+The taxonomy covers failures only. A 204 is the correct answer to a range that is not
+produced yet, so it has no `type` and no `code`: it carries no body, so a code could
+never reach a client, and on the metric it would only have restated `status="204"` while
+making the steady state of every polling client read as an `availability_error`.
 
 Every body-bearing error uses this envelope:
 
@@ -42,18 +48,98 @@ Every body-bearing error uses this envelope:
 ```
 
 `message` is unstable prose. `param` and `request_id` are optional. A 204 response is
-bodyless. A 409 response keeps `previousBlocks` at the top level and adds the `error`
-object beside it, preserving the recovery contract.
+bodyless and untyped. A 409 response keeps `previousBlocks` at the top level and adds
+the `error` object beside it, preserving the recovery contract.
 
-For proxied real-time errors, the Portal classifies the upstream response by status,
-rewrites the body into this envelope, and preserves public upstream headers. Successes
-and 204 remain streaming pass-through under ADR-003. The source marker records that the
-error originated on the real-time path; upstream implementation-specific codes and
-bodies are not public Portal API.
+`request_id` is emitted on 5xx only. Every response carries it as `x-request-id`
+regardless (REQ-9); the body copy exists for the support flow, where a user pastes JSON
+and loses the headers. A 4xx is the client's own fault and is handled programmatically —
+a 409 is a routine reorg resolved from `previousBlocks` — so nobody opens a ticket
+holding one, and the copy would cost a re-render of the whole body, siblings included.
+
+One renderer builds this body for both emitters — locally produced errors and rewritten
+upstream ones. That is a correctness requirement, not a tidiness one: the two emitters
+previously drifted, and 409, the one status carrying a top-level sibling, is served by
+both data sources.
+
+For proxied real-time errors, the Portal classifies the upstream response by status and
+rewrites the body into this envelope, preserving public upstream headers. One classifier
+serves every surface that talks to the real-time source, not just the stream proxy: an
+upstream status cannot mean one thing on `/stream` and another on the timestamp route. The upstream's
+own body is never published — its prose is not public API and can name instances, paths
+and internal ids — and the envelope carries the code's own message instead.
+
+The body is not read either, on any status but 409. Nothing consumes it: an upstream
+server error is already logged with the pod that served it, and the upstream logs its own
+failures in full, so copying a fragment here would duplicate diagnostics that already
+exist where they are complete — while buffering an unbounded body would let an upstream
+fault size Portal memory. `previousBlocks` on a 409 is the one upstream field that
+survives, because clients walk it to recover, and it is the only reason to read at all.
+
+That field is parsed into a non-empty typed list, not forwarded as whatever value sits
+under the key. It is the one place an upstream can put bytes in front of a client, so an
+upstream must not be able to put something else there — a scalar, an empty list, internal
+data — and an empty list strands the client exactly as a missing one does. A body past
+the read cap is refused rather than truncated: half a chain slice would resume the client
+from an ancestor that is not the deepest one. A 409 left with no usable list is not a
+legal 409 under IB-5 and is indistinguishable from a healthy reorg on the wire and on the
+metric, so it is logged at `error` — the only witness. Whether it should instead be
+refused as `unclassified` is open (GAP-28).
+
+Successes and 204 remain streaming pass-through under ADR-003. The source marker records
+that the error originated on the real-time path; upstream implementation-specific codes
+and bodies are not public Portal API.
+
+### Field casing
+
+Envelope keys are snake_case: `request_id` is the only multi-word one, and it matches the
+other Portal-emitted fields (`portal_version`, `start_block`, `block_number`). `code` and
+`type` values are identifiers rather than prose and double as metric label values, where
+snake_case is the convention.
+
+`param` is the exception by construction — it echoes the offending field's wire name
+exactly as the client sent it, so snake_case for query parameters (`buffer_size`) and
+camelCase for body fields (`fromBlock`). It points into the request rather than following
+a convention of its own — so an otherwise snake_case `error` object can carry
+`"param": "fromBlock"`, and a 409 sets `previousBlocks` beside it. That is compatibility,
+not design.
+
+**Unsettled.** None of this ratifies a casing convention for the API. It records what
+Portal-owned JSON does today, not a decision that it should stay. Do not cite it as
+precedent when adding fields elsewhere; settling the question is a breaking change owed
+its own migration.
+
+## Observability
 
 Metrics use the same `error_type` and `error_code` values. An error reaching the
 middleware without a classification is `unclassified`; an unmatched 4xx is treated as
 an invalid request, while an unclassified 5xx remains an `api_error` so it cannot hide.
+
+Errors the router raises before a handler runs — a path segment that will not parse, an
+unreadable query, an over-limit body — are rebuilt into the envelope at the middleware
+rather than at each extractor. A bad path parameter is the commonest client mistake there
+is, so "one envelope on every endpoint" is false without it, and converting call sites
+one at a time leaves the next one to be found by a client. A 4xx is named
+`malformed_request` and answers **400**: the code→status mapping above is closed, so a
+rejection the framework happened to answer with 413 or 415 cannot keep that status while
+claiming a code bound to 400 — the specifics stay in `message`. A 5xx keeps
+`unclassified` and its status, and still pages, since the router failing on its own is
+not the client's fault to name.
+
+A wrong verb on an existing route is the exception, and gets its own code bound to
+**405**. Folding it into `malformed_request` would be wrong on both axes: the request is
+well-formed, and the answer is `Allow`, which a 400 has nowhere to carry. It is also the
+one rejection the framework raises with an empty body, so the collapsed form left the
+client holding a bare "Bad request" — the shape this taxonomy replaced.
+
+The rebuilt response carries the original's extensions, not only its headers: the
+endpoint label lives there, and without it the metric falls back to the raw request path,
+which on a rejection is client-supplied. A malformed dynamic path would then mint an
+`endpoint` label per request.
+
+`doc_url` is deliberately omitted from the envelope. It is the remaining field worth
+adding once per-code documentation pages exist; the codes are stable, so the URLs are
+derivable then without a second migration.
 
 ## Consequences
 

--- a/spec/decisions/ADR-014-contract-reconciliation.md
+++ b/spec/decisions/ADR-014-contract-reconciliation.md
@@ -13,10 +13,19 @@ are recorded here so the immutable docs can change under the suite's own rules.
 ## Decisions
 
 1. **Proxied overload responses always carry a retry hint.** ADR-012's rule is
-   universal: when the real-time upstream returns 429/503/529 without `Retry-After`,
+   universal: when the real-time upstream returns 429 or 529 without `Retry-After`,
    the Portal injects `Retry-After: P-RETRY-AFTER-MIN` while otherwise preserving
    public upstream headers. A hint-less proxied overload would re-create the 2026-07
    refusal storm on the real-time path. (INV-26, DC-4, IB-5.)
+
+   An upstream **503 is not in that set**: ADR-007 reserves 503 for genuine
+   unavailability and gives congestion its own status, and that line holds whether the
+   saturated party is us or a dependency. Classifying it as `overloaded` asserted
+   exhausted capacity of a source that may have none running, made a dead dependency
+   read on the metric exactly like a healthy one shedding load — neither pages, so the
+   counter was the only difference — and invented a hint aiming the client back into it.
+   A 503 is `upstream_unavailable`; a `Retry-After` the upstream sent is still forwarded
+   as the public header it is. (ADR-007, DC-4, IB-5.)
 
 2. **Conflict detection precedes the beyond-frontier EMPTY outcome.** In real-time
    mode, a parent hash whose height is at or below the frontier is validated before

--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -46,8 +46,8 @@ use crate::{
     controller::timeouts::TimeoutManager,
     network::{ChunkNotFound, NetworkClient, NoWorker, QueryResult, StreamingNetwork, WorkerLease},
     types::{
-        BlockRange, ChunkId, DataChunk, QueryError, RequestError, ResponseChunk, SendQueryError,
-        StreamRequest,
+        BlockRange, ChunkId, DataChunk, ErrorCode, ExhaustionClass, QueryError, RequestError,
+        ResponseChunk, SendQueryError, StreamRequest,
     },
     utils::{logging::StreamStats, SlidingArray},
 };
@@ -193,7 +193,7 @@ impl<N: StreamingNetwork> StreamController<N> {
             }
             Err(e) => {
                 // Should not be the case under normal operation
-                return Err(RequestError::InternalError(format!(
+                return Err(RequestError::Internal(format!(
                     "block {} could not be found in dataset {} ({e}), please report this to the developers",
                     first_block, request.dataset_id
                 )));
@@ -387,22 +387,27 @@ impl<N: StreamingNetwork> StreamController<N> {
                             running.worker,
                             join_err,
                         );
-                        return Err(RequestState::Done(Err(RequestError::InternalError(
-                            format!("worker query task failed: {join_err}"),
-                        ))));
+                        return Err(RequestState::Done(Err(RequestError::Internal(format!(
+                            "worker query task failed: {join_err}"
+                        )))));
                     }
                 };
-                let response = check_response_range(response, &data_range.range);
-                if let Err(QueryError::Integrity(reason)) = &response {
-                    tracing::warn!(
-                        "Discarding invalid response for range {}-{} from worker {}: {}",
-                        data_range.range.start(),
-                        data_range.range.end(),
-                        running.worker,
-                        reason,
-                    );
-                    self.network.report_integrity_failure(running.worker);
-                }
+                // Only what this layer rejects: the network reports its own, so
+                // reporting every `Integrity` counted a bad signature twice.
+                let response = match wrong_range(&response, &data_range.range) {
+                    Some(reason) => {
+                        tracing::warn!(
+                            "Discarding invalid response for range {}-{} from worker {}: {}",
+                            data_range.range.start(),
+                            data_range.range.end(),
+                            running.worker,
+                            reason,
+                        );
+                        self.network.report_integrity_failure(running.worker);
+                        Err(QueryError::Integrity(reason))
+                    }
+                    None => response,
+                };
 
                 if retriable(&response) {
                     tracing::debug!(
@@ -459,27 +464,36 @@ impl<N: StreamingNetwork> StreamController<N> {
 
     fn all_attempts_failed(pending: &mut PendingRequests) -> RequestState {
         let mut errors = Vec::with_capacity(pending.requests.len());
-        let mut all_integrity = true;
+        let mut classes = Vec::with_capacity(pending.requests.len());
         for request in pending.requests.drain(..) {
             let WorkerRequest::Finished(f) = request else {
                 unreachable!("all worker requests should be finished")
             };
             let error = f.result.unwrap_err();
-            all_integrity &= matches!(error, QueryError::Integrity(_));
+            classes.push(error.exhaustion_class());
             // Format from the QueryError directly so every attempt is labeled with its
             // worker. Going through RequestError would drop the peer id for variants whose
             // Display is a fixed string (e.g. RateLimitExceeded, BaseBlockMismatch).
             errors.push(format!("worker {}: {}", f.worker, error));
         }
-        let message = format!("All query attempts failed: {}", errors.join("; "));
-        // Every attempt equivocating means the network is serving bad data or
-        // verification is broken — an operator problem, not a transient outage,
-        // so it pages rather than reporting the data temporarily unavailable
-        // (DC-1). A mix of transient and integrity failures stays transient.
-        RequestState::Done(Err(if all_integrity {
-            RequestError::Failure(message)
-        } else {
-            RequestError::InternalError(message)
+        // A class is claimed only when every attempt agrees; a mixed run stays
+        // transient, and an empty one claims nothing.
+        let unanimous = classes
+            .first()
+            .copied()
+            .filter(|first| classes.iter().all(|c| c == first));
+        let message = errors.join("; ");
+
+        RequestState::Done(Err(match unanimous {
+            Some(ExhaustionClass::Integrity) => {
+                RequestError::Failure(format!("All query attempts failed: {message}"))
+            }
+            Some(ExhaustionClass::Capacity) => {
+                tracing::debug!("All query attempts refused for capacity: {message}");
+                RequestError::RateLimitExceeded
+            }
+            // RetriesExhausted prefixes the message itself.
+            _ => RequestError::RetriesExhausted(message),
         }))
     }
 
@@ -1089,28 +1103,21 @@ fn parse_response(
     state
 }
 
-/// A misbehaving worker may report a `last_block` outside the range it was
-/// asked for, in either direction. The data is an opaque compressed blob, so it
-/// can't be trimmed to the range without decompressing and re-encoding it — and
-/// the continuation range derived from such a `last_block` is inverted (past the
-/// end) or re-covers blocks the client already has (below the start). Reject the
-/// whole response as an integrity failure: it is discarded, never delivered, and
-/// the next reserved worker serves the range (DC-1).
-fn check_response_range(response: QueryResult, range: &BlockRange) -> QueryResult {
-    let Ok(success) = &response else {
-        return response;
-    };
-    let last_block = success.ok.last_block;
+/// Why a response falls outside the range this slot asked for, if it does.
+///
+/// The network rejects these at the source. This is the delivery boundary refusing to
+/// emit them (INV-21) whatever a [`StreamingNetwork`] hands it — unreachable in
+/// production, which is the point.
+fn wrong_range(response: &QueryResult, range: &BlockRange) -> Option<String> {
+    let last_block = response.as_ref().ok()?.ok.last_block;
     let bound = if last_block > *range.end() {
         format!("beyond the queried range end {}", range.end())
     } else if last_block < *range.start() {
         format!("below the first queried block {}", range.start())
     } else {
-        return response;
+        return None;
     };
-    Err(QueryError::Integrity(format!(
-        "worker returned last block {last_block} {bound}"
-    )))
+    Some(format!("worker returned last block {last_block} {bound}"))
 }
 
 fn retriable(result: &QueryResult) -> bool {
@@ -1129,7 +1136,9 @@ fn retriable(result: &QueryResult) -> bool {
 fn short_code(result: &RequestState) -> &'static str {
     match result {
         RequestState::Done(Ok(_)) => "ok",
-        RequestState::Done(Err(e)) => e.short_code(),
+        // NoData is the one variant with no code: a 204 is not a failure.
+        RequestState::Done(Err(RequestError::NoData)) => "no_data",
+        RequestState::Done(Err(e)) => e.code().map_or("-", ErrorCode::as_str),
         RequestState::Partial(_) => "partial",
         RequestState::Pending(_) | RequestState::Paused(_) | RequestState::NoWorkers => "-",
     }
@@ -1730,6 +1739,10 @@ mod tests {
         /// (first_block, last_block) of every response chunk, in emission order.
         emissions: Vec<(u64, u64)>,
         error: Option<String>,
+        /// What the client is actually told. The message is prose and carries a random
+        /// PeerId, so two runs differ whatever they were classified as — only the code
+        /// distinguishes an integrity exhaustion from a transient one.
+        code: Option<ErrorCode>,
     }
 
     struct ScenarioOutcome {
@@ -1747,6 +1760,7 @@ mod tests {
         let mut controller = StreamController::new(request, network, stream_index, 1).unwrap();
         let mut emissions = Vec::new();
         let mut error = None;
+        let mut code = None;
         while let Some(item) = controller.next().await {
             match item {
                 Ok(bytes) => {
@@ -1756,11 +1770,16 @@ mod tests {
                 }
                 Err(e) => {
                     error = Some(e.to_string());
+                    code = e.code();
                     break;
                 }
             }
         }
-        StreamOutcome { emissions, error }
+        StreamOutcome {
+            emissions,
+            error,
+            code,
+        }
     }
 
     fn run_scenario(scenario: &Scenario) -> ScenarioOutcome {
@@ -1929,20 +1948,22 @@ mod tests {
         let range = BlockRange::new(100, 150);
 
         for (last_block, case) in [(151, "overshoot"), (99, "undershoot")] {
-            let rejected = check_response_range(success(last_block), &range);
-            assert!(
-                matches!(rejected, Err(QueryError::Integrity(_))),
-                "{case} must become an integrity error"
-            );
+            let reason = wrong_range(&success(last_block), &range);
+            assert!(reason.is_some(), "{case} must be rejected");
+            let rejected: QueryResult = Err(QueryError::Integrity(reason.unwrap()));
             assert!(retriable(&rejected), "{case} must be rerouted");
         }
 
         for last_block in [100, 125, 150] {
             assert!(
-                check_response_range(success(last_block), &range).is_ok(),
+                wrong_range(&success(last_block), &range).is_none(),
                 "in-range response {last_block} must pass through"
             );
         }
+
+        // A failure the network already classified is not re-reported here.
+        let from_network: QueryResult = Err(QueryError::Integrity("bad signature".into()));
+        assert!(wrong_range(&from_network, &range).is_none());
     }
 
     /// Exhaustion class: transient failures report the data as temporarily
@@ -1978,6 +1999,12 @@ mod tests {
             2,
             "every discarded response must be counted against its worker"
         );
+        assert_eq!(
+            outcome.code,
+            Some(ErrorCode::WorkerFailure),
+            "an all-equivocating run is our bug to page on, not an outage to retry: {:?}",
+            outcome.error
+        );
 
         // One transient failure in the mix keeps the outcome transient.
         let mixed = scenario(vec![QueryEvent::Retriable, QueryEvent::Overshoot(5)]);
@@ -1986,10 +2013,81 @@ mod tests {
         let mixed_outcome =
             collect_stream(mixed.request(&mixed.streams[0], 0), network.clone(), 0).await;
         assert!(mixed_outcome.emissions.is_empty());
-        assert_ne!(
-            outcome.error, mixed_outcome.error,
-            "integrity exhaustion must not be reported as a transient outage"
+        assert_eq!(
+            mixed_outcome.code,
+            Some(ErrorCode::RetriesExhausted),
+            "one transient attempt means a later retry can still succeed: {:?}",
+            mixed_outcome.error
         );
+    }
+
+    /// The class is chosen here; every other taxonomy test starts from a `RequestError`
+    /// that already exists. Capacity refusals used to land in `retries_exhausted`, so a
+    /// rate-limited fleet answered a bare 503 — the 2026-07 storm's shape (ADR-012).
+    #[tokio::test]
+    async fn the_exhaustion_class_follows_what_every_attempt_agreed_on() {
+        let exhaust = |errors: Vec<QueryError>| {
+            let mut pending = PendingRequests::new(
+                errors
+                    .iter()
+                    .map(|_| WorkerLease::for_tests(PeerId::random())),
+                Duration::from_secs(1),
+            );
+            pending.requests = errors
+                .into_iter()
+                .map(|e| {
+                    WorkerRequest::Finished(FinishedWorkerRequest {
+                        result: Err(e),
+                        worker: PeerId::random(),
+                    })
+                })
+                .collect();
+            match StreamController::<ScriptedNetwork>::all_attempts_failed(&mut pending) {
+                RequestState::Done(Err(e)) => e,
+                _ => panic!("exhaustion must produce an error"),
+            }
+        };
+        let integrity = || QueryError::Integrity("equivocated".into());
+        let transient = || QueryError::Retriable("timed out".into());
+
+        let cases = [
+            (
+                vec![QueryError::RateLimitExceeded, QueryError::RateLimitExceeded],
+                ErrorCode::Overloaded,
+                "capacity refusals",
+            ),
+            (
+                vec![integrity(), integrity()],
+                ErrorCode::WorkerFailure,
+                "equivocation",
+            ),
+            (
+                vec![transient(), transient()],
+                ErrorCode::RetriesExhausted,
+                "transient failures",
+            ),
+            // No class is claimed unless every attempt agrees on it.
+            (
+                vec![QueryError::RateLimitExceeded, transient()],
+                ErrorCode::RetriesExhausted,
+                "a mix with a transient attempt",
+            ),
+            (
+                vec![QueryError::RateLimitExceeded, integrity()],
+                ErrorCode::RetriesExhausted,
+                "a mix of refusal and equivocation",
+            ),
+        ];
+
+        for (errors, want, case) in cases {
+            assert_eq!(exhaust(errors).code(), Some(want), "{case}");
+        }
+
+        // The hint INV-26 owes an overload has to survive to the wire.
+        use axum::response::IntoResponse;
+        let response = exhaust(vec![QueryError::RateLimitExceeded]).into_response();
+        assert_eq!(response.status().as_u16(), 529);
+        assert_eq!(response.headers()[axum::http::header::RETRY_AFTER], "1");
     }
 
     /// The undershoot half of the wrong-range contract: a worker reporting a

--- a/src/endpoints/block_number_by_timestamp.rs
+++ b/src/endpoints/block_number_by_timestamp.rs
@@ -2,7 +2,7 @@ use std::{future::Future, sync::Arc};
 
 use axum::{
     extract::Path,
-    http::{header, StatusCode},
+    http::{header, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     Extension,
 };
@@ -16,7 +16,10 @@ use crate::{
     hotblocks::{HeadMode, HotblocksErr, HotblocksHandle, Status},
     network::NetworkClient,
     openapi::BlockNumberResponse,
-    types::{Compression, DatasetId, GenericError, ParsedQuery, StreamRequest},
+    types::{
+        coded_response, error_response, Compression, DatasetId, ErrorCode, ErrorResponse,
+        ParsedQuery, RequestError, StreamRequest,
+    },
     utils::{
         conversion::collect_to_string,
         internal_query::{build_blocknumber_query, find_block_in_chunk},
@@ -37,9 +40,23 @@ use super::stream::{DATA_SOURCE_HEADER, DATA_SOURCE_NETWORK_METRIC, DATA_SOURCE_
     ),
     responses(
         (status = 200, description = "Block number resolved", body = BlockNumberResponse),
-        (status = 404, description = "No block found for timestamp"),
-        (status = 500, description = "Internal server error"),
-        (status = 503, description = "Upstream data source unavailable"),
+        (status = 400, description = "\
+Unparseable `timestamp` path segment — or the real-time source refused the query the Portal \
+generated on the client's behalf, which is classified by upstream status like any other \
+(ADR-011). The request itself carries only a dataset name and an integer, so a 400 here is \
+not necessarily the caller's to fix; read `error.message`.", body = ErrorResponse),
+        (status = 404, description = "No block found for timestamp", body = ErrorResponse),
+        (status = 429, description = "Too many requests - retry after the interval in `Retry-After`", body = ErrorResponse,
+            headers(
+                ("Retry-After" = String, description = "Delay in seconds before retrying (at least 1)"),
+            )),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+        (status = 502, description = "The requested data could not be retrieved right now - retry later", body = ErrorResponse),
+        (status = 503, description = "Service temporarily unavailable - retry later. May carry `Retry-After`; honour it when present", body = ErrorResponse),
+        (status = 529, description = "Overloaded - retry after the interval in `Retry-After`", body = ErrorResponse,
+            headers(
+                ("Retry-After" = String, description = "Delay in seconds before retrying (at least 1)"),
+            )),
     ),
     tag = "Datasets"
 )]
@@ -103,19 +120,99 @@ impl BlockNumberDataSource {
 pub enum BlockNumberLookupError {
     NotFound(String),
     Internal(String),
+    /// The real-time source failed to answer. 502 per IB-5: the Portal's own call
+    /// upstream failed, which is not the same as the Portal having no capacity.
     Unavailable(String),
+    /// The head arrived, the body did not finish — a mid-body reset, or a stall past the
+    /// read deadline. UPSTREAM-FAILURE like [`Self::Unavailable`], but never replayed: the
+    /// read budget is already spent, and DC-4 bars a second attempt precisely so a stalled
+    /// upstream cannot push past the client's deadline (REQ-22).
+    UpstreamIncomplete(String),
+    /// A refusal the network layer already classified, carried whole. Flattening it into
+    /// [`Self::Unavailable`] lost the 529 and the `Retry-After` that an overload refusal
+    /// owes the client (INV-26), and reported congestion as an upstream fault.
+    Refused(RequestError),
+    /// A real-time source refusal, classified by the same rules the stream proxy uses.
+    /// One upstream status cannot mean two things depending on which endpoint asked.
+    Upstream {
+        status: StatusCode,
+        code: ErrorCode,
+        retry_after: Option<String>,
+    },
+}
+
+/// Classify a failed hotblocks response the way [`forward_response`] does, so a 429 stays
+/// an overload here too instead of becoming a Portal bug, and keeps the hint INV-26 owes
+/// the client.
+///
+/// [`forward_response`]: crate::http_server::forward_response
+fn upstream_failure(response: &reqwest::Response) -> BlockNumberLookupError {
+    let (status, code) = ErrorCode::classify_upstream(response.status());
+    BlockNumberLookupError::Upstream {
+        status,
+        code,
+        retry_after: response
+            .headers()
+            .get(header::RETRY_AFTER)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned),
+    }
 }
 
 impl BlockNumberLookupError {
+    pub fn class(&self) -> ErrorCode {
+        match self {
+            Self::NotFound(_) => ErrorCode::NotFound,
+            Self::Internal(_) => ErrorCode::Internal,
+            Self::Unavailable(_) | Self::UpstreamIncomplete(_) => ErrorCode::UpstreamUnavailable,
+            // NoData never reaches here: it is a stream outcome, not a lookup one.
+            Self::Refused(e) => e.code().unwrap_or(ErrorCode::Unclassified),
+            Self::Upstream { code, .. } => *code,
+        }
+    }
+
     /// Convert a resolver error into the timestamp endpoint's HTTP response.
     pub fn into_response(self) -> Response {
-        let (status, message) = match self {
-            Self::NotFound(message) => (StatusCode::NOT_FOUND, message),
-            Self::Internal(message) => (StatusCode::INTERNAL_SERVER_ERROR, message),
-            Self::Unavailable(message) => (StatusCode::SERVICE_UNAVAILABLE, message),
+        let class = self.class();
+        let message = match self {
+            // Already carries its own status, headers and envelope.
+            Self::Refused(e) => return e.into_response(),
+            Self::Upstream {
+                status,
+                code,
+                retry_after,
+            } => {
+                let mut response = error_response(status, code, code.default_message());
+                match code {
+                    // INV-26: an overload always carries a usable hint, upstream or not.
+                    ErrorCode::Overloaded => {
+                        let seconds = retry_after
+                            .and_then(|value| value.trim().parse::<u64>().ok())
+                            .filter(|seconds| *seconds >= 1)
+                            .unwrap_or(1);
+                        response
+                            .headers_mut()
+                            .insert(header::RETRY_AFTER, seconds.into());
+                    }
+                    // Any other class forwards the header verbatim, as the proxy does.
+                    // Parsing it first swallowed the RFC's date form on a 503, so one
+                    // upstream response carried a hint on /stream and none here.
+                    _ => {
+                        if let Some(value) = retry_after.and_then(|v| HeaderValue::try_from(v).ok())
+                        {
+                            response.headers_mut().insert(header::RETRY_AFTER, value);
+                        }
+                    }
+                }
+                return response;
+            }
+            Self::NotFound(message)
+            | Self::Internal(message)
+            | Self::Unavailable(message)
+            | Self::UpstreamIncomplete(message) => message,
         };
 
-        (status, axum::Json(GenericError { message })).into_response()
+        coded_response(class, message)
     }
 }
 
@@ -248,9 +345,7 @@ async fn get_archival_blocknumber_by_timestamp(
         Ok(stream) => stream,
         Err(e) => {
             tracing::warn!("spawn stream error: {:?}", e);
-            return Err(BlockNumberLookupError::Unavailable(
-                "SQD Network error".to_string(),
-            ));
+            return Err(BlockNumberLookupError::Refused(e));
         }
     };
 
@@ -293,16 +388,33 @@ where
     Lookup: FnMut() -> LookupFuture,
     LookupFuture: Future<Output = Result<u64, BlockNumberLookupError>>,
 {
-    match lookup().await {
-        Err(BlockNumberLookupError::Unavailable(reason)) => {
-            tracing::debug!(
-                reason,
-                "hotblocks timestamp lookup unavailable, retrying once"
-            );
-            lookup().await
+    let first = lookup().await;
+    let reason = match &first {
+        // The call itself failed transiently.
+        Err(BlockNumberLookupError::Unavailable(reason)) => reason.clone(),
+        // A refusal that arrived as a response. The state change this retry exists for
+        // surfaces here — as the 400 a pruned range answers — so skipping the whole
+        // variant would leave it covering only the rarer half.
+        Err(BlockNumberLookupError::Upstream { status, code, .. }) if retryable(*code) => {
+            status.to_string()
         }
-        result => result,
-    }
+        _ => return first,
+    };
+    tracing::debug!(
+        reason,
+        "hotblocks timestamp lookup unavailable, retrying once"
+    );
+    lookup().await
+}
+
+/// Whether a second attempt can answer differently. Excluded: an overload, because the
+/// source just shed load and a retry adds to it; and refusals that are properties of the
+/// request rather than of the moment, which the same request reproduces exactly.
+fn retryable(code: ErrorCode) -> bool {
+    !matches!(
+        code,
+        ErrorCode::Overloaded | ErrorCode::UnknownDataset | ErrorCode::BaseBlockMismatch
+    )
 }
 
 async fn get_hotblocks_blocknumber_by_timestamp_once(
@@ -310,13 +422,14 @@ async fn get_hotblocks_blocknumber_by_timestamp_once(
     hotblocks: &HotblocksHandle,
     dataset: &DatasetConfig,
 ) -> Result<u64, BlockNumberLookupError> {
-    let status = hotblocks
-        .get_status(&dataset.default_name)
+    let response = hotblocks
+        .request_status(&dataset.default_name)
         .await
         .map_err(|e| {
             tracing::warn!("hotblocks status error: {:?}", e);
             classify_hotblocks_error(e, "Hotblocks status error")
         })?;
+    let status = decode_status(response).await?;
 
     get_hotblocks_blocknumber_by_timestamp_inner(
         timestamp,
@@ -335,18 +448,38 @@ async fn get_hotblocks_blocknumber_by_timestamp_once(
             let status = response.status();
             if !status.is_success() {
                 tracing::warn!("hotblocks stream failed with status {}", status);
-                return Err(BlockNumberLookupError::Unavailable(format!(
-                    "Hotblocks stream failed with status {status}"
-                )));
+                return Err(upstream_failure(&response));
             }
 
-            collect_hotblocks_stream(response).await.map_err(|e| {
-                tracing::warn!("hotblocks stream processing error: {:?}", e);
-                BlockNumberLookupError::Internal("hotblocks stream processing error".to_string())
-            })
+            collect_hotblocks_stream(response).await
         },
     )
     .await
+}
+
+/// Classify the status response before decoding it, the way every other call to the
+/// real-time source is classified. `get_status` resolves the status internally, so a
+/// refusal reached this endpoint as a transport error and answered 502 whatever it
+/// actually was — the one hotblocks call that never saw the shared classifier (DC-4).
+async fn decode_status(response: reqwest::Response) -> Result<Status, BlockNumberLookupError> {
+    if !response.status().is_success() {
+        tracing::warn!("hotblocks status failed with status {}", response.status());
+        return Err(upstream_failure(&response));
+    }
+    // Read and parse separately. reqwest wraps a body that never finished — a mid-body reset,
+    // a stall past the read timeout — in the same `Kind::Decode` as a body that arrived and
+    // wasn't JSON, so `is_decode()` cannot tell a DC-4 transport fault from our own bug. Only
+    // the second is ours: reporting the first as `Internal` pages on a hotblocks roll and
+    // tells the client not to retry something a retry fixes.
+    let bytes = response.bytes().await.map_err(|e| {
+        tracing::warn!("hotblocks status body error: {:?}", e);
+        BlockNumberLookupError::UpstreamIncomplete("Hotblocks status error".to_owned())
+    })?;
+    serde_json::from_slice(&bytes).map_err(|e| {
+        tracing::warn!("hotblocks status decode error: {:?}", e);
+        // Ours to fix, and identical on a second attempt.
+        BlockNumberLookupError::Internal("Hotblocks status error".to_owned())
+    })
 }
 
 /// Classify a hotblocks client error for the timestamp endpoint.
@@ -406,14 +539,22 @@ where
     })
 }
 
-async fn collect_hotblocks_stream(response: reqwest::Response) -> anyhow::Result<String> {
+async fn collect_hotblocks_stream(
+    response: reqwest::Response,
+) -> Result<String, BlockNumberLookupError> {
     let is_gzip = response
         .headers()
         .get(header::CONTENT_ENCODING)
         .is_some_and(|v| v.as_bytes().eq_ignore_ascii_case(b"gzip"));
-    let bytes = response.bytes().await?;
+    let bytes = response.bytes().await.map_err(|e| {
+        tracing::warn!("hotblocks stream body error: {:?}", e);
+        BlockNumberLookupError::UpstreamIncomplete("Hotblocks stream error".to_owned())
+    })?;
 
-    decode_hotblocks_stream_body(is_gzip, bytes.as_ref())
+    decode_hotblocks_stream_body(is_gzip, bytes.as_ref()).map_err(|e| {
+        tracing::warn!("hotblocks stream processing error: {:?}", e);
+        BlockNumberLookupError::Internal("hotblocks stream processing error".to_owned())
+    })
 }
 
 fn decode_hotblocks_stream_body(is_gzip: bool, bytes: &[u8]) -> anyhow::Result<String> {
@@ -464,6 +605,101 @@ mod tests {
     use crate::hotblocks::StatusData;
 
     use super::*;
+
+    /// A refusal the network layer already classified must reach the client intact.
+    /// Flattening it into `Unavailable` dropped the 529 and the `Retry-After` that INV-26
+    /// requires, and reported the Portal's own congestion as an upstream fault.
+    #[tokio::test]
+    async fn a_classified_refusal_keeps_its_status_and_hint() {
+        let response = BlockNumberLookupError::Refused(RequestError::BusyFor(
+            std::time::Duration::from_secs(3),
+        ))
+        .into_response();
+
+        assert_eq!(response.status().as_u16(), 529);
+        assert_eq!(response.headers()[axum::http::header::RETRY_AFTER], "4");
+        assert_eq!(
+            response.extensions().get::<ErrorCode>().copied(),
+            Some(ErrorCode::Overloaded)
+        );
+
+        let response = BlockNumberLookupError::Refused(RequestError::Unavailable).into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            response.extensions().get::<ErrorCode>().copied(),
+            Some(ErrorCode::NoWorkers),
+            "no capacity is not an upstream failure"
+        );
+    }
+
+    /// One upstream status cannot mean two things depending on which endpoint asked. This
+    /// path used to call every 4xx a Portal bug — so a hotblocks 429 surfaced as a 500 —
+    /// and every 5xx an upstream outage, so a 503 or 529 lost both its status and the hint
+    /// INV-26 owes the client.
+    #[tokio::test]
+    async fn upstream_refusals_are_classified_like_the_stream_proxy() {
+        async fn refusal(status: u16, retry_after: Option<&str>) -> Response {
+            let mut upstream = axum::http::Response::builder().status(status);
+            if let Some(hint) = retry_after {
+                upstream = upstream.header(header::RETRY_AFTER, hint);
+            }
+            let response = reqwest::Response::from(upstream.body(Vec::new()).unwrap());
+            upstream_failure(&response).into_response()
+        }
+
+        for (upstream, want_status, want_code) in [
+            (429u16, 429u16, ErrorCode::Overloaded),
+            (529, 529, ErrorCode::Overloaded),
+            (404, 404, ErrorCode::UnknownDataset),
+            (400, 400, ErrorCode::MalformedRequest),
+            (500, 500, ErrorCode::UpstreamUnavailable),
+            // ADR-007: 503 is unavailability, not congestion.
+            (503, 503, ErrorCode::UpstreamUnavailable),
+        ] {
+            let response = refusal(upstream, None).await;
+            assert_eq!(
+                response.status().as_u16(),
+                want_status,
+                "upstream {upstream}"
+            );
+            assert_eq!(
+                response.extensions().get::<ErrorCode>().copied(),
+                Some(want_code),
+                "upstream {upstream}"
+            );
+            assert_eq!(
+                response.headers().contains_key(header::RETRY_AFTER),
+                want_code == ErrorCode::Overloaded,
+                "upstream {upstream}: a hint is owed by OVERLOADED and invented by nothing else"
+            );
+        }
+
+        let response = refusal(429, Some("30")).await;
+        assert_eq!(response.headers()[header::RETRY_AFTER], "30");
+        let response = refusal(429, Some("0")).await;
+        assert_eq!(response.headers()[header::RETRY_AFTER], "1");
+
+        // The proxy forwards an upstream hint whatever its class or form, so this
+        // surface must too: one response cannot carry it on /stream and not here.
+        for hint in ["30", "Wed, 21 Oct 2015 07:28:00 GMT"] {
+            let response = refusal(503, Some(hint)).await;
+            assert_eq!(response.headers()[header::RETRY_AFTER], hint);
+        }
+    }
+
+    /// IB-5 fixes a local upstream failure at 502. 503 read as "the Portal has no
+    /// capacity", which is a different fault with a different owner.
+    #[tokio::test]
+    async fn an_upstream_failure_answers_502() {
+        let response = BlockNumberLookupError::Unavailable("Hotblocks stream error".to_owned())
+            .into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(
+            response.extensions().get::<ErrorCode>().copied(),
+            Some(ErrorCode::UpstreamUnavailable)
+        );
+    }
 
     #[tokio::test]
     async fn get_blocknumber_by_timestamp_uses_archive_path_first() {
@@ -644,6 +880,47 @@ mod tests {
         assert!(decode_hotblocks_stream_body(true, b"not gzip").is_err());
     }
 
+    #[tokio::test]
+    async fn an_unfinished_stream_body_is_an_upstream_failure_not_our_bug() {
+        let truncated = futures::stream::iter([
+            Ok::<_, std::io::Error>(bytes::Bytes::from_static(b"partial")),
+            Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "connection reset mid-body",
+            )),
+        ]);
+        let upstream = axum::http::Response::builder()
+            .status(200)
+            .body(reqwest::Body::wrap_stream(truncated))
+            .unwrap();
+
+        let error = collect_hotblocks_stream(reqwest::Response::from(upstream))
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, BlockNumberLookupError::UpstreamIncomplete(_)),
+            "a truncated body is the upstream's fault: {error:?}"
+        );
+        assert_eq!(error.class(), ErrorCode::UpstreamUnavailable);
+        assert_eq!(error.into_response().status(), StatusCode::BAD_GATEWAY);
+
+        // Once the body arrived, decoding it is local processing and remains a 500.
+        let malformed = axum::http::Response::builder()
+            .status(200)
+            .header(header::CONTENT_ENCODING, "gzip")
+            .body(Vec::from("not gzip"))
+            .unwrap();
+        let error = collect_hotblocks_stream(reqwest::Response::from(malformed))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, BlockNumberLookupError::Internal(_)));
+        assert_eq!(
+            error.into_response().status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+
     fn gzip(bytes: &[u8]) -> Vec<u8> {
         let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
         encoder.write_all(bytes).unwrap();
@@ -735,6 +1012,9 @@ mod tests {
         for error in [
             BlockNumberLookupError::NotFound("block not in hotblocks".to_string()),
             BlockNumberLookupError::Internal("stream processing error".to_string()),
+            // DC-4: a read stall is UPSTREAM-FAILURE but never replayed — the read budget
+            // is spent, so a second attempt would push past the client's deadline (REQ-22).
+            BlockNumberLookupError::UpstreamIncomplete("Hotblocks status error".to_string()),
         ] {
             let calls = Arc::new(AtomicUsize::new(0));
             let error = Arc::new(std::sync::Mutex::new(Some(error)));
@@ -752,5 +1032,127 @@ mod tests {
             assert!(result.is_err());
             assert_eq!(calls.load(Ordering::Relaxed), 1);
         }
+    }
+
+    /// The state change the retry exists for surfaces as a refusal *response* — a
+    /// pruned range answers 400 — which the taxonomy turned from `Unavailable` into
+    /// `Upstream`. Every test above builds its error by hand, so the retry could stop
+    /// covering the case it was added for without one of them noticing. An overload is
+    /// excluded: the source just shed load.
+    /// reqwest reports a body that never finished and a body that wasn't JSON with the same
+    /// `Kind::Decode`, so the split has to be structural. Only the second is our bug: the
+    /// first is DC-4's, and answering `internal_error` paged on a hotblocks roll while
+    /// telling the client not to retry.
+    #[tokio::test]
+    async fn an_unfinished_status_body_is_an_upstream_failure_not_our_bug() {
+        let incomplete =
+            BlockNumberLookupError::UpstreamIncomplete("Hotblocks status error".to_owned());
+        assert_eq!(incomplete.class(), ErrorCode::UpstreamUnavailable);
+        assert_eq!(
+            incomplete.class().error_type().as_str(),
+            "availability_error"
+        );
+        assert_eq!(
+            incomplete.into_response().status(),
+            StatusCode::BAD_GATEWAY,
+            "IB-5 binds upstream_unavailable to 502"
+        );
+
+        // A body that arrived and wasn't JSON stays ours.
+        let ours = BlockNumberLookupError::Internal("Hotblocks status error".to_owned());
+        assert_eq!(ours.class(), ErrorCode::Internal);
+        assert_eq!(ours.class().error_type().as_str(), "api_error");
+    }
+
+    #[tokio::test]
+    async fn retry_once_on_unavailable_retries_an_upstream_refusal_but_not_an_overload() {
+        let attempts = |code, status: u16| async move {
+            let calls = Arc::new(AtomicUsize::new(0));
+            let _ = retry_once_on_unavailable(|| {
+                let calls = calls.clone();
+                async move {
+                    calls.fetch_add(1, Ordering::Relaxed);
+                    Err(BlockNumberLookupError::Upstream {
+                        status: StatusCode::from_u16(status).unwrap(),
+                        code,
+                        retry_after: None,
+                    })
+                }
+            })
+            .await;
+            calls.load(Ordering::Relaxed)
+        };
+
+        assert_eq!(attempts(ErrorCode::MalformedRequest, 400).await, 2);
+        assert_eq!(attempts(ErrorCode::UpstreamUnavailable, 500).await, 2);
+        assert_eq!(attempts(ErrorCode::Overloaded, 429).await, 1);
+        // The same request reproduces these exactly; a retry only costs a round trip.
+        assert_eq!(attempts(ErrorCode::UnknownDataset, 404).await, 1);
+        assert_eq!(attempts(ErrorCode::BaseBlockMismatch, 409).await, 1);
+    }
+
+    /// The status call resolved its own HTTP status inside the client, so a refusal
+    /// reached the endpoint as a transport error: every one of them answered 502
+    /// `upstream_unavailable`, and a 404 was even retried. It is the one call to the
+    /// real-time source that never saw the shared classifier (DC-4).
+    #[tokio::test]
+    async fn a_status_refusal_is_classified_like_every_other_upstream_response() {
+        let respond = |status: u16, body: &'static str| async move {
+            let upstream = axum::http::Response::builder()
+                .status(status)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Vec::from(body))
+                .unwrap();
+            decode_status(reqwest::Response::from(upstream)).await
+        };
+
+        for (upstream, want_status, want_code) in [
+            (404u16, 404u16, ErrorCode::UnknownDataset),
+            (500, 500, ErrorCode::UpstreamUnavailable),
+            (503, 503, ErrorCode::UpstreamUnavailable),
+        ] {
+            let error = respond(upstream, "refused").await.unwrap_err();
+            assert_eq!(error.class(), want_code, "upstream {upstream}");
+            assert_eq!(
+                error.into_response().status().as_u16(),
+                want_status,
+                "upstream {upstream}"
+            );
+        }
+
+        // A body that does not decode is ours, not the source's, and never retried.
+        let error = respond(200, "not json").await.unwrap_err();
+        assert_eq!(error.class(), ErrorCode::Internal);
+
+        // A body that never finished is the source's. reqwest reports both as
+        // `Kind::Decode`, so only reading before parsing separates them.
+        let truncated = futures::stream::iter([
+            Ok::<_, std::io::Error>(bytes::Bytes::from_static(br#"{"kind":"ev"#)),
+            Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "connection reset mid-body",
+            )),
+        ]);
+        let upstream = axum::http::Response::builder()
+            .status(200)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(reqwest::Body::wrap_stream(truncated))
+            .unwrap();
+        let error = decode_status(reqwest::Response::from(upstream))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(error, BlockNumberLookupError::UpstreamIncomplete(_)),
+            "a truncated body is DC-4's fault, not ours: {error:?}"
+        );
+        assert_eq!(error.class(), ErrorCode::UpstreamUnavailable);
+        assert_eq!(error.into_response().status(), StatusCode::BAD_GATEWAY);
+
+        // The shape the real-time source serves on /status.
+        let status = respond(200, r#"{"kind":"evm","retentionStrategy":{},"data":null}"#).await;
+        assert!(
+            status.is_ok(),
+            "a healthy status must still decode: {status:?}"
+        );
     }
 }

--- a/src/endpoints/stream.rs
+++ b/src/endpoints/stream.rs
@@ -16,8 +16,8 @@ use crate::{
     hotblocks::{traceless_key, HeadMode, HotblocksHandle},
     http_server::{forward_hotblocks_response, forward_response},
     network::NetworkClient,
-    openapi::{ConflictResponse, StreamRequestBody},
-    types::{Compression, DatasetId, RequestError, StreamRequest},
+    openapi::{BaseBlockConflictResponse, StreamRequestBody},
+    types::{Compression, DatasetId, ErrorResponse, RequestError, StreamRequest},
     utils::conversion::{join_gzip_default, recompress_gzip},
 };
 
@@ -39,14 +39,20 @@ use crate::{
                 ("X-Sqd-Head-Number" = Option<u64>, description = "Last available block number"),
             )),
         (status = 204, description = "No new blocks available in the requested range"),
-        (status = 400, description = "Invalid request parameters or query"),
-        (status = 404, description = "Dataset not found"),
-        (status = 529, description = "Overloaded - not enough compute units or all workers busy, retry later",
+        (status = 400, description = "Invalid request parameters or query", body = ErrorResponse),
+        (status = 404, description = "Dataset not found", body = ErrorResponse),
+        (status = 409, description = "\
+Parent block hash mismatch — `query.parentBlockHash` does not match the canonical parent of \
+the first requested block. This data does not reorganize, so the client's hash is stale or was \
+carried over from an unfinalized block. The body (see schema below) lists recent canonical-chain \
+blocks so the client can find a shared ancestor and resume. See \
+[How parentBlockHash works](#description/how-parentblockhash-works) for the recovery procedure.", body = BaseBlockConflictResponse),
+        (status = 529, description = "Overloaded - not enough compute units, or the service is at capacity; retry after the interval in `Retry-After`", body = ErrorResponse,
             headers(
                 ("Retry-After" = String, description = "Delay in seconds before retrying (at least 1)"),
             )),
-        (status = 500, description = "Internal server error"),
-        (status = 503, description = "Service temporarily unavailable"),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+        (status = 503, description = "Service temporarily unavailable", body = ErrorResponse),
     ),
     tag = "Streaming",
     extensions(("x-internal" = json!(true))),
@@ -80,14 +86,20 @@ pub(crate) async fn run_archival_stream_restricted(
                 ("X-Sqd-Head-Number" = Option<u64>, description = "Last available block number"),
             )),
         (status = 204, description = "No new blocks available in the requested range"),
-        (status = 400, description = "Invalid request parameters or query"),
-        (status = 404, description = "Dataset not found"),
-        (status = 529, description = "Overloaded - not enough compute units or all workers busy, retry later",
+        (status = 400, description = "Invalid request parameters or query", body = ErrorResponse),
+        (status = 404, description = "Dataset not found", body = ErrorResponse),
+        (status = 409, description = "\
+Parent block hash mismatch — `query.parentBlockHash` does not match the canonical parent of \
+the first requested block. This data does not reorganize, so the client's hash is stale or was \
+carried over from an unfinalized block. The body (see schema below) lists recent canonical-chain \
+blocks so the client can find a shared ancestor and resume. See \
+[How parentBlockHash works](#description/how-parentblockhash-works) for the recovery procedure.", body = BaseBlockConflictResponse),
+        (status = 529, description = "Overloaded - not enough compute units, or the service is at capacity; retry after the interval in `Retry-After`", body = ErrorResponse,
             headers(
                 ("Retry-After" = String, description = "Delay in seconds before retrying (at least 1)"),
             )),
-        (status = 500, description = "Internal server error"),
-        (status = 503, description = "Service temporarily unavailable"),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+        (status = 503, description = "Service temporarily unavailable", body = ErrorResponse),
     ),
     tag = "Streaming",
     extensions(("x-internal" = json!(true))),
@@ -147,20 +159,25 @@ pub(crate) async fn run_archival_stream(
                 ("X-Sqd-Head-Number" = Option<u64>, description = "Last available block number"),
             )),
         (status = 204, description = "No new blocks available in the requested range"),
-        (status = 400, description = "Invalid request parameters or query"),
-        (status = 404, description = "Dataset not found"),
+        (status = 400, description = "Invalid request parameters or query", body = ErrorResponse),
+        (status = 404, description = "Dataset not found", body = ErrorResponse),
         (status = 409, description = "\
 Parent block hash mismatch — the `parentHash` of the first requested block does not match \
 `query.parentBlockHash`, typically a chain reorganization relative to the client's state. \
 The body (see schema below) lists recent canonical-chain blocks so the client can find a \
 shared ancestor and resume. See [How parentBlockHash works](#description/how-parentblockhash-works) \
-for the recovery procedure and a worked example.", body = ConflictResponse),
-        (status = 529, description = "Overloaded - not enough compute units or all workers busy, retry later",
+for the recovery procedure and a worked example.", body = BaseBlockConflictResponse),
+        (status = 429, description = "Too many requests - retry after the interval in `Retry-After`", body = ErrorResponse,
             headers(
                 ("Retry-After" = String, description = "Delay in seconds before retrying (at least 1)"),
             )),
-        (status = 500, description = "Internal server error"),
-        (status = 503, description = "Service temporarily unavailable"),
+        (status = 529, description = "Overloaded - not enough compute units, or the service is at capacity; retry after the interval in `Retry-After`", body = ErrorResponse,
+            headers(
+                ("Retry-After" = String, description = "Delay in seconds before retrying (at least 1)"),
+            )),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+        (status = 502, description = "The requested data could not be retrieved right now - retry later", body = ErrorResponse),
+        (status = 503, description = "Service temporarily unavailable - retry later. May carry `Retry-After`; honour it when present", body = ErrorResponse),
     ),
     tag = "Streaming"
 )]
@@ -186,8 +203,9 @@ pub(crate) async fn run_stream(
 
 /// Finalized stream
 ///
-/// Returns only finalized blocks matching the query. Same request format as /stream;
-/// no chain reorganizations (no 409 responses).
+/// Returns only finalized blocks matching the query. Same request format as /stream.
+/// Finalized data does not reorganize, but a stale `query.parentBlockHash` still
+/// conflicts, so 409 remains reachable.
 #[utoipa::path(
     post,
     path = "/datasets/{dataset}/finalized-stream",
@@ -203,14 +221,25 @@ pub(crate) async fn run_stream(
                 ("X-Sqd-Head-Number" = Option<u64>, description = "Last available block number"),
             )),
         (status = 204, description = "No new blocks available in the requested range"),
-        (status = 400, description = "Invalid request parameters or query"),
-        (status = 404, description = "Dataset not found"),
-        (status = 529, description = "Overloaded - not enough compute units or all workers busy, retry later",
+        (status = 400, description = "Invalid request parameters or query", body = ErrorResponse),
+        (status = 404, description = "Dataset not found", body = ErrorResponse),
+        (status = 409, description = "\
+Parent block hash mismatch — `query.parentBlockHash` does not match the canonical parent of \
+the first requested block. This data does not reorganize, so the client's hash is stale or was \
+carried over from an unfinalized block. The body (see schema below) lists recent canonical-chain \
+blocks so the client can find a shared ancestor and resume. See \
+[How parentBlockHash works](#description/how-parentblockhash-works) for the recovery procedure.", body = BaseBlockConflictResponse),
+        (status = 429, description = "Too many requests - retry after the interval in `Retry-After`", body = ErrorResponse,
             headers(
                 ("Retry-After" = String, description = "Delay in seconds before retrying (at least 1)"),
             )),
-        (status = 500, description = "Internal server error"),
-        (status = 503, description = "Service temporarily unavailable"),
+        (status = 529, description = "Overloaded - not enough compute units, or the service is at capacity; retry after the interval in `Retry-After`", body = ErrorResponse,
+            headers(
+                ("Retry-After" = String, description = "Delay in seconds before retrying (at least 1)"),
+            )),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+        (status = 502, description = "The requested data could not be retrieved right now - retry later", body = ErrorResponse),
+        (status = 503, description = "Service temporarily unavailable - retry later. May carry `Retry-After`; honour it when present", body = ErrorResponse),
     ),
     tag = "Streaming"
 )]
@@ -369,9 +398,9 @@ async fn stream_from_hotblocks(
                 return delayed_no_content_response(DATA_SOURCE_REALTIME).await;
             }
 
-            forward_response(&dataset.default_name, response)
+            forward_response(&dataset.default_name, response).await
         }
-        Err(e) => forward_hotblocks_response(&dataset.default_name, Err(e)),
+        Err(e) => forward_hotblocks_response(&dataset.default_name, Err(e)).await,
     };
 
     res.headers_mut()
@@ -474,9 +503,9 @@ async fn delayed_no_content_response_with_builder(
         .unwrap()
 }
 
-const FINALIZED_NUMBER_HEADER: &str = "x-sqd-finalized-head-number";
-const FINALIZED_HASH_HEADER: &str = "x-sqd-finalized-head-hash";
-const HEAD_NUMBER_HEADER: &str = "x-sqd-head-number";
+pub(crate) const FINALIZED_NUMBER_HEADER: &str = "x-sqd-finalized-head-number";
+pub(crate) const FINALIZED_HASH_HEADER: &str = "x-sqd-finalized-head-hash";
+pub(crate) const HEAD_NUMBER_HEADER: &str = "x-sqd-head-number";
 pub(crate) const DATA_SOURCE_HEADER: &str = "x-sqd-data-source";
 pub(crate) const DATA_SOURCE_NETWORK_METRIC: &str = "network";
 pub(crate) const DATA_SOURCE_REALTIME_METRIC: &str = "real_time";

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -45,7 +45,10 @@ use crate::{
     controller::task_manager::TaskManager,
     hotblocks::{traceless_key, HeadMode, HotblocksHandle},
     network::{NetworkClient, NoWorker, NotReady},
-    types::{ChunkId, DatasetId, ParsedQuery, RequestError, StreamRequest},
+    types::{
+        coded_response, error_body_response, error_response, ChunkId, DatasetId, ErrorBody,
+        ErrorCode, ErrorResponse, ParsedQuery, RequestError, StreamRequest, RETRY_AFTER_FLOOR,
+    },
     utils::logging,
 };
 
@@ -53,6 +56,33 @@ use crate::{
 use crate::sql;
 #[cfg(feature = "sql")]
 use axum::body;
+
+/// Response headers a cross-origin client must be able to read.
+///
+/// The Fetch spec hands JavaScript only the CORS-safelisted headers unless the server
+/// names the rest here — and that list contains none of ours: not `Retry-After`, the hint
+/// INV-26 makes mandatory, nor `x-request-id` (REQ-9), nor the stream metadata IB-2 binds
+/// to every 200. Those headers were on the wire all along, which is why no server-side
+/// test saw the gap: the filtering happens in the browser.
+///
+/// Spelled out rather than `Any`, so a header added later is invisible until someone
+/// decides it is public — `x-internal-*` above all.
+const EXPOSED_HEADERS: [axum::http::HeaderName; 6] = [
+    header::RETRY_AFTER,
+    logging::X_REQUEST_ID,
+    axum::http::HeaderName::from_static(crate::endpoints::stream::DATA_SOURCE_HEADER),
+    axum::http::HeaderName::from_static(crate::endpoints::stream::HEAD_NUMBER_HEADER),
+    axum::http::HeaderName::from_static(crate::endpoints::stream::FINALIZED_NUMBER_HEADER),
+    axum::http::HeaderName::from_static(crate::endpoints::stream::FINALIZED_HASH_HEADER),
+];
+
+fn cors_layer() -> CorsLayer {
+    CorsLayer::new()
+        .allow_methods([Method::GET, Method::POST, Method::OPTIONS, Method::PUT])
+        .allow_headers(Any)
+        .allow_origin(Any)
+        .expose_headers(EXPOSED_HEADERS)
+}
 
 #[allow(deprecated)]
 pub async fn run_server(
@@ -67,10 +97,7 @@ pub async fn run_server(
     show_internal_docs: bool,
 ) -> anyhow::Result<()> {
     let openapi_spec = build_openapi_spec(show_internal_docs);
-    let cors = CorsLayer::new()
-        .allow_methods([Method::GET, Method::POST, Method::OPTIONS, Method::PUT])
-        .allow_headers(Any)
-        .allow_origin(Any);
+    let cors = cors_layer();
 
     tracing::info!("Starting HTTP server listening on {addr}");
     let app = Router::new()
@@ -172,6 +199,11 @@ pub async fn run_server(
         .route_layer(axum::middleware::from_fn(logging::middleware))
         .layer(sentry_tower::NewSentryLayer::new_from_top())
         .layer(RequestDecompressionLayer::new())
+        .layer(
+            // Outside the decompression layer and the router, both of which can answer
+            // without reaching `logging::middleware`.
+            axum::middleware::from_fn(logging::observe_bypassed),
+        )
         .layer(cors)
         .layer(
             // Copies the request id onto every response (REQ-9). Must be added
@@ -183,6 +215,11 @@ pub async fn run_server(
         .layer(
             // This layer is added here to be applied before the request reaches trace layers
             SetRequestIdLayer::x_request_id(MakeRequestUuid),
+        )
+        .layer(
+            // Outside SetRequestIdLayer: a non-ASCII client id is rejected with a 400 and
+            // a generated response correlation id before it can enter logs or handlers.
+            axum::middleware::from_fn(logging::reject_non_ascii_request_id),
         )
         .layer(Extension(task_manager))
         .layer(Extension(network_client))
@@ -249,7 +286,7 @@ where
     ),
     responses(
         (status = 200, description = "Archival head block retrieved", body = Option<BlockHead>),
-        (status = 404, description = "Dataset has no archival data source"),
+        (status = 404, description = "Dataset has no archival data source", body = ErrorResponse),
     ),
     tag = "Streaming",
     extensions(("x-internal" = json!(true))),
@@ -263,14 +300,13 @@ async fn get_archival_head(
         return axum::Json(network.head(&dataset_id)).into_response();
     }
 
-    (
-        StatusCode::NOT_FOUND,
+    coded_response(
+        ErrorCode::UnknownDataset,
         format!(
             "Dataset {} has no archival data source",
             dataset.default_name
         ),
     )
-        .into_response()
 }
 
 /// Whether the head must be reported as the minimum of the traced and traceless variants.
@@ -330,14 +366,15 @@ async fn head_response(
             if reports_min_finalized_head(dataset, mode) {
                 return match real_time_head(hotblocks, dataset, mode).await {
                     Ok(head) => axum::Json(head).into_response(),
-                    Err(e) => forward_hotblocks_response(&dataset.default_name, Err(e)),
+                    Err(e) => forward_hotblocks_response(&dataset.default_name, Err(e)).await,
                 };
             }
             // Pass the hotblocks response through unchanged.
             return forward_hotblocks_response(
                 &dataset.default_name,
                 hotblocks.request_head(&dataset.default_name, mode).await,
-            );
+            )
+            .await;
         };
 
         match real_time_head(hotblocks, dataset, mode).await {
@@ -359,11 +396,10 @@ async fn head_response(
         return axum::Json(network.head(dataset_id)).into_response();
     }
 
-    (
-        StatusCode::NOT_FOUND,
+    coded_response(
+        ErrorCode::UnknownDataset,
         format!("Dataset {} has no data sources", dataset.default_name),
     )
-        .into_response()
 }
 
 /// Latest finalized head
@@ -380,7 +416,7 @@ async fn head_response(
     ),
     responses(
         (status = 200, description = "Finalized head block retrieved", body = Option<BlockHead>),
-        (status = 404, description = "Dataset has no data sources"),
+        (status = 404, description = "Dataset has no data sources", body = ErrorResponse),
     ),
     tag = "Streaming"
 )]
@@ -406,7 +442,7 @@ async fn get_finalized_head(
     ),
     responses(
         (status = 200, description = "Head block retrieved", body = Option<BlockHead>),
-        (status = 404, description = "Dataset has no data sources"),
+        (status = 404, description = "Dataset has no data sources", body = ErrorResponse),
     ),
     tag = "Streaming"
 )]
@@ -517,7 +553,7 @@ async fn get_datasets(
     ),
     responses(
         (status = 200, description = "Dataset state retrieved successfully", body = serde_json::Value),
-        (status = 404, description = "Dataset not found"),
+        (status = 404, description = "Dataset not found", body = ErrorResponse),
     ),
     tag = "Datasets",
     extensions(("x-internal" = json!(true))),
@@ -541,7 +577,7 @@ async fn get_dataset_state(
     ),
     responses(
         (status = 200, description = "Dataset metadata retrieved successfully", body = AvailableDatasetApiResponse),
-        (status = 404, description = "Dataset not found"),
+        (status = 404, description = "Dataset not found", body = ErrorResponse),
     ),
     tag = "Datasets"
 )]
@@ -578,7 +614,7 @@ async fn get_dataset_metadata(
     ),
     responses(
         (status = 200, description = "Debug information retrieved", body = serde_json::Value),
-        (status = 404, description = "Dataset or block not found"),
+        (status = 404, description = "Dataset or block not found", body = ErrorResponse),
     ),
     tag = "Debug",
     extensions(("x-internal" = json!(true))),
@@ -653,7 +689,7 @@ async fn get_metrics(Extension(registry): Extension<Arc<Registry>>) -> impl Into
     path = "/ready",
     responses(
         (status = 200, description = "Portal is ready"),
-        (status = 503, description = "Portal is not ready"),
+        (status = 503, description = "Portal is not ready", body = ErrorResponse),
     ),
     tag = "Monitoring",
     extensions(("x-internal" = json!(true))),
@@ -700,7 +736,7 @@ async fn get_readiness(
         };
 
     if LAST_STATE.swap(state, Ordering::Relaxed) != state {
-        match (state, reason) {
+        match (state, &reason) {
             (READY, _) => tracing::info!("readiness check now passing: portal is ready"),
             (SHUTTING_DOWN, _) => tracing::info!("readiness check now failing: shutting down"),
             (_, Some(reason)) => tracing::warn!("readiness check now failing: {reason}"),
@@ -708,7 +744,29 @@ async fn get_readiness(
         }
     }
 
-    (code, body).into_response()
+    readiness_response(code, &readiness_detail(reason.as_ref(), body))
+}
+
+/// What the probe is told, beyond the status: the live reason when there is one, the
+/// category otherwise.
+///
+/// Separate from [`readiness_response`] because this is the half OB-5 cares about — a
+/// probe flip must be attributable without log archaeology — and the half a test can
+/// reach without building a `NetworkClient`.
+fn readiness_detail(reason: Option<&NotReady>, category: &str) -> String {
+    match reason {
+        Some(reason) => reason.to_string(),
+        None => category.to_owned(),
+    }
+}
+
+/// IB-6: a declining probe answers with the ADR-011 `not_ready` envelope. 200 stays bare
+/// text — there is no error to describe, and probes read the status either way.
+fn readiness_response(code: StatusCode, detail: &str) -> Response {
+    if code == StatusCode::OK {
+        return (code, detail.to_owned()).into_response();
+    }
+    error_response(code, ErrorCode::NotReady, detail)
 }
 
 /// Dataset Height
@@ -722,7 +780,7 @@ async fn get_readiness(
     ),
     responses(
         (status = 200, description = "Height retrieved successfully", body = String),
-        (status = 404, description = "Dataset not found"),
+        (status = 404, description = "Dataset not found", body = ErrorResponse),
     ),
     tag = "Streaming",
     extensions(("x-internal" = json!(true))),
@@ -747,7 +805,7 @@ async fn get_height(
     ),
     responses(
         (status = 200, description = "Height retrieved successfully", body = String),
-        (status = 404, description = "Dataset not found"),
+        (status = 404, description = "Dataset not found", body = ErrorResponse),
     ),
     tag = "Streaming",
     extensions(("x-internal" = json!(true))),
@@ -772,7 +830,7 @@ async fn get_finalized_stream_height(
     ),
     responses(
         (status = 200, description = "Height retrieved successfully", body = String),
-        (status = 404, description = "Dataset not found"),
+        (status = 404, description = "Dataset not found", body = ErrorResponse),
     ),
     tag = "Streaming",
     extensions(("x-internal" = json!(true))),
@@ -786,15 +844,12 @@ async fn get_archival_stream_height(
     height_response(&network, &dataset, &dataset_id)
 }
 
-fn height_response(
-    network: &NetworkClient,
-    dataset: &str,
-    dataset_id: &DatasetId,
-) -> (StatusCode, String) {
+fn height_response(network: &NetworkClient, dataset: &str, dataset_id: &DatasetId) -> Response {
     match network.get_height(dataset_id) {
-        Some(height) => (StatusCode::OK, height.to_string()),
-        None => (
-            StatusCode::NOT_FOUND,
+        // Bare number, not JSON: the deprecated height endpoints' response contract.
+        Some(height) => (StatusCode::OK, height.to_string()).into_response(),
+        None => coded_response(
+            ErrorCode::UnknownDataset,
             format!("No data for dataset {dataset}"),
         ),
     }
@@ -812,9 +867,9 @@ fn height_response(
     ),
     responses(
         (status = 200, description = "Worker URL retrieved", body = String),
-        (status = 404, description = "Dataset not found"),
-        (status = 429, description = "Rate limit exceeded"),
-        (status = 503, description = "No available workers"),
+        (status = 404, description = "Dataset not found", body = ErrorResponse),
+        (status = 429, description = "Rate limit exceeded", body = ErrorResponse),
+        (status = 503, description = "No available workers", body = ErrorResponse),
     ),
     tag = "Debug",
     extensions(("x-internal" = json!(true))),
@@ -829,19 +884,22 @@ async fn get_worker(
     let worker_id = match client.find_worker(&dataset_id, start_block) {
         Ok(worker_id) => worker_id.worker(),
         Err(NoWorker::AllUnavailable) => {
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
+            return coded_response(
+                ErrorCode::NoWorkers,
                 format!("No available worker for dataset {dataset} block {start_block}"),
-            )
-                .into_response();
+            );
         }
         Err(NoWorker::Backoff(retry_at)) => {
             let seconds = retry_at.duration_since(Instant::now()).as_secs() + 1; // +1 for rounding up
-            return Response::builder()
-                .status(StatusCode::TOO_MANY_REQUESTS)
-                .header(header::RETRY_AFTER, seconds)
-                .body(Body::from("Too many requests"))
-                .unwrap();
+            let mut response = error_response(
+                StatusCode::TOO_MANY_REQUESTS,
+                ErrorCode::Overloaded,
+                "Too many requests",
+            );
+            response
+                .headers_mut()
+                .insert(header::RETRY_AFTER, seconds.into());
+            return response;
         }
     };
 
@@ -869,9 +927,9 @@ async fn get_worker(
     request_body = serde_json::Value,
     responses(
         (status = 200, description = "Query executed successfully", body = String),
-        (status = 400, description = "Invalid query"),
-        (status = 404, description = "Dataset or worker not found"),
-        (status = 503, description = "Service unavailable"),
+        (status = 400, description = "Invalid query", body = ErrorResponse),
+        (status = 404, description = "Dataset or worker not found", body = ErrorResponse),
+        (status = 503, description = "Service unavailable", body = ErrorResponse),
     ),
     tag = "Streaming",
     extensions(("x-internal" = json!(true))),
@@ -886,11 +944,10 @@ async fn execute_query(
     let dataset_id = match DatasetId::from_base64(&dataset_id_encoded) {
         Ok(dataset_id) => dataset_id,
         Err(e) => {
-            return (
-                StatusCode::NOT_FOUND,
+            return coded_response(
+                ErrorCode::UnknownDataset,
                 format!("Couldn't parse dataset id: {e}"),
             )
-                .into_response()
         }
     };
 
@@ -929,9 +986,7 @@ async fn execute_query(
             .header(header::CONTENT_ENCODING, "gzip")
             .body(Body::from(data))
             .unwrap(),
-        Err(e) => {
-            RequestError::InternalError(format!("Couldn't convert response: {e}")).into_response()
-        }
+        Err(e) => RequestError::Internal(format!("Couldn't convert response: {e}")).into_response(),
     }
 }
 
@@ -951,7 +1006,7 @@ where
             .map_err(IntoResponse::into_response)?;
         let (_, alias) = args
             .first()
-            .ok_or((StatusCode::NOT_FOUND, "not enough arguments").into_response())?;
+            .ok_or_else(|| coded_response(ErrorCode::UnknownDataset, "not enough arguments"))?;
         let Extension(network) = parts
             .extract::<Extension<Arc<NetworkClient>>>()
             .await
@@ -959,9 +1014,10 @@ where
 
         match network.dataset(alias) {
             Some(config) => Ok(config.clone()),
-            None => {
-                Err((StatusCode::NOT_FOUND, format!("Unknown dataset: {alias}")).into_response())
-            }
+            None => Err(coded_response(
+                ErrorCode::UnknownDataset,
+                format!("Unknown dataset: {alias}"),
+            )),
         }
     }
 }
@@ -985,8 +1041,8 @@ where
             .expect("RequestId should be set by the SetRequestIdLayer")
             .header_value()
             .to_str()
-            // A client-supplied `x-request-id` is preserved verbatim and can contain
-            // non-visible-ASCII bytes; fall back rather than panic on the request task.
+            // The outer validator rejects a non-ASCII id before routing. Keep this
+            // defensive fallback for stacks that omit the production layer.
             .unwrap_or_default()
             .to_owned();
 
@@ -1001,17 +1057,19 @@ where
 
         let buffer_size = match params.get("buffer_size").map(|v| v.parse()) {
             Some(Ok(0)) => {
-                return Err(RequestError::BadRequest(
-                    "buffer_size must be greater than 0".to_string(),
-                )
+                return Err(RequestError::InvalidParam {
+                    param: "buffer_size",
+                    message: "buffer_size must be greater than 0".to_string(),
+                }
                 .into_response())
             }
             Some(Ok(value)) => value,
             Some(Err(e)) => {
-                return Err(
-                    RequestError::BadRequest(format!("Couldn't parse buffer_size: {e}"))
-                        .into_response(),
-                )
+                return Err(RequestError::InvalidParam {
+                    param: "buffer_size",
+                    message: format!("Couldn't parse buffer_size: {e}"),
+                }
+                .into_response())
             }
             None => config.default_buffer_size,
         };
@@ -1019,9 +1077,10 @@ where
             Some(value) => match value.parse() {
                 Ok(quantile) => quantile,
                 Err(e) => {
-                    return Err(RequestError::BadRequest(format!(
-                        "Couldn't parse timeout_quantile: {e}"
-                    ))
+                    return Err(RequestError::InvalidParam {
+                        param: "timeout_quantile",
+                        message: format!("Couldn't parse timeout_quantile: {e}"),
+                    }
                     .into_response())
                 }
             },
@@ -1031,10 +1090,11 @@ where
             Some(value) => match value.parse() {
                 Ok(value) => value,
                 Err(e) => {
-                    return Err(
-                        RequestError::BadRequest(format!("Couldn't parse retries: {e}"))
-                            .into_response(),
-                    )
+                    return Err(RequestError::InvalidParam {
+                        param: "retries",
+                        message: format!("Couldn't parse retries: {e}"),
+                    }
+                    .into_response())
                 }
             },
             None => config.default_retries,
@@ -1042,17 +1102,19 @@ where
         let max_chunks = match params.get("max_chunks") {
             Some(value) => match value.parse() {
                 Ok(0) => {
-                    return Err(RequestError::BadRequest(
-                        "max_chunks must be greater than 0".to_string(),
-                    )
+                    return Err(RequestError::InvalidParam {
+                        param: "max_chunks",
+                        message: "max_chunks must be greater than 0".to_string(),
+                    }
                     .into_response())
                 }
                 Ok(value) => Some(value),
                 Err(e) => {
-                    return Err(
-                        RequestError::BadRequest(format!("Couldn't parse max_chunks: {e}"))
-                            .into_response(),
-                    )
+                    return Err(RequestError::InvalidParam {
+                        param: "max_chunks",
+                        message: format!("Couldn't parse max_chunks: {e}"),
+                    }
+                    .into_response())
                 }
             },
             None => None,
@@ -1141,41 +1203,44 @@ where
 
         match dataset.network_id {
             Some(dataset_id) => Ok(dataset_id),
-            None => Err((
-                StatusCode::NOT_FOUND,
+            None => Err(coded_response(
+                ErrorCode::UnknownDataset,
                 format!(
                     "Dataset {} doesn't have archival data",
                     dataset.default_name
                 ),
-            )
-                .into_response()),
+            )),
         }
     }
 }
 
-pub(crate) fn forward_hotblocks_response(
+pub(crate) async fn forward_hotblocks_response(
     dataset: &str,
     response: Result<reqwest::Response, HotblocksErr>,
 ) -> Response {
     match response {
-        Ok(response) => forward_response(dataset, response),
+        Ok(response) => forward_response(dataset, response).await,
+        // Unreachable by construction; a panic here would kill the connection task.
         Err(HotblocksErr::UnknownDataset) => {
-            unreachable!("dataset should be known by the hotblocks service")
+            RequestError::Internal("dataset should be known by the hotblocks service".to_owned())
+                .into_response()
         }
         Err(HotblocksErr::Request(e)) => {
             // Until this fires, a stalled upstream leaves no trace: the request never
-            // returns, so it carries no status. reqwest's Display already names the URL.
+            // returns, so it carries no status. reqwest's Display already names the URL —
+            // which is why it stays in the log and out of the body. DC-4 keeps an
+            // upstream's own prose unpublished; a transport error names the same internal
+            // topology in the same way, and the client can do nothing with either.
             tracing::warn!(
                 dataset,
                 timed_out = e.is_timeout(),
                 error = %e,
                 "hotblocks request failed"
             );
-            (
-                StatusCode::BAD_GATEWAY,
-                format!("Hotblocks request error: {e}"),
+            coded_response(
+                ErrorCode::UpstreamUnavailable,
+                ErrorCode::UpstreamUnavailable.default_message(),
             )
-                .into_response()
         }
     }
 }
@@ -1189,33 +1254,155 @@ const INTERNAL_HEADER_PREFIX: &str = "x-internal-";
 /// single ClusterIP, so this is the portal's only way to attribute a response to a pod.
 const HOTBLOCKS_INSTANCE_HEADER: &str = "x-internal-hotblocks-instance";
 
-pub(crate) fn forward_response(
+/// Proxy a hotblocks response, rewriting error bodies into the portal's envelope: one
+/// stream endpoint is served by either data source and must not emit two body shapes.
+pub(crate) async fn forward_response(
     dataset: &str,
-    response: reqwest::Response,
+    mut response: reqwest::Response,
 ) -> axum::response::Response {
     let status = response.status();
+    let instance = || {
+        response
+            .headers()
+            .get(HOTBLOCKS_INSTANCE_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("-")
+    };
     if status.is_server_error() {
         tracing::warn!(
             dataset,
             status = status.as_u16(),
-            instance = response
-                .headers()
-                .get(HOTBLOCKS_INSTANCE_HEADER)
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("-"),
+            instance = instance(),
             "hotblocks returned a server error"
         );
     }
+    // The portal validated this alias against its own catalog before asking, so a 404
+    // here is the two deployments disagreeing about what exists, not a client typo — and
+    // on the wire and on the metric the two are identical (DC-4, spec/05). Since the
+    // upstream's own prose is not published, this log is the only witness.
+    if status == StatusCode::NOT_FOUND {
+        tracing::error!(
+            dataset,
+            instance = instance(),
+            "hotblocks does not know a dataset the portal advertises: catalog incoherence"
+        );
+    }
 
-    let mut builder = Response::builder().status(status);
+    // 204 and success stream through untouched, keeping x-sqd-finalized-head-*.
+    if status == StatusCode::NO_CONTENT || status.is_success() || status.is_redirection() {
+        return stream_response(response);
+    }
+
+    let (public_status, class) = ErrorCode::classify_upstream(status);
+    let headers = response.headers().clone();
+
+    let mut error = ErrorBody::new(class, class.default_message());
+
+    // 409 is the only status whose body is read at all. The upstream's prose is never
+    // published (DC-4) and adds nothing to the log — a server error is already recorded
+    // above with the pod that served it, and hotblocks logs its own errors in full — so
+    // every other status streams straight to drop.
+    if status == StatusCode::CONFLICT {
+        // Clients walk `previousBlocks` to find a shared ancestor, so it is preserved at
+        // the top level beside `error` (IB-5). It is the one public upstream field.
+        match conflict_previous_blocks(&mut response).await {
+            Some(blocks) => {
+                error = error.with_sibling("previousBlocks", serde_json::json!(blocks));
+            }
+            // Not a legal 409 under IB-5, and unrecoverable for the client: it has
+            // nothing to walk, so it re-requests the same range and conflicts again.
+            // Indistinguishable from a healthy reorg on the wire and on the metric, so
+            // this log is the only witness.
+            None => tracing::error!(
+                dataset,
+                "hotblocks 409 carried no usable previousBlocks: clients cannot resolve the reorg"
+            ),
+        }
+    }
+
+    let mut rewritten = error_body_response(public_status, error);
+
+    // Keep upstream headers (retry-after, x-sqd-*), but not the replaced body's own, and
+    // never the internal ones — this path bypasses stream_response's filter.
+    let out = rewritten.headers_mut();
+    for (key, value) in headers.iter() {
+        if key == header::CONTENT_TYPE
+            || key == header::CONTENT_LENGTH
+            || key == header::CONTENT_ENCODING
+            || key == header::TRANSFER_ENCODING
+            || key.as_str().starts_with(INTERNAL_HEADER_PREFIX)
+        {
+            continue;
+        }
+        out.insert(key, value.clone());
+    }
+
+    // INV-26: OVERLOADED always carries a *usable* hint. An upstream value survives only
+    // if it reads as seconds at or above the floor — a 0 would invite an immediate retry
+    // loop against a source that just shed load, and the portal documents this header in
+    // seconds, so the RFC's HTTP-date form is replaced rather than passed on.
+    if class == ErrorCode::Overloaded {
+        let usable = out
+            .get(header::RETRY_AFTER)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.trim().parse::<u64>().ok())
+            .is_some_and(|seconds| seconds >= RETRY_AFTER_FLOOR);
+        if !usable {
+            out.insert(header::RETRY_AFTER, RETRY_AFTER_FLOOR.into());
+        }
+    }
+
+    rewritten
+}
+
+/// A 409's recovery list is a short `{number, hash}` slice by contract, so this bounds a
+/// broken upstream rather than budgeting a legitimate one: a body past the cap is not the
+/// contract, and is refused instead of truncated.
+const MAX_CONFLICT_BODY: usize = 64 * 1024;
+
+/// The 409 recovery list, or `None` if the upstream did not supply a usable one.
+///
+/// Typed and non-empty rather than forwarded as an opaque value: `previousBlocks` is the
+/// one upstream field clients are told to walk, so an upstream must not be able to put
+/// something else — a scalar, an empty list, arbitrary internal data — under that name.
+/// Read here and nowhere else, bounded, because this is the only upstream body the portal
+/// consumes at all.
+async fn conflict_previous_blocks(response: &mut reqwest::Response) -> Option<Vec<BlockRef>> {
+    #[derive(serde::Deserialize)]
+    struct Conflict {
+        #[serde(rename = "previousBlocks")]
+        previous_blocks: Vec<BlockRef>,
+    }
+
+    let mut body = bytes::BytesMut::new();
+    loop {
+        match response.chunk().await {
+            Ok(Some(chunk)) if body.len() + chunk.len() <= MAX_CONFLICT_BODY => {
+                body.extend_from_slice(&chunk)
+            }
+            Ok(Some(_)) => return None,
+            Ok(None) => break,
+            // A truncated prefix cannot be parsed, and half a chain slice is worse than
+            // none: the client would resume from an ancestor that is not the deepest one.
+            Err(_) => return None,
+        }
+    }
+
+    let conflict: Conflict = serde_json::from_slice(&body).ok()?;
+    (!conflict.previous_blocks.is_empty()).then_some(conflict.previous_blocks)
+}
+
+fn stream_response(response: reqwest::Response) -> axum::response::Response {
+    let mut builder = Response::builder().status(response.status());
     for (key, value) in response.headers() {
         if key.as_str().starts_with(INTERNAL_HEADER_PREFIX) {
             continue;
         }
         builder = builder.header(key, value);
     }
-    let body = Body::from_stream(response.bytes_stream());
-    builder.body(body).unwrap()
+    builder
+        .body(Body::from_stream(response.bytes_stream()))
+        .unwrap()
 }
 
 #[cfg(feature = "sql")]
@@ -1248,10 +1435,80 @@ async fn sql_metadata(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::server_overloaded;
     use std::time::Duration;
 
-    #[test]
-    fn forward_response_strips_internal_headers() {
+    /// A server-side test can only see that a header is *on* the response — whether a
+    /// browser hands it to JavaScript is decided by `access-control-expose-headers`, and
+    /// that is why no assertion on a handler could ever have caught its absence. The
+    /// names are written out here rather than read from [`EXPOSED_HEADERS`]: a test that
+    /// iterates the list it is checking restates the implementation instead of pinning
+    /// the contract, and dropping a name would quietly move both.
+    #[tokio::test]
+    async fn cors_exposes_every_header_a_client_is_told_to_read() {
+        use axum::{body::Body, http::Request, routing::get, Router};
+        use tower::ServiceExt;
+
+        let app = Router::new()
+            .route(
+                "/refused",
+                get(|| async { RequestError::BusyFor(Duration::from_secs(9)).into_response() }),
+            )
+            .layer(cors_layer());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/refused")
+                    .header(header::ORIGIN, "https://app.example.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), server_overloaded());
+        assert_eq!(
+            response.headers()[header::RETRY_AFTER],
+            "10",
+            "the hint must be on the wire before exposing it can matter"
+        );
+
+        let exposed = response
+            .headers()
+            .get(header::ACCESS_CONTROL_EXPOSE_HEADERS)
+            .expect("a cross-origin response must name what it exposes")
+            .to_str()
+            .unwrap()
+            .to_ascii_lowercase();
+        let exposed: Vec<&str> = exposed.split(',').map(str::trim).collect();
+
+        for name in [
+            // INV-26 owes an overload a back-off interval; unreadable, it owes nothing.
+            "retry-after",
+            // REQ-9: the id a user quotes in a ticket.
+            "x-request-id",
+            // IB-2's stream metadata, which the harness asserts on every 200.
+            "x-sqd-data-source",
+            "x-sqd-head-number",
+            "x-sqd-finalized-head-number",
+            "x-sqd-finalized-head-hash",
+        ] {
+            assert!(
+                exposed.contains(&name),
+                "{name} is unreadable cross-origin: {exposed:?}"
+            );
+        }
+        assert!(
+            !exposed
+                .iter()
+                .any(|h| *h == "*" || h.starts_with(INTERNAL_HEADER_PREFIX)),
+            "the exposed set must stay explicit and free of internal headers: {exposed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_response_strips_internal_headers() {
         let upstream = axum::http::Response::builder()
             .status(StatusCode::OK)
             .header(HOTBLOCKS_INSTANCE_HEADER, "hotblocks-db-0")
@@ -1259,7 +1516,8 @@ mod tests {
             .body(Vec::new())
             .unwrap();
 
-        let forwarded = forward_response("polygon-mainnet", reqwest::Response::from(upstream));
+        let forwarded =
+            forward_response("polygon-mainnet", reqwest::Response::from(upstream)).await;
 
         let headers = forwarded.headers();
         assert!(
@@ -1273,6 +1531,447 @@ mod tests {
             "42",
             "client-facing headers must still be forwarded"
         );
+    }
+
+    /// Error responses are rebuilt into the envelope rather than streamed, so they copy
+    /// upstream headers on a separate path that has to strip the internal ones too.
+    #[tokio::test]
+    async fn forward_response_strips_internal_headers_on_errors() {
+        let upstream = axum::http::Response::builder()
+            .status(StatusCode::SERVICE_UNAVAILABLE)
+            .header(HOTBLOCKS_INSTANCE_HEADER, "hotblocks-db-0")
+            .header(header::RETRY_AFTER, "5")
+            .body(Vec::from("upstream is down"))
+            .unwrap();
+
+        let forwarded =
+            forward_response("polygon-mainnet", reqwest::Response::from(upstream)).await;
+
+        let headers = forwarded.headers();
+        assert!(
+            !headers
+                .keys()
+                .any(|k| k.as_str().starts_with(INTERNAL_HEADER_PREFIX)),
+            "internal headers must not reach clients: {headers:?}"
+        );
+        assert_eq!(
+            headers.get(header::RETRY_AFTER).unwrap(),
+            "5",
+            "upstream retry-after must survive the body rewrite"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // CT-5 — interface conformance for the error surface (IB-5, INV-26).
+    //
+    // The taxonomy has two emitters: locally produced errors and rewritten upstream
+    // ones. The invariant that matters is that a client cannot tell them apart, so
+    // these assert the *proxied* shape and pin it against the local one. Unit tests
+    // per emitter cannot catch a divergence between them.
+    // ---------------------------------------------------------------------------
+
+    async fn proxied(status: StatusCode, body: &'static str) -> (StatusCode, serde_json::Value) {
+        let upstream = axum::http::Response::builder()
+            .status(status)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Vec::from(body))
+            .unwrap();
+        let response = forward_response("polygon-mainnet", reqwest::Response::from(upstream)).await;
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json = if bytes.is_empty() {
+            serde_json::Value::Null
+        } else {
+            serde_json::from_slice(&bytes).expect("proxied error bodies are the JSON envelope")
+        };
+        (status, json)
+    }
+
+    /// Every proxied failure arrives as the envelope on the public status DC-4 fixes,
+    /// classified onto the closed vocabulary. A matched status is preserved; an
+    /// unmatched 4xx normalizes to 400.
+    #[tokio::test]
+    async fn proxied_errors_use_the_envelope() {
+        let cases = [
+            (400, 400, "malformed_request", "invalid_request_error"),
+            (403, 400, "malformed_request", "invalid_request_error"),
+            (418, 400, "malformed_request", "invalid_request_error"),
+            (404, 404, "unknown_dataset", "invalid_request_error"),
+            (429, 429, "overloaded", "rate_limit_error"),
+            (529, 529, "overloaded", "rate_limit_error"),
+            (500, 500, "upstream_unavailable", "availability_error"),
+            (502, 502, "upstream_unavailable", "availability_error"),
+            // ADR-007: 503 is unavailability, not congestion. Read as an overload it
+            // claimed exhausted capacity of a source that may have none running at all.
+            (503, 503, "upstream_unavailable", "availability_error"),
+        ];
+
+        for (upstream, want_status, want_code, want_type) in cases {
+            let upstream = StatusCode::from_u16(upstream).unwrap();
+            let (got_status, body) =
+                proxied(upstream, "instance hotblocks-db-0: /var/lib oops").await;
+
+            assert_eq!(got_status.as_u16(), want_status, "upstream {upstream}");
+            assert_eq!(body["error"]["code"], want_code, "upstream {upstream}");
+            assert_eq!(body["error"]["type"], want_type, "upstream {upstream}");
+        }
+    }
+
+    /// DC-4: the upstream's prose is not public API and can name instances and paths.
+    /// No proxied error may echo it.
+    /// The other half of DC-4. `a_proxied_error_never_leaks_the_upstream_body` only ever
+    /// builds an `Ok(reqwest::Response)`, so the branch where the request never completed
+    /// went uncovered — and that is the one whose `reqwest::Error` Display carries the
+    /// upstream URL, naming the internal service, namespace and port to any client that
+    /// can make hotblocks time out.
+    #[tokio::test]
+    async fn a_transport_failure_does_not_publish_the_upstream_url() {
+        // Port 1 is privileged and unbound, so this refuses immediately without DNS.
+        let error = reqwest::Client::new()
+            .get("http://127.0.0.1:1/datasets/internal-only-name/stream")
+            .send()
+            .await
+            .expect_err("nothing listens on port 1");
+        assert!(
+            error.to_string().contains("127.0.0.1:1"),
+            "reqwest names the url, which is the whole hazard: {error}"
+        );
+
+        let response =
+            forward_hotblocks_response("eth-mainnet", Err(HotblocksErr::Request(error))).await;
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["error"]["code"], "upstream_unavailable");
+        assert_eq!(body["error"]["type"], "availability_error");
+
+        let message = body["error"]["message"].as_str().unwrap();
+        for leak in ["127.0.0.1", "internal-only-name", "http://", ":1/"] {
+            assert!(
+                !message.contains(leak),
+                "the upstream url must stay in the log: {message}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_proxied_error_never_leaks_the_upstream_body() {
+        let secret = "instance hotblocks-db-0 at /var/lib/hotblocks: shard 7 corrupt";
+        for upstream in [400u16, 403, 404, 409, 429, 500, 502, 503] {
+            let status = StatusCode::from_u16(upstream).unwrap();
+            let (_, body) = proxied(status, secret).await;
+            let rendered = body.to_string();
+            assert!(
+                !rendered.contains("hotblocks-db-0") && !rendered.contains("/var/lib"),
+                "upstream {upstream} leaked its body: {rendered}"
+            );
+            assert!(
+                body["error"]["message"]
+                    .as_str()
+                    .is_some_and(|m| !m.is_empty()),
+                "upstream {upstream} must still explain itself"
+            );
+        }
+    }
+
+    /// The bug this class of test exists to catch: 409 is the one status where the
+    /// envelope has a top-level sibling, and it is served by both data sources.
+    #[tokio::test]
+    async fn both_stream_paths_emit_the_same_409_shape() {
+        let (proxied_status, proxied_body) = proxied(
+            StatusCode::CONFLICT,
+            r#"{"previousBlocks":[{"number":42,"hash":"0xdead"}]}"#,
+        )
+        .await;
+
+        let local = RequestError::BaseBlockMismatch(BlockRef {
+            number: 42,
+            hash: "0xdead".to_owned(),
+        })
+        .into_response();
+        let local_status = local.status();
+        let local_body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(local.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(proxied_status, local_status);
+        for (source, body) in [("proxied", &proxied_body), ("local", &local_body)] {
+            assert_eq!(body["error"]["code"], "base_block_mismatch", "{source}");
+            assert_eq!(body["error"]["type"], "invalid_request_error", "{source}");
+            assert!(
+                body["error"]["message"].is_string(),
+                "{source} must explain itself"
+            );
+            // IB-5: the recovery contract stays a top-level sibling, not nested.
+            assert_eq!(body["previousBlocks"][0]["number"], 42, "{source}");
+            assert_eq!(body["previousBlocks"][0]["hash"], "0xdead", "{source}");
+        }
+    }
+
+    /// INV-26: an overload refusal must always tell the client how long to wait, even
+    /// when the upstream forgot to. Nothing else invents one — a hint on a 503 pointed
+    /// the client straight back at a dependency that may be down rather than busy.
+    #[tokio::test]
+    async fn only_a_proxied_overload_carries_an_invented_retry_hint() {
+        for (status, wants_hint) in [(429u16, true), (529, true), (503, false), (500, false)] {
+            let upstream = axum::http::Response::builder()
+                .status(status)
+                .body(Vec::from("busy"))
+                .unwrap();
+            let forwarded =
+                forward_response("polygon-mainnet", reqwest::Response::from(upstream)).await;
+
+            let hint = forwarded.headers().get(header::RETRY_AFTER);
+            assert_eq!(hint.is_some(), wants_hint, "{status}");
+            if let Some(hint) = hint {
+                assert!(
+                    hint.to_str().unwrap().parse::<u64>().unwrap() >= RETRY_AFTER_FLOOR,
+                    "{status} hint must be at least the floor"
+                );
+            }
+        }
+    }
+
+    /// 204 streams through as-is: it is not a failure, so it gets no envelope, no code,
+    /// and keeps the head markers clients read off it.
+    #[tokio::test]
+    async fn proxied_204_is_untouched() {
+        let upstream = axum::http::Response::builder()
+            .status(StatusCode::NO_CONTENT)
+            .header("x-sqd-finalized-head-number", "99")
+            .body(Vec::new())
+            .unwrap();
+        let forwarded =
+            forward_response("polygon-mainnet", reqwest::Response::from(upstream)).await;
+
+        assert_eq!(forwarded.status(), StatusCode::NO_CONTENT);
+        assert_eq!(forwarded.headers()["x-sqd-finalized-head-number"], "99");
+        assert!(
+            forwarded.extensions().get::<ErrorCode>().is_none(),
+            "a 204 must not be tagged with a taxonomy code"
+        );
+    }
+
+    /// An upstream error body cannot size our response, however large it is: it is not
+    /// copied into the envelope at all.
+    #[tokio::test]
+    async fn a_huge_upstream_body_does_not_size_the_response() {
+        let upstream = axum::http::Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body("x".repeat(200 * 1024).into_bytes())
+            .unwrap();
+        let forwarded =
+            forward_response("polygon-mainnet", reqwest::Response::from(upstream)).await;
+        let bytes = axum::body::to_bytes(forwarded.into_body(), usize::MAX)
+            .await
+            .unwrap();
+
+        assert!(
+            bytes.len() < 1024,
+            "envelope must not carry the upstream body"
+        );
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["error"]["code"], "upstream_unavailable");
+    }
+
+    /// The stronger claim behind the test above: the body is not merely omitted from the
+    /// response, it is never read. Nothing consumes it — it is not published (DC-4) and a
+    /// server error is already logged with the pod that served it — so buffering it would
+    /// let an upstream fault size portal memory. 409 is the sole exception.
+    #[tokio::test]
+    async fn only_a_409_reads_the_upstream_body() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        async fn forward_watching_the_body(status: StatusCode, payload: &'static str) -> bool {
+            let polled = Arc::new(AtomicBool::new(false));
+            let flag = polled.clone();
+            let body = reqwest::Body::wrap_stream(futures::stream::once(async move {
+                flag.store(true, Ordering::SeqCst);
+                Ok::<_, std::io::Error>(bytes::Bytes::from_static(payload.as_bytes()))
+            }));
+            let upstream = axum::http::Response::builder()
+                .status(status)
+                .body(body)
+                .unwrap();
+
+            forward_response("polygon-mainnet", reqwest::Response::from(upstream)).await;
+            polled.load(Ordering::SeqCst)
+        }
+
+        for status in [400u16, 404, 429, 500, 502, 503] {
+            assert!(
+                !forward_watching_the_body(StatusCode::from_u16(status).unwrap(), "prose").await,
+                "{status} must not read the upstream body"
+            );
+        }
+
+        assert!(
+            forward_watching_the_body(StatusCode::CONFLICT, r#"{"previousBlocks":[]}"#).await,
+            "409 must read the body — previousBlocks lives in it"
+        );
+    }
+
+    /// `previousBlocks` is the one upstream field clients are told to walk, so it is
+    /// parsed into a non-empty typed list rather than forwarded as whatever value happens
+    /// to sit under that key. Anything else — absent, empty, a scalar, arbitrary internal
+    /// data, or a body too large to be the contract — is refused rather than passed on as
+    /// a recovery hint the client cannot use.
+    #[tokio::test]
+    async fn a_409_publishes_only_a_usable_recovery_list() {
+        let unusable = [
+            ("not json at all", "non-JSON body"),
+            (r#"{"code":"conflict"}"#, "key absent"),
+            (r#"{"previousBlocks":[]}"#, "empty list"),
+            (r#"{"previousBlocks":"0xdead"}"#, "scalar"),
+            (
+                r#"{"previousBlocks":[{"secret":"/var/lib"}]}"#,
+                "wrong shape",
+            ),
+        ];
+
+        for (upstream_body, case) in unusable {
+            let (status, body) = proxied(StatusCode::CONFLICT, upstream_body).await;
+
+            assert_eq!(status, StatusCode::CONFLICT, "{case}");
+            assert_eq!(body["error"]["code"], "base_block_mismatch", "{case}");
+            assert!(
+                body.get("previousBlocks").is_none(),
+                "{case}: no recovery hint can be invented, and none may be echoed: {body}"
+            );
+        }
+
+        let (_, body) = proxied(
+            StatusCode::CONFLICT,
+            r#"{"previousBlocks":[{"number":42,"hash":"0xdead"}],"internal":"/var/lib"}"#,
+        )
+        .await;
+        assert_eq!(body["previousBlocks"][0]["number"], 42);
+        assert!(
+            body.get("internal").is_none(),
+            "only the recovery list survives: {body}"
+        );
+    }
+
+    /// A body past the cap is not the short `{number, hash}` slice IB-5 describes, so it
+    /// is refused rather than truncated — a partial chain slice would resume the client
+    /// from an ancestor that is not the deepest one.
+    #[tokio::test]
+    async fn an_oversized_409_body_is_refused_not_truncated() {
+        let filler = "x".repeat(MAX_CONFLICT_BODY);
+        let upstream = axum::http::Response::builder()
+            .status(StatusCode::CONFLICT)
+            .body(
+                format!(
+                    r#"{{"previousBlocks":[{{"number":42,"hash":"0xdead"}}],"pad":"{filler}"}}"#
+                )
+                .into_bytes(),
+            )
+            .unwrap();
+        let forwarded =
+            forward_response("polygon-mainnet", reqwest::Response::from(upstream)).await;
+
+        assert_eq!(forwarded.status(), StatusCode::CONFLICT);
+        let bytes = axum::body::to_bytes(forwarded.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(body.get("previousBlocks").is_none(), "{body}");
+    }
+
+    /// INV-26 asks for a hint a client can act on, not merely a present header. A 0 would
+    /// send it straight back at a source that just shed load, and the header is documented
+    /// in seconds, so the RFC's date form is replaced rather than forwarded.
+    #[tokio::test]
+    async fn an_unusable_upstream_retry_hint_is_replaced() {
+        for hint in ["0", "-1", "not-a-number", "Wed, 21 Oct 2015 07:28:00 GMT"] {
+            let upstream = axum::http::Response::builder()
+                .status(StatusCode::TOO_MANY_REQUESTS)
+                .header(header::RETRY_AFTER, hint)
+                .body(Vec::from("busy"))
+                .unwrap();
+            let forwarded =
+                forward_response("polygon-mainnet", reqwest::Response::from(upstream)).await;
+
+            let got = forwarded.headers()[header::RETRY_AFTER].to_str().unwrap();
+            assert!(
+                got.parse::<u64>().is_ok_and(|s| s >= RETRY_AFTER_FLOOR),
+                "{hint:?} must not survive as a hint, got {got:?}"
+            );
+        }
+
+        // A usable one is still preserved.
+        let upstream = axum::http::Response::builder()
+            .status(StatusCode::TOO_MANY_REQUESTS)
+            .header(header::RETRY_AFTER, "30")
+            .body(Vec::from("busy"))
+            .unwrap();
+        let forwarded =
+            forward_response("polygon-mainnet", reqwest::Response::from(upstream)).await;
+        assert_eq!(forwarded.headers()[header::RETRY_AFTER], "30");
+    }
+
+    /// IB-6: a declining probe answers with the `not_ready` envelope, not bare prose,
+    /// and names the live reason so a flip is attributable (OB-5). 200 has no error to
+    /// describe and stays plain.
+    #[tokio::test]
+    async fn readiness_declines_with_the_envelope() {
+        // Drive the real `NotReady` through the same selection `get_readiness` uses.
+        // Passing the renderer a string of the test's own invention asserted nothing
+        // about the wiring: `detail = category` would have satisfied it, and OB-5 turns
+        // on exactly that substitution.
+        let reason = NotReady::InsufficientConnections {
+            active: 2,
+            required: 10,
+            workers: 12,
+        };
+        let detail = readiness_detail(Some(&reason), "Not ready");
+        let response = readiness_response(StatusCode::SERVICE_UNAVAILABLE, &detail);
+        assert_eq!(
+            response.extensions().get::<ErrorCode>().copied(),
+            Some(ErrorCode::NotReady),
+            "a drain must not be counted as an api_error"
+        );
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["error"]["code"], "not_ready");
+        assert_eq!(body["error"]["type"], "availability_error");
+        // The live counts, not the category: an operator must be able to tell a
+        // bootstrapping portal from one that lost half its connections (OB-5).
+        let message = body["error"]["message"].as_str().unwrap();
+        assert_eq!(message, reason.to_string());
+        for detail in ["2", "10", "12"] {
+            assert!(
+                message.contains(detail),
+                "the reason's counts must survive into the body: {message}"
+            );
+        }
+        assert_ne!(message, "Not ready", "the category is not the reason");
+
+        // The other variant carries no counts, so pin it by identity too.
+        assert_eq!(
+            readiness_detail(Some(&NotReady::NoWorkers), "Not ready"),
+            NotReady::NoWorkers.to_string()
+        );
+        // Shutting down has no `NotReady` to report; the category is all there is.
+        assert_eq!(readiness_detail(None, "Shutting down"), "Shutting down");
+
+        let ready = readiness_response(StatusCode::OK, "Ready");
+        assert!(ready.extensions().get::<ErrorCode>().is_none());
+        let bytes = axum::body::to_bytes(ready.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(&bytes[..], b"Ready");
     }
 
     /// End-to-end: real TCP listener + axum router + reqwest client. Verifies that

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -12,7 +12,10 @@ use prometheus_client::{
 use reqwest::StatusCode;
 use sqd_contract_client::PeerId;
 
-use crate::{types::DatasetId, utils::logging::StreamStats};
+use crate::{
+    types::{DatasetId, ErrorCode, ErrorType},
+    utils::logging::StreamStats,
+};
 
 pub enum MutexLockMode {
     Read,
@@ -161,17 +164,49 @@ pub fn hotblocks_requests(outcome: HotblocksRequestOutcome) -> u64 {
         .get()
 }
 
+/// Carries the wire's `code`/`type`, prefixed — a bare `type` label says nothing on a
+/// metric. Errors only, so success series keep their label set. An unclassified error is
+/// still counted rather than dropped.
+pub fn http_labels(
+    endpoint: String,
+    status: StatusCode,
+    data_source: String,
+    error_code: Option<ErrorCode>,
+) -> Labels {
+    let mut labels = vec![
+        ("endpoint".to_owned(), endpoint),
+        ("status".to_owned(), status.as_str().to_owned()),
+        ("data_source".to_owned(), data_source),
+    ];
+
+    // Only failures carry the taxonomy. A 2xx is not one whatever a handler tagged it
+    // with — labelling a routine 204 `availability_error` would make the steady state of
+    // every polling client read as a fault (INV-30).
+    if !(status.is_client_error() || status.is_server_error()) {
+        return labels;
+    }
+
+    // An unclassified 4xx is a client hitting a bad route or verb; only a 5xx
+    // implicates us.
+    let code = error_code.unwrap_or(ErrorCode::Unclassified);
+    let error_type = match code {
+        ErrorCode::Unclassified if status.is_client_error() => ErrorType::InvalidRequest,
+        code => code.error_type(),
+    };
+    labels.push(("error_code".to_owned(), code.as_str().to_owned()));
+    labels.push(("error_type".to_owned(), error_type.as_str().to_owned()));
+
+    labels
+}
+
 pub fn report_http_response(
     endpoint: String,
     status: StatusCode,
     data_source: String,
+    error_code: Option<ErrorCode>,
     seconds_to_first_byte: f64,
 ) {
-    let labels = vec![
-        ("endpoint".to_owned(), endpoint.clone()),
-        ("status".to_owned(), status.as_str().to_owned()),
-        ("data_source".to_owned(), data_source),
-    ];
+    let labels = http_labels(endpoint, status, data_source, error_code);
     HTTP_STATUS.get_or_create(&labels).inc();
     HTTP_TTFB
         .get_or_create(&labels)
@@ -392,4 +427,75 @@ pub fn register_metrics(registry: &mut Registry) {
         "Number of existing mutexes",
         MUTEXES_EXISTING.clone(),
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn labels_for(status: u16, code: Option<ErrorCode>) -> Labels {
+        http_labels(
+            "/stream".to_owned(),
+            StatusCode::from_u16(status).unwrap(),
+            "network".to_owned(),
+            code,
+        )
+    }
+
+    fn get<'a>(labels: &'a Labels, key: &str) -> Option<&'a str> {
+        labels
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+    }
+
+    #[test]
+    fn success_keeps_the_original_label_set() {
+        let labels = labels_for(200, None);
+        assert_eq!(get(&labels, "error_code"), None);
+        assert_eq!(get(&labels, "error_type"), None);
+    }
+
+    /// A 204 is the steady state of every polling client. Labelling it as an error type
+    /// would make normal operation dominate any availability alert (INV-30). The gate is
+    /// on the status, so a stray tag on a 2xx cannot reintroduce that.
+    #[test]
+    fn no_2xx_is_ever_labelled_as_an_error() {
+        for status in [200, 204, 206] {
+            let labels = labels_for(status, Some(ErrorCode::UpstreamUnavailable));
+            assert_eq!(get(&labels, "error_code"), None, "{status}");
+            assert_eq!(get(&labels, "error_type"), None, "{status}");
+        }
+    }
+
+    #[test]
+    fn classified_errors_carry_code_and_type() {
+        let labels = labels_for(529, Some(ErrorCode::Overloaded));
+        assert_eq!(get(&labels, "error_code"), Some("overloaded"));
+        assert_eq!(get(&labels, "error_type"), Some("rate_limit_error"));
+    }
+
+    /// The point of the catch-all: an unclassified 5xx is our bug, not nothing.
+    #[test]
+    fn unclassified_5xx_is_counted_as_an_api_error() {
+        let labels = labels_for(500, None);
+        assert_eq!(get(&labels, "error_code"), Some("unclassified"));
+        assert_eq!(get(&labels, "error_type"), Some("api_error"));
+    }
+
+    /// A client hitting a bad route must not page anyone.
+    #[test]
+    fn unclassified_4xx_is_the_clients_fault() {
+        let labels = labels_for(404, None);
+        assert_eq!(get(&labels, "error_code"), Some("unclassified"));
+        assert_eq!(get(&labels, "error_type"), Some("invalid_request_error"));
+    }
+
+    /// A rolling deploy fails /ready on every pod; that must not read as an api_error.
+    #[test]
+    fn draining_readiness_is_an_availability_error() {
+        let labels = labels_for(503, Some(ErrorCode::NotReady));
+        assert_eq!(get(&labels, "error_code"), Some("not_ready"));
+        assert_eq!(get(&labels, "error_type"), Some("availability_error"));
+    }
 }

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -107,6 +107,87 @@ impl StreamingNetwork for NetworkClient {
     }
 }
 
+/// Whether the worker stays a candidate. Only two outcomes today; the split from the
+/// cooldown *class* is GAP-27.
+enum Health {
+    Ok,
+    Error,
+}
+
+/// One DC-1 row: how a worker verdict is classified, counted, and charged. The three
+/// were chosen independently in each match arm — eight arms times three decisions — and
+/// they drifted: the two capacity refusals shared a row in the spec while disagreeing
+/// here on both the error class and the health signal.
+struct Verdict {
+    error: QueryError,
+    label: &'static str,
+    health: Health,
+    backs_off: bool,
+}
+
+impl Verdict {
+    fn of(err: query_error::Err) -> Self {
+        use query_error::Err;
+        let row = |error, label, health, backs_off| Verdict {
+            error,
+            label,
+            health,
+            backs_off,
+        };
+        match err {
+            Err::BadRequest(s) => row(
+                QueryError::BadRequest(format!("couldn't parse request: {s}")),
+                "bad_request",
+                Health::Ok,
+                false,
+            ),
+            // Probably still downloading the chunk.
+            Err::NotFound(s) => row(QueryError::Retriable(s), "not_found", Health::Error, false),
+            // Input validation, not a bad response.
+            Err::ServerError(s) if parse_base_block_mismatch(&s).is_some() => row(
+                QueryError::BaseBlockMismatch(parse_base_block_mismatch(&s).expect("just matched")),
+                "block_mismatch",
+                Health::Ok,
+                false,
+            ),
+            // The query covers too much data: narrowing it is the client's move, and
+            // another worker would answer the same.
+            Err::ServerError(s) if s == "Response too large" => row(
+                QueryError::BadRequest(
+                    "the response for this block exceeds the size limit; \
+                     try narrowing the query to request only the necessary data"
+                        .to_owned(),
+                ),
+                "response_too_large",
+                Health::Ok,
+                false,
+            ),
+            Err::ServerError(s) => {
+                row(QueryError::Failure(s), "server_error", Health::Error, false)
+            }
+            // One row, two verdicts: both are capacity refusals.
+            Err::ServerOverloaded(()) => row(
+                QueryError::RateLimitExceeded,
+                "server_overloaded",
+                Health::Error,
+                true,
+            ),
+            Err::TooManyRequests(()) => row(
+                QueryError::RateLimitExceeded,
+                "too_many_requests",
+                Health::Ok,
+                true,
+            ),
+        }
+    }
+}
+
+/// The data is opaque, so a `last_block` outside the queried range cannot be trimmed to
+/// it, and the continuation derived from it is inverted or re-covers delivered blocks.
+fn out_of_range(ok: &QueryOk, range: &BlockRange) -> bool {
+    !range.contains(&ok.last_block)
+}
+
 #[derive(Debug)]
 pub struct QuerySuccess {
     pub ok: QueryOk,
@@ -569,7 +650,9 @@ impl NetworkClient {
                 compression,
             )
             .await;
-        let result = self.execute_query(worker, query, priority).await;
+        let result = self
+            .execute_query(worker, query, &block_range, priority)
+            .await;
         result
     }
 
@@ -577,6 +660,7 @@ impl NetworkClient {
         &self,
         worker: PeerId,
         query: Query,
+        block_range: &BlockRange,
         priority: Option<u32>,
     ) -> QueryResult {
         let mut stream = self.send_to_transport(worker, query, priority).await?;
@@ -587,7 +671,7 @@ impl NetworkClient {
             .download_body(worker, &mut stream, &mut buf, priority)
             .await?;
         let query_time = network_start.elapsed();
-        self.finalize_response(worker, buf, ttfb, transfer_time, query_time)
+        self.finalize_response(worker, buf, block_range, ttfb, transfer_time, query_time)
             .await
     }
 
@@ -731,6 +815,7 @@ impl NetworkClient {
         &self,
         worker: PeerId,
         buf: Vec<u8>,
+        block_range: &BlockRange,
         ttfb: Duration,
         transfer_time: Duration,
         query_time: Duration,
@@ -754,7 +839,7 @@ impl NetworkClient {
         } else {
             None
         };
-        self.parse_query_result(worker, result, throughput)
+        self.parse_query_result(worker, result, block_range, throughput)
             .await
             .inspect(|_| metrics::report_query_ok(query_time))
             .map(|ok| QuerySuccess {
@@ -809,10 +894,9 @@ impl NetworkClient {
         &self,
         peer_id: PeerId,
         result: Result<sqd_messages::QueryResult, QueryFailure>,
+        block_range: &BlockRange,
         throughput: Option<f64>,
     ) -> Result<QueryOk, QueryError> {
-        use query_error::Err;
-
         match result {
             Ok(q) if self.verify_responses && !verify_signature(&q, peer_id).await => {
                 metrics::report_query_result(&peer_id, "integrity");
@@ -832,67 +916,36 @@ impl NetworkClient {
                     metrics::report_backoff(&peer_id);
                 };
                 match result {
+                    // Before the success is recorded: counted first, one wrong-range
+                    // answer landed in both `ok` and `integrity`, and left its latency
+                    // and throughput in the worker's health.
+                    query_result::Result::Ok(ok) if out_of_range(&ok, block_range) => {
+                        metrics::report_query_result(&peer_id, "integrity");
+                        self.network_state.report_query_error(peer_id);
+                        Err(QueryError::Integrity(format!(
+                            "worker returned last block {} outside the queried range {}-{}",
+                            ok.last_block,
+                            block_range.start(),
+                            block_range.end()
+                        )))
+                    }
                     query_result::Result::Ok(ok) => {
                         metrics::report_query_result(&peer_id, "ok");
                         self.network_state.report_query_success(peer_id, throughput);
                         Ok(ok)
                     }
                     query_result::Result::Err(sqd_messages::QueryError { err: Some(err) }) => {
-                        match err {
-                            Err::BadRequest(s) => {
-                                metrics::report_query_result(&peer_id, "bad_request");
-                                self.network_state.report_query_success(peer_id, None);
-                                Err(QueryError::BadRequest(format!(
-                                    "couldn't parse request: {s}"
-                                )))
-                            }
-                            Err::NotFound(s) => {
-                                // Chunk was not found on the worker. It's probably still downloading it
-                                metrics::report_query_result(&peer_id, "not_found");
-                                self.network_state.report_query_error(peer_id);
-                                Err(QueryError::Retriable(s))
-                            }
-                            Err::ServerError(s) => {
-                                if let Some(block_ref) = parse_base_block_mismatch(&s) {
-                                    // That's input validation rather than bad query response
-                                    metrics::report_query_result(&peer_id, "block_mismatch");
-                                    self.network_state.report_query_success(peer_id, None);
-                                    Err(QueryError::BaseBlockMismatch(block_ref))
-                                } else if s == "Response too large" {
-                                    // Caused by the query covering too much data; the client
-                                    // should narrow it down rather than retry against another worker
-                                    metrics::report_query_result(&peer_id, "response_too_large");
-                                    self.network_state.report_query_success(peer_id, None);
-                                    Err(QueryError::BadRequest(
-                                        "the response for this block exceeds the size limit; \
-                                         try narrowing the query to request only the necessary data"
-                                            .to_owned(),
-                                    ))
-                                } else {
-                                    metrics::report_query_result(&peer_id, "server_error");
-                                    self.network_state.report_query_error(peer_id);
-                                    Err(QueryError::Failure(s))
-                                }
-                            }
-                            Err::ServerOverloaded(()) => {
-                                metrics::report_query_result(&peer_id, "server_overloaded");
-                                self.network_state.report_query_error(peer_id);
-                                if retry_after_ms.is_none() {
-                                    self.network_state
-                                        .hint_backoff(peer_id, self.default_worker_backoff);
-                                }
-                                Err(QueryError::Retriable("worker overloaded".to_owned()))
-                            }
-                            Err::TooManyRequests(()) => {
-                                metrics::report_query_result(&peer_id, "too_many_requests");
-                                self.network_state.report_query_success(peer_id, None);
-                                if retry_after_ms.is_none() {
-                                    self.network_state
-                                        .hint_backoff(peer_id, self.default_worker_backoff);
-                                }
-                                Err(QueryError::RateLimitExceeded)
-                            }
+                        let verdict = Verdict::of(err);
+                        metrics::report_query_result(&peer_id, verdict.label);
+                        match verdict.health {
+                            Health::Ok => self.network_state.report_query_success(peer_id, None),
+                            Health::Error => self.network_state.report_query_error(peer_id),
                         }
+                        if verdict.backs_off && retry_after_ms.is_none() {
+                            self.network_state
+                                .hint_backoff(peer_id, self.default_worker_backoff);
+                        }
+                        Err(verdict.error)
                     }
                     query_result::Result::Err(sqd_messages::QueryError { err: None }) => {
                         metrics::report_query_result(&peer_id, "invalid");

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -8,6 +8,7 @@ use utoipa::{OpenApi, ToSchema};
 
 use crate::network::{CurrentEpoch, NetworkClientStatus, Status, Workers};
 use crate::types::api_types::AvailableDatasetApiResponse;
+use crate::types::{ErrorDetail, ErrorResponse};
 
 /// Status response for the portal
 #[derive(Serialize, Clone, Debug, ToSchema)]
@@ -25,32 +26,33 @@ pub struct BlockHead {
     pub hash: String,
 }
 
-/// Body of a `409 Conflict` on a stream request — a slice of the **current
-/// canonical chain** at and below the conflict point, most recent first.
-#[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
-#[serde(rename_all = "camelCase")]
-#[schema(example = json!({
-    "previousBlocks": [
-        { "number": 21780872, "hash": "0xf6a96a29..." },
-        { "number": 21780871, "hash": "0xab12cd..." }
-    ]
-}))]
-pub struct ConflictResponse {
-    /// `{ number, hash }` pairs from the canonical chain, descending from the conflict
-    /// point. Guaranteed to contain at least the parent of the requested `fromBlock`.
-    pub previous_blocks: Vec<BlockHead>,
-}
-
 /// Block number response for timestamp query
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
 pub struct BlockNumberResponse {
     pub block_number: u64,
 }
 
-/// Generic error response
-#[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
-pub struct ErrorResponse {
-    pub message: String,
+/// 409 body: the standard error envelope, plus `previousBlocks` at the top level — a slice
+/// of the **current canonical chain** at and below the conflict point, most recent first.
+// Documentation-only; ErrorDetail borrows 'static strs and cannot Deserialize.
+#[derive(Serialize, Clone, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+#[schema(example = json!({
+    "error": {
+        "type": "invalid_request_error",
+        "code": "base_block_mismatch",
+        "message": "Base block mismatch"
+    },
+    "previousBlocks": [
+        { "number": 21780872, "hash": "0xf6a96a29..." },
+        { "number": 21780871, "hash": "0xab12cd..." }
+    ]
+}))]
+pub struct BaseBlockConflictResponse {
+    pub error: ErrorDetail,
+    /// `{ number, hash }` pairs from the canonical chain, descending from the conflict
+    /// point. Guaranteed to contain at least the parent of the requested `fromBlock`.
+    pub previous_blocks: Vec<BlockHead>,
 }
 
 /// Metadata query parameters
@@ -133,9 +135,10 @@ pub struct DatasetStateResponse {
             Status,
             AvailableDatasetApiResponse,
             BlockHead,
-            ConflictResponse,
             BlockNumberResponse,
             ErrorResponse,
+            ErrorDetail,
+            BaseBlockConflictResponse,
             MetadataQueryParams,
             StreamRequestBody,
             QueryRequest,

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -1,7 +1,6 @@
 use std::ops::Range;
 use std::sync::Arc;
 
-use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use sql_query_plan::plan;
 
@@ -15,7 +14,7 @@ use query::{QueryErr, SqlQueryResponse, TableItem};
 
 use crate::datasets;
 use crate::network::NetworkClient;
-use crate::types::GenericError;
+use crate::types::{coded_response, ErrorCode};
 
 use axum::body;
 
@@ -33,13 +32,12 @@ impl IntoResponse for SqlErr {
     fn into_response(self) -> Response {
         match self {
             SqlErr::QueryErr(err) => err.into_response(),
-            SqlErr::Metadata(err) => (
-                StatusCode::BAD_REQUEST,
-                axum::Json(GenericError {
-                    message: err.to_string(),
-                }),
-            )
-                .into_response(),
+            // Only a missing schema is the caller's problem; a failed read or parse
+            // of our own schema files is ours.
+            SqlErr::Metadata(err @ SchemaErr::SchemaNotFound(_)) => {
+                coded_response(ErrorCode::MalformedRequest, err.to_string())
+            }
+            SqlErr::Metadata(err) => coded_response(ErrorCode::Internal, err.to_string()),
         }
     }
 }

--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -5,7 +5,6 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use axum::body;
-use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use once_cell::sync::Lazy;
 use prost::{DecodeError, Message};
@@ -15,7 +14,7 @@ use thiserror;
 
 use crate::network::{ChunkNotFound, NetworkClient};
 use crate::sql::rewrite_target;
-use crate::types::{BlockNumber, DatasetId, GenericError};
+use crate::types::{coded_response, BlockNumber, DatasetId, ErrorCode};
 
 use sql_query_plan::plan::{self, Source, TargetPlan};
 
@@ -35,22 +34,22 @@ pub enum QueryErr {
     InternalError(String),
 }
 
+impl QueryErr {
+    pub fn class(&self) -> ErrorCode {
+        match self {
+            Self::InternalError(_) => ErrorCode::Internal,
+            // No worker holds the chunk: nothing the client can rewrite.
+            Self::NoWorker(_) => ErrorCode::NoWorkers,
+            Self::DecodePlan(_) | Self::Planning(_) | Self::RewriteTarget(_) | Self::NoChunk(_) => {
+                ErrorCode::MalformedRequest
+            }
+        }
+    }
+}
+
 impl IntoResponse for QueryErr {
     fn into_response(self) -> Response {
-        match self {
-            QueryErr::InternalError(msg) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                axum::Json(GenericError { message: msg }),
-            )
-                .into_response(),
-            err => (
-                StatusCode::BAD_REQUEST,
-                axum::Json(GenericError {
-                    message: err.to_string(),
-                }),
-            )
-                .into_response(),
-        }
+        coded_response(self.class(), self.to_string())
     }
 }
 

--- a/src/types/errors.rs
+++ b/src/types/errors.rs
@@ -1,18 +1,342 @@
 use std::time::Duration;
 
 use axum::http::StatusCode;
+use axum::response::Response;
 use serde::Serialize;
 use sqd_contract_client::PeerId;
 use tokio::time::Instant;
+
+/// Coarse category, the wire's `type`. `Api` is the only one that should page.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ErrorType {
+    InvalidRequest,
+    RateLimit,
+    Availability,
+    /// An invariant we own was violated.
+    Api,
+}
+
+impl ErrorType {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidRequest => "invalid_request_error",
+            Self::RateLimit => "rate_limit_error",
+            Self::Availability => "availability_error",
+            Self::Api => "api_error",
+        }
+    }
+
+    pub const fn retryable(self) -> bool {
+        match self {
+            Self::RateLimit | Self::Availability => true,
+            Self::InvalidRequest | Self::Api => false,
+        }
+    }
+}
+
+/// Declare the code vocabulary once, and derive the enum, [`ErrorCode::ALL`] and
+/// [`ErrorCode::as_str`] from that single list.
+///
+/// A hand-written `ALL` beside a hand-written enum can fall behind it, and a compile-time
+/// tripwire cannot stop that: an exhaustive `match` forces an arm *in the match*, never an
+/// entry in a `&[Self]` literal. Since every test that pins DEF-10 and IB-5 iterates `ALL`,
+/// a code missing from it ships with no status row and no frozen wire string, silently.
+/// Generating both makes that divergence unrepresentable rather than merely asserted.
+macro_rules! error_codes {
+    (
+        $(#[$enum_meta:meta])*
+        pub enum $name:ident {
+            $( $(#[$variant_meta:meta])* $variant:ident => $wire:literal ),+ $(,)?
+        }
+    ) => {
+        $(#[$enum_meta])*
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        pub enum $name {
+            $( $(#[$variant_meta])* $variant, )+
+        }
+
+        impl $name {
+            /// Every code. Derived from the same list as the enum, so a variant that is
+            /// missing here does not exist.
+            pub const ALL: &'static [Self] = &[ $(Self::$variant),+ ];
+
+            pub const fn as_str(self) -> &'static str {
+                match self { $(Self::$variant => $wire,)+ }
+            }
+        }
+    };
+}
+
+error_codes! {
+    /// Specific cause, the wire's `code`. [`ErrorCode::as_str`] is public API twice over:
+    /// the `code` error field and the `error_code` metric label. Adding a variant is safe;
+    /// renaming one breaks client matches and dashboards silently.
+    ///
+    /// A 204 has no code: it is the correct answer to a query whose range isn't produced
+    /// yet, not a failure. It carries no body, so a code could never reach a client anyway
+    /// (IB-4, ADR-014) — and on the metric `no_data` only ever restated `status="204"`.
+    pub enum ErrorCode {
+        MalformedRequest => "malformed_request",
+        /// Right path, wrong verb. Keeps 405 rather than folding into
+        /// [`Self::MalformedRequest`]: the request is well-formed, and `Allow` tells the
+        /// client what to do — a detail a 400 has nowhere to put.
+        MethodNotAllowed => "method_not_allowed",
+        UnknownDataset => "unknown_dataset",
+        NotFound => "not_found",
+        BaseBlockMismatch => "base_block_mismatch",
+        Overloaded => "overloaded",
+        NoWorkers => "no_workers",
+        /// Workers were reachable; every attempt failed transiently until retries ran out.
+        RetriesExhausted => "retries_exhausted",
+        UpstreamUnavailable => "upstream_unavailable",
+        /// `/ready` declining traffic, so a routine drain doesn't read as an error.
+        NotReady => "not_ready",
+        /// A worker returned something that cannot be right.
+        WorkerFailure => "worker_failure",
+        Internal => "internal_error",
+        /// Unset by any handler. `api_error` so it pages instead of hiding; `http_labels`
+        /// re-types an unclassified 4xx.
+        Unclassified => "unclassified",
+    }
+}
+
+impl ErrorCode {
+    pub const fn error_type(self) -> ErrorType {
+        match self {
+            Self::MalformedRequest
+            | Self::MethodNotAllowed
+            | Self::UnknownDataset
+            | Self::NotFound
+            | Self::BaseBlockMismatch => ErrorType::InvalidRequest,
+
+            Self::Overloaded => ErrorType::RateLimit,
+
+            Self::NoWorkers
+            | Self::RetriesExhausted
+            | Self::UpstreamUnavailable
+            | Self::NotReady => ErrorType::Availability,
+
+            Self::WorkerFailure | Self::Internal | Self::Unclassified => ErrorType::Api,
+        }
+    }
+
+    /// IB-5's status for this code. The binding is closed, so it lives here rather than
+    /// being restated at each site that builds a response — those restatements were free
+    /// to disagree, and only a hand-written test said they didn't.
+    ///
+    /// Two documented exceptions keep a status of their own: a *proxied* refusal retains
+    /// the upstream's (a 429 rather than our 529, its own 5xx rather than our 502), and
+    /// `Unclassified` reports whatever escaped classification — 500 is only its floor.
+    pub fn status(self) -> StatusCode {
+        match self {
+            Self::MalformedRequest => StatusCode::BAD_REQUEST,
+            Self::MethodNotAllowed => StatusCode::METHOD_NOT_ALLOWED,
+            Self::UnknownDataset | Self::NotFound => StatusCode::NOT_FOUND,
+            Self::BaseBlockMismatch => StatusCode::CONFLICT,
+            Self::Overloaded => server_overloaded(),
+            Self::NoWorkers | Self::RetriesExhausted | Self::NotReady => {
+                StatusCode::SERVICE_UNAVAILABLE
+            }
+            Self::UpstreamUnavailable => StatusCode::BAD_GATEWAY,
+            Self::WorkerFailure | Self::Internal | Self::Unclassified => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        }
+    }
+
+    /// INV-26: the one class that always owes the client a back-off interval. The value
+    /// is context's (a worker's backoff, an upstream's header); only the obligation is
+    /// the code's.
+    pub const fn requires_hint(self) -> bool {
+        matches!(self, Self::Overloaded)
+    }
+
+    /// Stands in when an upstream error body carries no usable prose of its own.
+    pub const fn default_message(self) -> &'static str {
+        match self {
+            Self::MalformedRequest => "Bad request",
+            Self::MethodNotAllowed => "Method not allowed for this endpoint",
+            Self::UnknownDataset => "Unknown dataset",
+            Self::NotFound => "Not found",
+            Self::BaseBlockMismatch => "Base block mismatch",
+            Self::Overloaded => "Service is overloaded, please try again later",
+            Self::NoWorkers => "No available workers to serve the request",
+            Self::RetriesExhausted => "All query attempts failed",
+            Self::UpstreamUnavailable => "Upstream data source unavailable",
+            Self::NotReady => "Portal is not ready",
+            Self::WorkerFailure => "Worker returned invalid data",
+            Self::Internal => "Internal error",
+            Self::Unclassified => "Unclassified error",
+        }
+    }
+
+    /// Classify a proxied response, where the status is all we see, into the public
+    /// status and code. Lossy: hotblocks splits 400 five ways but keeps the discriminant
+    /// in extensions, which never reach the wire.
+    ///
+    /// A matched status is preserved; an *unmatched* 4xx is normalized to 400, because
+    /// the upstream's choice among them describes a contract the portal generated and the
+    /// client cannot act on (DC-4, ADR-014).
+    ///
+    /// Only 429 and 529 read as OVERLOADED. A 503 is unavailability, not congestion —
+    /// that is the whole of ADR-007, applied to the upstream instead of to ourselves.
+    /// Lumping it in said "capacity is exhausted" about a source that has no capacity at
+    /// all, made a dead dependency indistinguishable from a healthy one shedding load,
+    /// and had us hand the client a retry hint pointing back into it.
+    pub fn classify_upstream(status: StatusCode) -> (StatusCode, Self) {
+        match status.as_u16() {
+            409 => (status, Self::BaseBlockMismatch),
+            404 => (status, Self::UnknownDataset),
+            // The two that keep the upstream's status rather than the code's: its 429 is
+            // more specific than our 529, and its 5xx than our 502.
+            429 | 529 => (status, Self::Overloaded),
+            500..=599 => (status, Self::UpstreamUnavailable),
+            400..=499 => (Self::MalformedRequest.status(), Self::MalformedRequest),
+            _ => (status, Self::Unclassified),
+        }
+    }
+}
+
+/// Non-standard "Site is overloaded" status used to signal clients to back off (ADR-007).
+pub fn server_overloaded() -> StatusCode {
+    StatusCode::from_u16(529).expect("529 is a valid status code")
+}
+
+/// Error body shared by every endpoint.
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+pub struct ErrorResponse {
+    pub error: ErrorDetail,
+}
+
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+pub struct ErrorDetail {
+    /// Coarse category to branch on.
+    #[serde(rename = "type")]
+    #[schema(rename = "type", example = "rate_limit_error")]
+    pub error_type: &'static str,
+    /// Specific cause. Stable — match on this.
+    #[schema(example = "overloaded")]
+    pub code: &'static str,
+    /// Human-readable detail. Prose, not stable; do not parse.
+    #[schema(example = "Service is overloaded, please try again later")]
+    pub message: String,
+    /// The request parameter at fault, when the error is about one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "buffer_size")]
+    pub param: Option<&'static str>,
+    /// Echo of `x-request-id`, for support. Filled in by the logging middleware on 5xx
+    /// only; every response carries the header regardless.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+}
+
+impl ErrorResponse {
+    pub fn new(code: ErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            error: ErrorDetail {
+                error_type: code.error_type().as_str(),
+                code: code.as_str(),
+                message: message.into(),
+                param: None,
+                request_id: None,
+            },
+        }
+    }
+}
+
+/// The envelope plus any top-level siblings the binding requires, kept as a struct so
+/// exactly one place decides the shape. Every error body in the portal — locally
+/// produced or rewritten from an upstream — is built here and rendered by
+/// [`error_body_response`], which is what keeps the two `/stream` data sources from
+/// drifting into two shapes (IB-5).
+#[derive(Debug, Clone)]
+pub struct ErrorBody {
+    code: ErrorCode,
+    response: ErrorResponse,
+    siblings: serde_json::Map<String, serde_json::Value>,
+}
+
+impl ErrorBody {
+    pub fn new(code: ErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            response: ErrorResponse::new(code, message),
+            siblings: serde_json::Map::new(),
+        }
+    }
+
+    pub fn with_param(mut self, param: &'static str) -> Self {
+        self.response.error.param = Some(param);
+        self
+    }
+
+    /// A top-level key beside `error`. Only for keys the binding pins there — today
+    /// just 409's `previousBlocks`, which clients walk to find a shared ancestor and
+    /// which therefore cannot move under `error`.
+    pub fn with_sibling(mut self, key: &str, value: serde_json::Value) -> Self {
+        self.siblings.insert(key.to_owned(), value);
+        self
+    }
+
+    pub fn code(&self) -> ErrorCode {
+        self.code
+    }
+
+    pub fn set_request_id(&mut self, request_id: &str) {
+        self.response.error.request_id = Some(request_id.to_owned());
+    }
+
+    pub fn to_json(&self) -> serde_json::Value {
+        let mut object = serde_json::Map::with_capacity(1 + self.siblings.len());
+        object.insert(
+            "error".to_owned(),
+            serde_json::to_value(&self.response.error).expect("ErrorDetail is serializable"),
+        );
+        object.extend(self.siblings.clone());
+        serde_json::Value::Object(object)
+    }
+}
+
+/// Render an error body, and keep the struct in extensions so the logging middleware can
+/// stamp in `request_id` — the one field only it knows — by re-rendering rather than
+/// parsing the bytes back out.
+pub fn error_body_response(status: StatusCode, body: ErrorBody) -> Response {
+    use axum::response::IntoResponse;
+    let mut response = (status, axum::Json(body.to_json())).into_response();
+    response.extensions_mut().insert(body.code);
+    response.extensions_mut().insert(body);
+    response
+}
+
+pub fn error_response(status: StatusCode, code: ErrorCode, message: impl Into<String>) -> Response {
+    error_body_response(status, ErrorBody::new(code, message))
+}
+
+/// The usual case: the status is the one IB-5 binds the code to. Prefer this to
+/// [`error_response`], which exists for the two places that carry a status of their own —
+/// a proxied refusal, and a deprecated route with its own history.
+pub fn coded_response(code: ErrorCode, message: impl Into<String>) -> Response {
+    error_response(code.status(), code, message)
+}
 
 #[derive(thiserror::Error, Debug)]
 pub enum RequestError {
     #[error("{0}")]
     BadRequest(String),
+    /// Names the offending parameter, so a client need not parse the message for it.
+    #[error("{message}")]
+    InvalidParam {
+        param: &'static str,
+        message: String,
+    },
     #[error("No data")]
     NoData,
     #[error("{0}")]
-    InternalError(String),
+    RetriesExhausted(String),
+    /// Split from [`Self::RetriesExhausted`]: telling a client to retry our own bug
+    /// wastes its time and hides ours.
+    #[error("{0}")]
+    Internal(String),
     #[error("{0}")]
     Failure(String),
     #[error("No available workers to serve the request")]
@@ -45,6 +369,34 @@ pub enum QueryError {
     BaseBlockMismatch(sqd_primitives::BlockRef),
 }
 
+/// What an exhausted run of one failure means for the client, once every attempt agrees
+/// on it. A total function rather than a list of names at the call site: a new
+/// [`QueryError`] then has to say which bucket it falls in, instead of joining the
+/// transient one by omission — which is how a run of capacity refusals came to answer a
+/// bare 503 (DC-1).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExhaustionClass {
+    /// The network serves bad data or verification is broken. Pages.
+    Integrity,
+    /// Congestion: the client is owed a status to back off from and a hint.
+    Capacity,
+    /// A later retry can still succeed.
+    Transient,
+}
+
+impl QueryError {
+    pub const fn exhaustion_class(&self) -> ExhaustionClass {
+        match self {
+            Self::Integrity(_) => ExhaustionClass::Integrity,
+            Self::RateLimitExceeded => ExhaustionClass::Capacity,
+            Self::BadRequest(_)
+            | Self::Retriable(_)
+            | Self::Failure(_)
+            | Self::BaseBlockMismatch(_) => ExhaustionClass::Transient,
+        }
+    }
+}
+
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum SendQueryError {
     #[error("no workers for the given block are available")]
@@ -57,9 +409,9 @@ impl RequestError {
     pub fn from_query_error(value: QueryError, worker: PeerId) -> Self {
         match value {
             QueryError::BadRequest(s) => RequestError::BadRequest(s),
-            QueryError::Retriable(s) => {
-                RequestError::InternalError(format!("received an error from worker {worker}: {s}"))
-            }
+            QueryError::Retriable(s) => RequestError::RetriesExhausted(format!(
+                "received an error from worker {worker}: {s}"
+            )),
             QueryError::Integrity(s) => {
                 RequestError::Failure(format!("worker {worker} returned invalid data: {s}"))
             }
@@ -68,78 +420,350 @@ impl RequestError {
             QueryError::BaseBlockMismatch(block_ref) => RequestError::BaseBlockMismatch(block_ref),
         }
     }
-}
 
-/// Non-standard "Site is overloaded" status used to signal clients to back off.
-fn server_overloaded() -> StatusCode {
-    StatusCode::from_u16(529).expect("529 should be a valid status code")
+    /// `None` for [`Self::NoData`] alone: a 204 is the correct answer, not a failure,
+    /// and the taxonomy covers failures.
+    pub fn code(&self) -> Option<ErrorCode> {
+        Some(match self {
+            Self::NoData => return None,
+            Self::BadRequest(_) | Self::InvalidParam { .. } => ErrorCode::MalformedRequest,
+            Self::RetriesExhausted(_) => ErrorCode::RetriesExhausted,
+            Self::Internal(_) => ErrorCode::Internal,
+            Self::Failure(_) => ErrorCode::WorkerFailure,
+            Self::Unavailable => ErrorCode::NoWorkers,
+            Self::RateLimitExceeded | Self::BusyFor(_) => ErrorCode::Overloaded,
+            Self::BaseBlockMismatch(_) => ErrorCode::BaseBlockMismatch,
+        })
+    }
 }
 
 impl axum::response::IntoResponse for RequestError {
     fn into_response(self) -> axum::response::Response {
         use axum::http::header;
-        let mut response = match self {
-            Self::BadRequest(e) => {
-                (StatusCode::BAD_REQUEST, format!("Bad request: {e}")).into_response()
+
+        // Not an error: no body, no envelope, no code (IB-4).
+        let Some(code) = self.code() else {
+            return Response::builder()
+                .status(StatusCode::NO_CONTENT)
+                .body(axum::body::Body::empty())
+                .expect("204 with an empty body is valid");
+        };
+
+        // What the client is told, beyond the code: prose, and the two structured fields
+        // a variant can carry. The status is the code's (IB-5) and is not restated.
+        let body = match self {
+            Self::NoData => unreachable!("NoData has no code"),
+            Self::BaseBlockMismatch(ref block_ref) => ErrorBody::new(code, self.to_string())
+                .with_sibling("previousBlocks", serde_json::json!([block_ref])),
+            Self::InvalidParam { param, ref message } => {
+                ErrorBody::new(code, format!("Bad request: {message}")).with_param(param)
             }
-
-            Self::NoData => (StatusCode::NO_CONTENT, ()).into_response(),
-
-            s @ Self::Unavailable => {
-                (StatusCode::SERVICE_UNAVAILABLE, s.to_string()).into_response()
+            Self::BadRequest(ref e) => ErrorBody::new(code, format!("Bad request: {e}")),
+            Self::Internal(ref e) => ErrorBody::new(code, format!("Internal error: {e}")),
+            Self::RetriesExhausted(ref e) => {
+                ErrorBody::new(code, format!("All query attempts failed: {e}"))
             }
-
-            s @ Self::Failure(_) => {
-                (StatusCode::INTERNAL_SERVER_ERROR, s.to_string()).into_response()
-            }
-
-            s @ Self::BusyFor(duration) => axum::http::Response::builder()
-                .status(server_overloaded())
-                .header(header::RETRY_AFTER, duration.as_secs() + 1)
-                .body(axum::body::Body::from(s.to_string()))
-                .unwrap(),
-
-            s @ Self::RateLimitExceeded => axum::http::Response::builder()
-                .status(server_overloaded())
-                .header(header::RETRY_AFTER, 1)
-                .body(axum::body::Body::from(s.to_string()))
-                .unwrap(),
-
-            Self::InternalError(e) => (
-                StatusCode::SERVICE_UNAVAILABLE,
-                format!("All query attempts failed, last error: {e}"),
-            )
-                .into_response(),
-
-            Self::BaseBlockMismatch(block_ref) => {
-                let body = serde_json::json!({
-                    "previousBlocks": [block_ref],
-                });
-                return (StatusCode::CONFLICT, axum::Json(body)).into_response();
+            Self::Unavailable | Self::Failure(_) | Self::BusyFor(_) | Self::RateLimitExceeded => {
+                ErrorBody::new(code, self.to_string())
             }
         };
-        response.headers_mut().insert(
-            header::CONTENT_TYPE,
-            header::HeaderValue::from_static("text/plain; charset=utf-8"),
-        );
+
+        let mut response = error_body_response(code.status(), body);
+
+        if code.requires_hint() {
+            // The obligation is the code's, the interval the variant's.
+            let seconds = match &self {
+                Self::BusyFor(duration) => duration.as_secs() + 1,
+                _ => RETRY_AFTER_FLOOR,
+            };
+            response
+                .headers_mut()
+                .insert(header::RETRY_AFTER, seconds.into());
+        }
         response
     }
 }
 
-impl RequestError {
-    pub fn short_code(&self) -> &'static str {
-        match self {
-            Self::BadRequest(_) => "bad_request",
-            Self::NoData => "no_data",
-            Self::InternalError(_) => "internal_error",
-            Self::Failure(_) => "failure",
-            Self::Unavailable | Self::BusyFor(_) | Self::RateLimitExceeded => "overloaded",
-            Self::BaseBlockMismatch(_) => "base_block_mismatch",
+/// P-RETRY-AFTER-MIN: the smallest back-off a refusal may ask for.
+pub const RETRY_AFTER_FLOOR: u64 = 1;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::response::IntoResponse;
+
+    async fn parts(response: Response) -> (StatusCode, Option<ErrorCode>, serde_json::Value) {
+        let status = response.status();
+        let code = response.extensions().get::<ErrorCode>().copied();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body = if bytes.is_empty() {
+            serde_json::Value::Null
+        } else {
+            serde_json::from_slice(&bytes).expect("error bodies are JSON")
+        };
+        (status, code, body)
+    }
+
+    #[tokio::test]
+    async fn every_variant_is_classified_and_carries_type_and_code() {
+        let cases = [
+            (
+                RequestError::BadRequest("nope".into()),
+                StatusCode::BAD_REQUEST,
+                ErrorCode::MalformedRequest,
+            ),
+            (
+                RequestError::RetriesExhausted("boom".into()),
+                StatusCode::SERVICE_UNAVAILABLE,
+                ErrorCode::RetriesExhausted,
+            ),
+            (
+                RequestError::Internal("bug".into()),
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorCode::Internal,
+            ),
+            (
+                RequestError::Failure("worker".into()),
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorCode::WorkerFailure,
+            ),
+            (
+                RequestError::Unavailable,
+                StatusCode::SERVICE_UNAVAILABLE,
+                ErrorCode::NoWorkers,
+            ),
+            (
+                RequestError::RateLimitExceeded,
+                server_overloaded(),
+                ErrorCode::Overloaded,
+            ),
+            (
+                RequestError::BusyFor(Duration::from_secs(3)),
+                server_overloaded(),
+                ErrorCode::Overloaded,
+            ),
+        ];
+
+        for (error, want_status, want_code) in cases {
+            let (status, code, body) = parts(error.into_response()).await;
+            assert_eq!(status, want_status, "{want_code:?}");
+            assert_eq!(code, Some(want_code), "code must reach the middleware");
+            assert_eq!(body["error"]["code"], want_code.as_str());
+            assert_eq!(body["error"]["type"], want_code.error_type().as_str());
+            assert!(
+                body["error"]["message"]
+                    .as_str()
+                    .is_some_and(|m| !m.is_empty()),
+                "{want_code:?} must explain itself"
+            );
         }
     }
-}
 
-#[derive(Debug, Clone, Serialize)]
-pub struct GenericError {
-    pub message: String,
+    #[tokio::test]
+    async fn a_bad_parameter_names_itself() {
+        let error = RequestError::InvalidParam {
+            param: "buffer_size",
+            message: "buffer_size must be greater than 0".into(),
+        };
+        let (status, code, body) = parts(error.into_response()).await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(code, Some(ErrorCode::MalformedRequest));
+        assert_eq!(body["error"]["param"], "buffer_size");
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+    }
+
+    /// `param` is absent, not null, when the error isn't about a parameter.
+    #[tokio::test]
+    async fn optional_fields_are_omitted_when_unset() {
+        let (_, _, body) = parts(RequestError::Unavailable.into_response()).await;
+        let error = body["error"].as_object().unwrap();
+        assert!(
+            !error.contains_key("param"),
+            "param must be omitted: {error:?}"
+        );
+        assert!(!error.contains_key("request_id"));
+    }
+
+    /// A 204 is the right answer to a range that isn't produced yet, not a failure. It
+    /// carries no body and no taxonomy code, so nothing downstream can report it as one.
+    #[tokio::test]
+    async fn no_data_is_not_an_error() {
+        let (status, code, body) = parts(RequestError::NoData.into_response()).await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+        assert_eq!(code, None, "204 must carry no error code");
+        assert_eq!(body, serde_json::Value::Null);
+        assert_eq!(RequestError::NoData.code(), None);
+    }
+
+    /// `previousBlocks` is what clients walk back to find a shared ancestor after a
+    /// reorg. It stays top-level; the error envelope is added beside it.
+    #[tokio::test]
+    async fn conflict_keeps_previous_blocks_top_level() {
+        let block = sqd_primitives::BlockRef {
+            number: 42,
+            hash: "0xdead".to_owned(),
+        };
+        let (status, code, body) =
+            parts(RequestError::BaseBlockMismatch(block).into_response()).await;
+
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(code, Some(ErrorCode::BaseBlockMismatch));
+        assert_eq!(body["previousBlocks"][0]["number"], 42);
+        assert_eq!(body["previousBlocks"][0]["hash"], "0xdead");
+        assert_eq!(body["error"]["code"], "base_block_mismatch");
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+    }
+
+    #[tokio::test]
+    async fn overload_tells_the_client_how_long_to_wait() {
+        let response = RequestError::BusyFor(Duration::from_secs(3)).into_response();
+        assert_eq!(response.headers()[axum::http::header::RETRY_AFTER], "4");
+
+        let response = RequestError::RateLimitExceeded.into_response();
+        assert_eq!(response.headers()[axum::http::header::RETRY_AFTER], "1");
+    }
+
+    /// The point of the split: a client that hits our bug must not be told to retry.
+    #[test]
+    fn retryability_follows_the_type() {
+        assert!(ErrorCode::RetriesExhausted.error_type().retryable());
+        assert!(ErrorCode::Overloaded.error_type().retryable());
+        assert!(!ErrorCode::Internal.error_type().retryable());
+        assert!(!ErrorCode::WorkerFailure.error_type().retryable());
+        assert!(!ErrorCode::MalformedRequest.error_type().retryable());
+    }
+
+    /// Only api_error should page, so an unclassified response must land there.
+    #[test]
+    fn unclassified_is_an_api_error() {
+        assert_eq!(ErrorCode::Unclassified.error_type(), ErrorType::Api);
+    }
+
+    /// A matched upstream status is preserved; an unmatched 4xx normalizes to 400,
+    /// because the upstream's choice among them describes a contract the portal
+    /// generated and the client cannot act on (DC-4).
+    ///
+    /// 503 is the line ADR-007 draws: unavailability, not congestion. Reading it as
+    /// OVERLOADED claimed exhausted capacity of a source that may have none running.
+    #[test]
+    fn upstream_statuses_map_onto_the_taxonomy() {
+        use ErrorCode::*;
+        let cases = [
+            (400, 400, MalformedRequest),
+            (403, 400, MalformedRequest),
+            (418, 400, MalformedRequest),
+            (404, 404, UnknownDataset),
+            (409, 409, BaseBlockMismatch),
+            (429, 429, Overloaded),
+            (529, 529, Overloaded),
+            (500, 500, UpstreamUnavailable),
+            (502, 502, UpstreamUnavailable),
+            (503, 503, UpstreamUnavailable),
+        ];
+        for (upstream, want_status, want_code) in cases {
+            let (status, code) =
+                ErrorCode::classify_upstream(StatusCode::from_u16(upstream).unwrap());
+            assert_eq!(status.as_u16(), want_status, "upstream {upstream}");
+            assert_eq!(code, want_code, "upstream {upstream}");
+        }
+    }
+
+    /// IB-5 calls the code→status mapping closed, which was previously only assertable
+    /// code by code because each response site named its own status. Now it is one
+    /// object, so the whole binding is checked against the spec in one place — and a
+    /// code added without a status cannot compile.
+    #[test]
+    fn every_code_answers_the_status_ib5_binds_it_to() {
+        use ErrorCode::*;
+        let binding = [
+            (MalformedRequest, 400),
+            (MethodNotAllowed, 405),
+            (UnknownDataset, 404),
+            (NotFound, 404),
+            (BaseBlockMismatch, 409),
+            (Overloaded, 529),
+            (NoWorkers, 503),
+            (RetriesExhausted, 503),
+            (UpstreamUnavailable, 502),
+            (NotReady, 503),
+            (WorkerFailure, 500),
+            (Internal, 500),
+            (Unclassified, 500),
+        ];
+        for (code, want) in binding {
+            assert_eq!(code.status().as_u16(), want, "{}", code.as_str());
+        }
+
+        // The tripwire, and it holds only because `ALL` is generated from the enum: a new
+        // code is in `ALL` by construction, so it must appear here and in DEF-10.
+        for code in ErrorCode::ALL {
+            assert!(
+                binding.iter().any(|(listed, _)| listed == code),
+                "{} needs a row here and in DEF-10",
+                code.as_str()
+            );
+        }
+
+        // INV-26 is an iff over the same object.
+        for (code, _) in binding {
+            assert_eq!(
+                code.requires_hint(),
+                code == Overloaded,
+                "{}",
+                code.as_str()
+            );
+        }
+    }
+
+    /// Clients match on these and dashboards group by them; a rename is a silent
+    /// breaking change. Update only alongside that migration.
+    #[test]
+    fn the_wire_vocabulary_is_frozen() {
+        use ErrorCode::*;
+        let expected = [
+            (
+                MalformedRequest,
+                "malformed_request",
+                "invalid_request_error",
+            ),
+            (
+                MethodNotAllowed,
+                "method_not_allowed",
+                "invalid_request_error",
+            ),
+            (UnknownDataset, "unknown_dataset", "invalid_request_error"),
+            (NotFound, "not_found", "invalid_request_error"),
+            (
+                BaseBlockMismatch,
+                "base_block_mismatch",
+                "invalid_request_error",
+            ),
+            (Overloaded, "overloaded", "rate_limit_error"),
+            (NoWorkers, "no_workers", "availability_error"),
+            (RetriesExhausted, "retries_exhausted", "availability_error"),
+            (
+                UpstreamUnavailable,
+                "upstream_unavailable",
+                "availability_error",
+            ),
+            (NotReady, "not_ready", "availability_error"),
+            (WorkerFailure, "worker_failure", "api_error"),
+            (Internal, "internal_error", "api_error"),
+            (Unclassified, "unclassified", "api_error"),
+        ];
+        for (code, want_code, want_type) in expected {
+            assert_eq!(code.as_str(), want_code);
+            assert_eq!(code.error_type().as_str(), want_type);
+        }
+        for code in ErrorCode::ALL {
+            assert!(
+                expected.iter().any(|(listed, ..)| listed == code),
+                "{} is not pinned here, so renaming it would break clients silently",
+                code.as_str()
+            );
+        }
+    }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -9,5 +9,9 @@ pub use api_types::DatasetRef;
 pub use chunk::*;
 pub use common::*;
 pub use dataset::*;
-pub use errors::{GenericError, QueryError, RequestError, SendQueryError};
+pub use errors::{
+    coded_response, error_body_response, error_response, server_overloaded, ErrorBody, ErrorCode,
+    ErrorDetail, ErrorResponse, ErrorType, ExhaustionClass, QueryError, RequestError,
+    SendQueryError, RETRY_AFTER_FLOOR,
+};
 pub use request::*;

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -1,4 +1,5 @@
 use axum::{
+    body::Body,
     extract::Request,
     response::{IntoResponse, Response},
     routing::MethodRouter,
@@ -9,10 +10,25 @@ use tower::{Layer, Service};
 use tower_http::request_id::RequestId;
 use tracing::Instrument;
 
-use crate::{metrics, types::StreamRequest};
+use crate::{
+    metrics,
+    types::{coded_response, error_response, ErrorBody, ErrorCode, StreamRequest},
+};
 
 const LOG_INTERVAL: Duration = Duration::from_secs(5);
 const NO_DATA_SOURCE: &str = "none";
+
+/// Endpoint label for a request that never reached a route. Constant because the path is
+/// client-supplied there, and labelling with it would mint a series per request.
+const UNROUTED_ENDPOINT: &str = "unrouted";
+
+/// Marks a response [`middleware`] already logged and counted.
+#[derive(Clone, Copy)]
+struct Observed;
+
+/// `SetRequestIdLayer`'s header, which it does not export.
+pub(crate) const X_REQUEST_ID: axum::http::HeaderName =
+    axum::http::HeaderName::from_static("x-request-id");
 
 pub struct StreamStats {
     pub queries_sent: u64,
@@ -102,6 +118,60 @@ impl StreamStats {
     }
 }
 
+/// Reject a non-ASCII client `x-request-id` with a generated correlation id.
+///
+/// HTTP permits obs-text in a header value, but REQ-9 restricts this application header to
+/// ASCII. This runs outside `SetRequestIdLayer` and therefore records the early response
+/// itself; no downstream request-id, CORS, observability, or routing layer has run yet.
+pub async fn reject_non_ascii_request_id(req: Request, next: axum::middleware::Next) -> Response {
+    let is_non_ascii = req
+        .headers()
+        .get(&X_REQUEST_ID)
+        .is_some_and(|value| value.to_str().is_err());
+    if !is_non_ascii {
+        return next.run(req).await;
+    }
+
+    let method = req.method().to_string();
+    let path = req.uri().path().to_string();
+    let start = Instant::now();
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let request_id_header: axum::http::HeaderValue = request_id
+        .parse()
+        .expect("a UUID is always a valid header value");
+    let mut response = coded_response(
+        ErrorCode::MalformedRequest,
+        "x-request-id must contain only ASCII characters",
+    );
+    response
+        .headers_mut()
+        .insert(X_REQUEST_ID, request_id_header.clone());
+    response
+        .extensions_mut()
+        .insert(RequestId::new(request_id_header));
+
+    let latency = start.elapsed();
+    tracing::info!(
+        target: "http_request",
+        request_id,
+        method,
+        path,
+        status = %response.status(),
+        error_code = ErrorCode::MalformedRequest.as_str(),
+        ?latency,
+        "HTTP request rejected before routing"
+    );
+    metrics::report_http_response(
+        UNROUTED_ENDPOINT.to_owned(),
+        response.status(),
+        NO_DATA_SOURCE.to_owned(),
+        Some(ErrorCode::MalformedRequest),
+        latency.as_secs_f64(),
+    );
+    response.extensions_mut().insert(Observed);
+    response
+}
+
 pub async fn middleware(req: Request, next: axum::middleware::Next) -> impl IntoResponse {
     let method = req.method().to_string();
     let path = req.uri().path().to_string();
@@ -113,14 +183,15 @@ pub async fn middleware(req: Request, next: axum::middleware::Next) -> impl Into
         .expect("RequestId should be set by SetRequestIdLayer")
         .header_value()
         .to_str()
-        // The request id may be a client-supplied `x-request-id` header, which is
-        // preserved verbatim and can contain non-visible-ASCII bytes. Fall back to
-        // an empty id rather than panicking the request task on such input.
-        .unwrap_or_default();
+        // [`reject_non_ascii_request_id`] rejects a non-ASCII id before routing; this only
+        // guards a stack missing that layer, where an empty id still beats a task panic.
+        .unwrap_or_default()
+        .to_owned();
 
     let span = tracing::span!(tracing::Level::INFO, "http_request", request_id);
 
-    let response = next.run(req).instrument(span.clone()).await;
+    let response =
+        normalize_framework_rejection(next.run(req).instrument(span.clone()).await).await;
 
     let latency = start.elapsed();
 
@@ -136,6 +207,7 @@ pub async fn middleware(req: Request, next: axum::middleware::Next) -> impl Into
         .map(data_source_metric_label)
         .unwrap_or(NO_DATA_SOURCE)
         .to_owned();
+    let error_code = response.extensions().get::<ErrorCode>().copied();
 
     span.in_scope(|| {
         tracing::info!(
@@ -144,6 +216,7 @@ pub async fn middleware(req: Request, next: axum::middleware::Next) -> impl Into
             path,
             ?version,
             status = %response.status(),
+            error_code = error_code.map(ErrorCode::as_str),
             ?latency,
             "HTTP request processed"
         );
@@ -153,10 +226,171 @@ pub async fn middleware(req: Request, next: axum::middleware::Next) -> impl Into
         endpoint,
         response.status(),
         data_source,
+        error_code,
         latency.as_secs_f64(),
     );
 
+    let mut response = stamp_request_id(response, &request_id);
+    response.extensions_mut().insert(Observed);
     response
+}
+
+/// Normalize, log and count a response [`middleware`] never saw.
+///
+/// That middleware is a `route_layer`, so it misses both a path the router never matched and
+/// a request refused by a layer outside it — today a `RequestDecompressionLayer` 415, which
+/// only `gzip` satisfies here, so `deflate`, `br` and `zstd` all answered a bodyless 415 with
+/// no envelope, no code and no metric (INV-26, GAP-16). Must sit outside that layer.
+pub async fn observe_bypassed(req: Request, next: axum::middleware::Next) -> Response {
+    let method = req.method().to_string();
+    let path = req.uri().path().to_string();
+    // Read softly: this path exists for degenerate requests, so a stack without
+    // SetRequestIdLayer must not panic here.
+    let request_id = req
+        .extensions()
+        .get::<RequestId>()
+        .and_then(|id| id.header_value().to_str().ok())
+        .unwrap_or_default()
+        .to_owned();
+    let start = Instant::now();
+
+    let response = next.run(req).await;
+    if response.extensions().get::<Observed>().is_some() {
+        return response;
+    }
+
+    let response = normalize_framework_rejection(response).await;
+    let latency = start.elapsed();
+    let error_code = response.extensions().get::<ErrorCode>().copied();
+
+    tracing::info!(
+        target: "http_request",
+        // On the field, not on a span: nesting a second `http_request` span around a
+        // routed request would record it twice. [`middleware`] gets it from its span,
+        // and without it here REQ-9 fails on exactly the requests this layer exists for —
+        // an unmatched route and a refused content-encoding.
+        request_id,
+        method,
+        path,
+        status = %response.status(),
+        error_code = error_code.map(ErrorCode::as_str),
+        ?latency,
+        "HTTP request processed outside the router"
+    );
+    metrics::report_http_response(
+        UNROUTED_ENDPOINT.to_owned(),
+        response.status(),
+        NO_DATA_SOURCE.to_owned(),
+        error_code,
+        latency.as_secs_f64(),
+    );
+
+    stamp_request_id(response, &request_id)
+}
+
+/// Rebuild an error the router raised before any handler ran — a path segment that will
+/// not parse, an unreadable query string, an over-limit body — into the envelope.
+///
+/// Those rejections come from axum, not from our code, so they answer with plain text and
+/// no [`ErrorCode`]: on the most common client mistake of all, a bad path parameter, the
+/// endpoint emits exactly the shape this taxonomy replaced. Converting each extractor
+/// call site would leave the next one to be found by a client, so the normalization lives
+/// here, where every routed response passes.
+///
+/// Only a body of known, small size is touched. A rejection is a short in-memory buffer,
+/// so an exact size hint separates it from anything streamed without polling the body —
+/// no stream is buffered, or consumed, to find out.
+async fn normalize_framework_rejection(response: Response) -> Response {
+    use http_body::Body as _;
+
+    const MAX_REJECTION_BODY: u64 = 8 * 1024;
+
+    let status = response.status();
+    if !(status.is_client_error() || status.is_server_error())
+        || response.extensions().get::<ErrorCode>().is_some()
+    {
+        return response;
+    }
+    if response
+        .body()
+        .size_hint()
+        .exact()
+        .is_none_or(|size| size > MAX_REJECTION_BODY)
+    {
+        return response;
+    }
+
+    // IB-5 is a closed code→status mapping, so the status moves with the code rather than
+    // keeping whatever the extractor picked: a 413 or a 415 answering `malformed_request`
+    // would contradict the binding it claims to follow. The distinction is not lost —
+    // axum's own prose carries it in `message`.
+    //
+    // 405 gets its own code instead of collapsing: the request is well-formed and the
+    // fault is the verb, which `Allow` names and a 400 could not. It is also the one
+    // rejection axum answers with an empty body, so the generic message would be all the
+    // client got.
+    //
+    // A 5xx keeps `unclassified` and its status, which is an api_error and pages: the
+    // router failing on its own is not something to name as the client's fault.
+    use axum::http::StatusCode;
+    let (code, public_status) = match status {
+        StatusCode::NOT_FOUND => (ErrorCode::NotFound, status),
+        StatusCode::METHOD_NOT_ALLOWED => (ErrorCode::MethodNotAllowed, status),
+        s if s.is_client_error() => (
+            ErrorCode::MalformedRequest,
+            ErrorCode::MalformedRequest.status(),
+        ),
+        // Unclassified is the one code whose status is contextual: whatever the router
+        // failed with is more informative than the floor.
+        _ => (ErrorCode::Unclassified, status),
+    };
+
+    let (parts, body) = response.into_parts();
+    // axum's rejection prose is worth keeping — "Cannot parse `abc` to a `u64`" names the
+    // fault better than a generic message can.
+    let message = match axum::body::to_bytes(body, MAX_REJECTION_BODY as usize).await {
+        Ok(bytes) if !bytes.is_empty() => String::from_utf8_lossy(&bytes).into_owned(),
+        _ => code.default_message().to_owned(),
+    };
+
+    let mut rebuilt = error_response(public_status, code, message);
+    for (key, value) in parts.headers.iter() {
+        if key == axum::http::header::CONTENT_TYPE || key == axum::http::header::CONTENT_LENGTH {
+            continue;
+        }
+        rebuilt.headers_mut().insert(key, value.clone());
+    }
+    // Carry the extensions across, not just the headers. `EndpointName` lives here, and
+    // without it the metric falls back to the raw request path — which on a rejection is
+    // client-supplied, so a malformed dynamic path would mint an `endpoint` label per
+    // request. The rejection had no `ErrorCode`, so nothing here overwrites the new one.
+    rebuilt.extensions_mut().extend(parts.extensions);
+    rebuilt
+}
+
+/// Stamp `error.request_id` into the body. Re-renders the [`ErrorBody`] the handler left
+/// in extensions rather than parsing the bytes back out, so there is no size cap, no
+/// chance of mangling a body that isn't the envelope, and nothing to buffer — a data
+/// stream carries no `ErrorBody` and is returned untouched.
+///
+/// 5xx only. The id is on `x-request-id` either way (REQ-9); the body copy exists for the
+/// support flow, where a user pastes JSON and loses headers. A 4xx is the client's own
+/// fault and is handled programmatically — a 409 in particular is a routine reorg the
+/// client resolves from `previousBlocks` — so the copy buys nothing and costs a
+/// re-render of the whole body, siblings included.
+fn stamp_request_id(response: Response, request_id: &str) -> Response {
+    if request_id.is_empty() || !response.status().is_server_error() {
+        return response;
+    }
+    let Some(mut body) = response.extensions().get::<ErrorBody>().cloned() else {
+        return response;
+    };
+    body.set_request_id(request_id);
+
+    let rendered = serde_json::to_vec(&body.to_json()).expect("ErrorBody is serializable");
+    let (mut parts, _) = response.into_parts();
+    parts.headers.remove(axum::http::header::CONTENT_LENGTH);
+    Response::from_parts(parts, Body::from(rendered))
 }
 
 fn data_source_metric_label(data_source: &str) -> &str {
@@ -206,10 +440,605 @@ mod tests {
         assert_eq!(data_source_metric_label("custom"), "custom");
     }
 
-    // Regression test: a client-supplied `x-request-id` header is preserved verbatim
-    // by SetRequestIdLayer and may contain non-visible-ASCII bytes (obs-text, 0x80-0xFF),
-    // which are valid in an HTTP header value but make `HeaderValue::to_str()` fail.
-    // The logging middleware must not panic on such input (previously a per-connection DoS).
+    /// Unique endpoint labels keep the shared global metric family isolated from
+    /// tests running concurrently.
+    #[tokio::test]
+    async fn handler_error_code_reaches_the_metric() {
+        use crate::metrics::{http_labels, HTTP_STATUS};
+        use crate::types::{ErrorCode, RequestError};
+        use axum::{
+            body::Body, http::Request, middleware::from_fn, response::IntoResponse, routing::get,
+            Router,
+        };
+        use tower::ServiceExt;
+        use tower_http::request_id::{MakeRequestUuid, SetRequestIdLayer};
+
+        use super::NO_DATA_SOURCE;
+
+        let app = Router::new()
+            .route(
+                "/boom",
+                get(|| async { RequestError::RateLimitExceeded.into_response() }),
+            )
+            .route("/fine", get(|| async { "ok" }))
+            .route_layer(from_fn(super::middleware))
+            .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid));
+
+        let count = |path: &str, status: u16, code: Option<ErrorCode>| {
+            HTTP_STATUS
+                .get_or_create(&http_labels(
+                    path.to_owned(),
+                    axum::http::StatusCode::from_u16(status).unwrap(),
+                    NO_DATA_SOURCE.to_owned(),
+                    code,
+                ))
+                .get()
+        };
+
+        let before = count("/boom", 529, Some(ErrorCode::Overloaded));
+        let resp = app
+            .clone()
+            .oneshot(Request::builder().uri("/boom").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 529);
+        assert_eq!(
+            count("/boom", 529, Some(ErrorCode::Overloaded)),
+            before + 1,
+            "RateLimitExceeded must be counted as overloaded"
+        );
+
+        let before = count("/fine", 200, None);
+        app.oneshot(Request::builder().uri("/fine").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            count("/fine", 200, None),
+            before + 1,
+            "success must stay on the unlabelled series"
+        );
+    }
+
+    /// A rejection the router raises before any handler runs — the commonest of them a
+    /// path segment that will not parse — used to answer with axum's plain text and no
+    /// code, which is the shape this taxonomy replaced. It must arrive as the envelope
+    /// like everything else, and be classified so the metric can see it.
+    #[tokio::test]
+    async fn a_router_rejection_arrives_as_the_envelope() {
+        use axum::{body::Body, extract::Path, http::Request, middleware::from_fn, routing::get};
+        use tower::ServiceExt;
+        use tower_http::request_id::{MakeRequestUuid, SetRequestIdLayer};
+
+        let app = axum::Router::new()
+            .route(
+                "/block/:number",
+                get(|Path(n): Path<u64>| async move { n.to_string() }),
+            )
+            .route_layer(from_fn(super::middleware))
+            .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid));
+
+        let call = |uri: &'static str| {
+            let app = app.clone();
+            async move {
+                let resp = app
+                    .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                    .await
+                    .unwrap();
+                let status = resp.status();
+                let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                (status, bytes)
+            }
+        };
+
+        let (status, bytes) = call("/block/not-a-number").await;
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+        let body: serde_json::Value = serde_json::from_slice(&bytes)
+            .unwrap_or_else(|e| panic!("a rejection must be the envelope, got {bytes:?}: {e}"));
+        assert_eq!(body["error"]["code"], "malformed_request");
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .is_some_and(|m| m.contains("not-a-number")),
+            "axum's prose names the fault better than a generic message: {body}"
+        );
+
+        // A success is not an error shape and must pass through byte for byte.
+        let (status, bytes) = call("/block/42").await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert_eq!(&bytes[..], b"42");
+    }
+
+    /// IB-5 is a closed code→status mapping, so a rejection axum answered with 413 or 415
+    /// cannot keep that status while calling itself `malformed_request`. The detail is not
+    /// lost — it stays in the message.
+    #[tokio::test]
+    async fn a_rejection_status_follows_its_code() {
+        use axum::{body::Body, http::Request, middleware::from_fn, routing::post, Router};
+        use tower::ServiceExt;
+        use tower_http::request_id::{MakeRequestUuid, SetRequestIdLayer};
+
+        let app = Router::new()
+            .route(
+                "/limited",
+                post(|_: axum::extract::Json<serde_json::Value>| async { "ok" }),
+            )
+            .route_layer(from_fn(super::middleware))
+            .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid));
+
+        // No content-type: axum rejects with 415 Unsupported Media Type.
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/limited")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            axum::http::StatusCode::BAD_REQUEST,
+            "malformed_request is bound to 400 by IB-5"
+        );
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["error"]["code"], "malformed_request");
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .is_some_and(|m| !m.is_empty()),
+            "the status is normalized, so the specifics must survive in the message: {body}"
+        );
+    }
+
+    /// 405 is the exception to that normalization. A wrong verb on a real route is not a
+    /// malformed request, `Allow` is the answer and a 400 has nowhere to put it, and it is
+    /// the one rejection axum leaves bodyless — collapsed to 400 the client was told only
+    /// "Bad request".
+    #[tokio::test]
+    async fn a_wrong_verb_keeps_its_status_and_says_so() {
+        use axum::{body::Body, http::Request, middleware::from_fn, routing::get, Router};
+        use tower::ServiceExt;
+        use tower_http::request_id::{MakeRequestUuid, SetRequestIdLayer};
+
+        let app = Router::new()
+            .route("/only-get", get(|| async { "ok" }))
+            .route_layer(from_fn(super::middleware))
+            .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid));
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/only-get")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), axum::http::StatusCode::METHOD_NOT_ALLOWED);
+        assert_eq!(
+            resp.headers()
+                .get(axum::http::header::ALLOW)
+                .map(|v| v.to_str().unwrap().to_owned()),
+            Some("GET,HEAD".to_owned()),
+            "the recovery hint must survive the rebuild"
+        );
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["error"]["code"], "method_not_allowed");
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .is_some_and(|m| m.to_lowercase().contains("method")),
+            "axum leaves 405 bodyless, so the default message has to name the fault: {body}"
+        );
+    }
+
+    /// The endpoint label is annotated onto the response, so rebuilding a rejection must
+    /// carry the extensions across. Without it the metric falls back to the raw request
+    /// path — which on a rejection is client-supplied, so every malformed dynamic path
+    /// would mint its own Prometheus series.
+    #[tokio::test]
+    async fn a_rebuilt_rejection_keeps_its_endpoint_label() {
+        use crate::metrics::{http_labels, HTTP_STATUS};
+        use crate::types::ErrorCode;
+        use axum::{body::Body, extract::Path, http::Request, middleware::from_fn, routing::get};
+        use tower::ServiceExt;
+        use tower_http::request_id::{MakeRequestUuid, SetRequestIdLayer};
+
+        use super::{MethodRouterExt, NO_DATA_SOURCE};
+
+        let app = axum::Router::new()
+            .route(
+                "/labelled/:number",
+                get(|Path(n): Path<u64>| async move { n.to_string() }).endpoint("/labelled"),
+            )
+            .route_layer(from_fn(super::middleware))
+            .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid));
+
+        let count = |endpoint: &str| {
+            HTTP_STATUS
+                .get_or_create(&http_labels(
+                    endpoint.to_owned(),
+                    axum::http::StatusCode::BAD_REQUEST,
+                    NO_DATA_SOURCE.to_owned(),
+                    Some(ErrorCode::MalformedRequest),
+                ))
+                .get()
+        };
+
+        let before = count("/labelled");
+        app.oneshot(
+            Request::builder()
+                .uri("/labelled/attacker-controlled-value")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            count("/labelled"),
+            before + 1,
+            "the rejection must be counted under the route, not the requested path"
+        );
+        assert_eq!(
+            count("/labelled/attacker-controlled-value"),
+            0,
+            "a client-supplied path must never become an endpoint label"
+        );
+    }
+
+    /// The id exists only at the middleware, so a 5xx must have it stamped in on the way
+    /// out. A 4xx must not: it is the client's own fault, handled programmatically rather
+    /// than pasted into a ticket, and `x-request-id` carries the id either way (REQ-9).
+    #[tokio::test]
+    async fn only_server_errors_echo_the_request_id_in_the_body() {
+        use crate::types::RequestError;
+        use axum::{
+            body::Body, http::Request, middleware::from_fn, response::IntoResponse, routing::get,
+            Router,
+        };
+        use tower::ServiceExt;
+        use tower_http::request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer};
+
+        let app = Router::new()
+            .route(
+                "/rid-boom",
+                get(|| async { RequestError::Unavailable.into_response() }),
+            )
+            .route(
+                "/rid-client-fault",
+                get(|| async { RequestError::BadRequest("nope".into()).into_response() }),
+            )
+            .route("/rid-fine", get(|| async { "streamed body" }))
+            .route_layer(from_fn(super::middleware))
+            // Mirrors the production stack: Propagate sits inside Set so it sees the id.
+            .layer(PropagateRequestIdLayer::x_request_id())
+            .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid));
+
+        let get_body = |path: &'static str| {
+            let app = app.clone();
+            async move {
+                let resp = app
+                    .oneshot(
+                        Request::builder()
+                            .uri(path)
+                            .header("x-request-id", "req-abc123")
+                            .body(Body::empty())
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap();
+                let echoed = resp.headers().get("x-request-id").cloned();
+                let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                (echoed, bytes)
+            }
+        };
+
+        let (echoed, bytes) = get_body("/rid-boom").await;
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["error"]["request_id"], "req-abc123");
+        assert_eq!(body["error"]["code"], "no_workers");
+        assert_eq!(echoed.unwrap(), "req-abc123");
+
+        let (echoed, bytes) = get_body("/rid-client-fault").await;
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(
+            !body["error"]
+                .as_object()
+                .unwrap()
+                .contains_key("request_id"),
+            "a 4xx must not carry the id in its body: {body}"
+        );
+        assert_eq!(body["error"]["code"], "malformed_request");
+        assert_eq!(
+            echoed.unwrap(),
+            "req-abc123",
+            "the header is how a 4xx conveys the id"
+        );
+
+        // A success body must pass through untouched, not be buffered and rewritten.
+        let (_, bytes) = get_body("/rid-fine").await;
+        assert_eq!(&bytes[..], b"streamed body");
+    }
+
+    /// Only `gzip` is compiled in, so `deflate`, `br` and `zstd` are refused by the
+    /// decompression layer — outside the routed middleware, which used to leave them a
+    /// bodyless 415 with no envelope and no code. `accept-encoding` must survive the
+    /// rebuild: it is the only thing telling the client which encoding to use instead.
+    #[tokio::test]
+    async fn a_refused_content_encoding_answers_the_envelope() {
+        use axum::{
+            body::Body,
+            http::{Request, StatusCode},
+            middleware::from_fn,
+            routing::post,
+            Router,
+        };
+        use tower::ServiceExt;
+        use tower_http::decompression::RequestDecompressionLayer;
+        use tower_http::request_id::{MakeRequestUuid, SetRequestIdLayer};
+
+        // Production order: the decompression layer inside `observe_bypassed`.
+        let app = Router::new()
+            .route("/echo", post(|| async { "ok" }))
+            .route_layer(from_fn(super::middleware))
+            .layer(RequestDecompressionLayer::new())
+            .layer(from_fn(super::observe_bypassed))
+            .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid));
+
+        for encoding in ["deflate", "br", "zstd"] {
+            let resp = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/echo")
+                        .header("content-encoding", encoding)
+                        .body(Body::from("payload"))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            // IB-5 moves the status to the code's; the detail survives in `accept-encoding`.
+            assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "{encoding}");
+            assert_eq!(
+                resp.headers().get("accept-encoding").unwrap(),
+                "gzip",
+                "{encoding} must be told what is accepted"
+            );
+            let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(body["error"]["code"], "malformed_request", "{encoding}");
+            assert_eq!(body["error"]["type"], "invalid_request_error", "{encoding}");
+        }
+
+        // gzip still routes, and a routed response must not be rewritten or double-counted.
+        //
+        // Both middlewares see every routed response — `middleware` is a `route_layer`,
+        // `observe_bypassed` an outer one — so only the `Observed` marker stops the second
+        // from counting it again. Asserting the status alone left that marker unguarded:
+        // deleting its early return would count every request twice and grow a phantom
+        // `unrouted` series at full traffic rate, with the suite still green. The routed
+        // series is +1 either way, so the `unrouted` one is the only witness.
+        use super::{NO_DATA_SOURCE, UNROUTED_ENDPOINT};
+        use crate::metrics::{http_labels, HTTP_STATUS};
+
+        let count = |endpoint: &str| {
+            HTTP_STATUS
+                .get_or_create(&http_labels(
+                    endpoint.to_owned(),
+                    StatusCode::OK,
+                    NO_DATA_SOURCE.to_owned(),
+                    None,
+                ))
+                .get()
+        };
+        let routed_before = count("/echo");
+        let unrouted_before = count(UNROUTED_ENDPOINT);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/echo")
+                    .body(Body::from("payload"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            count("/echo"),
+            routed_before + 1,
+            "the routed middleware must count it once"
+        );
+        assert_eq!(
+            count(UNROUTED_ENDPOINT),
+            unrouted_before,
+            "a response the router did route must not also be counted as unrouted"
+        );
+    }
+
+    /// A path the router never matched also bypasses the routed middleware (GAP-16).
+    #[tokio::test]
+    async fn an_unmatched_route_answers_the_envelope() {
+        use axum::{
+            body::Body,
+            http::{Request, StatusCode},
+            middleware::from_fn,
+            routing::get,
+            Router,
+        };
+        use tower::ServiceExt;
+
+        let app = Router::new()
+            .route("/known", get(|| async { "ok" }))
+            .route_layer(from_fn(super::middleware))
+            .layer(from_fn(super::observe_bypassed));
+
+        let resp = app
+            .oneshot(Request::builder().uri("/nope").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["error"]["code"], "not_found");
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+    }
+
+    /// An id that cannot be represented as ASCII is malformed input. It must not reach the
+    /// handler, and the 400 still needs a generated correlation id in its response header.
+    #[tokio::test]
+    async fn a_non_ascii_request_id_is_rejected_with_a_generated_id() {
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        };
+
+        use crate::types::RequestError;
+        use axum::{
+            body::Body,
+            http::{header::HeaderValue, Request, StatusCode},
+            middleware::from_fn,
+            response::IntoResponse,
+            routing::get,
+            Router,
+        };
+        use tower::ServiceExt;
+        use tower_http::{
+            cors::CorsLayer,
+            request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer},
+        };
+
+        // Production order: reject outside Set and CORS, and generate the rejection's id
+        // directly. Otherwise CORS can answer a preflight before validation runs.
+        let handler_calls = Arc::new(AtomicUsize::new(0));
+        let calls = handler_calls.clone();
+        let app = Router::new()
+            .route(
+                "/boom",
+                get(move || {
+                    let calls = calls.clone();
+                    async move {
+                        calls.fetch_add(1, Ordering::Relaxed);
+                        RequestError::Unavailable.into_response()
+                    }
+                }),
+            )
+            .route_layer(from_fn(super::middleware))
+            .layer(from_fn(super::observe_bypassed))
+            .layer(CorsLayer::permissive())
+            .layer(PropagateRequestIdLayer::x_request_id())
+            .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid))
+            .layer(from_fn(super::reject_non_ascii_request_id));
+
+        let obs_text = HeaderValue::from_bytes(&[0x80, 0x81]).unwrap();
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/boom")
+                    .header("x-request-id", obs_text.clone())
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let status = resp.status();
+        let echoed = resp.headers().get("x-request-id").cloned().unwrap();
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_ne!(echoed, obs_text, "the malformed id must not be echoed");
+        let echoed = echoed.to_str().expect("the generated id must be text");
+        assert!(
+            uuid::Uuid::parse_str(echoed).is_ok(),
+            "the validator should have supplied a UUID, got {echoed}"
+        );
+        assert_eq!(body["error"]["code"], "malformed_request");
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        assert_eq!(handler_calls.load(Ordering::Relaxed), 0);
+        assert!(
+            !body["error"]
+                .as_object()
+                .unwrap()
+                .contains_key("request_id"),
+            "4xx bodies do not duplicate the response header: {body}"
+        );
+
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("OPTIONS")
+                    .uri("/boom")
+                    .header("origin", "https://example.com")
+                    .header("access-control-request-method", "GET")
+                    .header("x-request-id", obs_text)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert!(
+            resp.headers()
+                .get("x-request-id")
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|value| uuid::Uuid::parse_str(value).is_ok()),
+            "a malformed preflight must be rejected before CORS"
+        );
+        assert_eq!(handler_calls.load(Ordering::Relaxed), 0);
+
+        // A usable client id is still preserved verbatim — the support flow depends on it.
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/boom")
+                    .header("x-request-id", "req-abc123")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.headers()["x-request-id"], "req-abc123");
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["error"]["request_id"], "req-abc123");
+        assert_eq!(handler_calls.load(Ordering::Relaxed), 1);
+    }
+
+    // Defense in depth: production rejects this request before routing, but the logging
+    // middleware must still not panic if embedded in a stack without that validator.
     #[tokio::test]
     async fn middleware_does_not_panic_on_non_ascii_request_id() {
         use axum::{

--- a/tools/spec-lint.py
+++ b/tools/spec-lint.py
@@ -63,9 +63,12 @@ CONFORMANCE = "13-conformance.md"
 REQUIREMENTS = "02-requirements.md"
 README = "README.md"
 
-# Which prefixes must appear in which matrix of 13.
+# Which prefixes must appear in which matrix of 13, and which column holds the status.
 MATRIX_PROPERTIES = ("INV", "LIV", "FM", "SLI")
 MATRIX_REQUIREMENTS = ("REQ",)
+# The closed set 13's header declares. A status outside it reads as a claim but means
+# nothing, and no other check looks at that column.
+MATRIX_STATUSES = {"C", "P", "U"}
 
 # Docs whose normative text must not carry bare dimensioned constants (the
 # `P-*`-only rule). 13 and 15 are the mutable registries; ADRs are exempt.
@@ -122,6 +125,7 @@ CHECKS: dict[str, tuple[str, str]] = {
     "adr-log-order":          ("warn",  "accepted decisions are not in ascending number/date order"),
     "trace-missing":          ("error", "defined property/requirement has no row in a 13 matrix"),
     "trace-unknown":          ("error", "13 matrix row names an ID that is not defined"),
+    "trace-bad-status":       ("error", "13 matrix row's status is not one of the declared values"),
     "doc-unlisted":           ("error", "spec document missing from the README document map"),
     "doc-missing":            ("error", "README document map lists a file that does not exist"),
     "req-missing-tag":        ("error", "requirement carries no RFC 2119 keyword"),
@@ -627,10 +631,11 @@ class Linter:
         if not doc:
             return
         matrices = {
-            "properties": (MATRIX_PROPERTIES, section_bounds(doc, lambda t: t.startswith("Traceability matrix"))),
-            "requirements": (MATRIX_REQUIREMENTS, section_bounds(doc, lambda t: t.startswith("Acceptance matrix"))),
+            # label: (prefixes, bounds, status column)
+            "properties": (MATRIX_PROPERTIES, section_bounds(doc, lambda t: t.startswith("Traceability matrix")), 2),
+            "requirements": (MATRIX_REQUIREMENTS, section_bounds(doc, lambda t: t.startswith("Acceptance matrix")), 1),
         }
-        for label, (prefixes, bounds) in matrices.items():
+        for label, (prefixes, bounds, status_col) in matrices.items():
             if bounds is None:
                 self.report("trace-missing", CONFORMANCE, 1,
                             f"no {label} matrix section found")
@@ -640,13 +645,21 @@ class Linter:
             for line, cells in parse_table_rows(doc, start, end):
                 if not cells:
                     continue
-                for m in ID_TOKEN.finditer(cells[0]):
+                ids = list(ID_TOKEN.finditer(cells[0]))
+                if not ids:
+                    continue  # the column header, not a row
+                for m in ids:
                     hard, soft = expand_ids(m)
                     for ident in hard + soft:
                         covered.add(ident)
                         if ident not in self.definitions and ident not in soft:
                             self.report("trace-unknown", CONFORMANCE, line,
                                         f"{label} matrix row names {ident}, which is not defined")
+                status = re.sub(r"[*_`]", "", cells[status_col]).strip() if len(cells) > status_col else ""
+                if status not in MATRIX_STATUSES:
+                    self.report("trace-bad-status", CONFORMANCE, line,
+                                f"{label} matrix status {status!r} is not one of "
+                                f"{sorted(MATRIX_STATUSES)}")
             for ident, (home, dline) in sorted(self.definitions.items()):
                 if ident.split("-")[0] in prefixes and ident not in covered:
                     self.report("trace-missing", home, dline,


### PR DESCRIPTION
Implements ADR-011 and the IB-5 binding, closing most of GAP-16. Companion to the hotblocks error hardening ([subsquid/data@546c1ac](https://github.com/subsquid/data/commit/546c1acb6594bccc7399d2e67c4d23a46a9c2fd3)), which classified that service's errors internally. The portal is the public API, so this puts the taxonomy on the wire.

## Why

The portal had a taxonomy in name only. `RequestError::short_code()` mapped each variant to a string, and that string reached exactly one place — an argument to a `tracing::debug!`. It was on no metric, no header, no body. A 503 meant "something", with no way to tell "no workers exist" from "a worker query task panicked" without reading logs.

Worse, `RequestError::InternalError` meant **both** "all retries legitimately ran out" **and** "a portal invariant broke" (a chunk that must exist wasn't found; a worker task panicked; a worker returned blocks below the queried range). Both rendered 503, so the portal told clients to retry its own bugs — a loop that never succeeds and hides the bug.

## What

Two axes: a coarse `type` to branch on, a specific `code` to match.

| `type` | Retryable | Pages |
|---|---|---|
| `invalid_request_error` | no | no |
| `rate_limit_error` | yes | no |
| `availability_error` | yes | no |
| `api_error` | no | **yes** |

`api_error` is the only type that should page — the transient-vs-integrity split (FM-2), put on the wire. `InternalError` splits into `RetriesExhausted` (503) and `Internal` (500); the four sites that meant "bug" now say so.

Error bodies become one envelope on every endpoint:

```json
{
  "error": {
    "type": "invalid_request_error",
    "code": "malformed_request",
    "message": "Bad request: buffer_size must be greater than 0",
    "param": "buffer_size"
  }
}
```

A 5xx adds `"request_id"`; a 4xx does not — see below.

### One renderer, because two emitters had already diverged

`ErrorBody` decides the shape and `error_body_response` renders it — everywhere. That is a correctness requirement, not tidiness: a hotblocks-served 409 was emitting `code`/`message` flat beside `previousBlocks` while a portal-served 409 nested them under `error`, on the same route, against the one schema documenting both. Three independent builders meant a client couldn't rely on either shape. Collapsing them makes the divergence unrepresentable rather than merely fixed.

`request_id` is the one field only the middleware knows. It used to be stamped in by parsing the finished body and re-serializing it, which capped error bodies at 64 KB and silently emptied anything larger — and which buffered *any* body carrying a code, including the proxied 204 whose body is a live upstream stream, guarded only by a status check. The middleware now re-renders the struct the handler left in extensions, so it can only ever touch a body the portal itself built, and never buffers.

It stamps **5xx only**. `x-request-id` is on every response regardless (REQ-9); the body copy exists for the support flow, where a user pastes JSON and loses the headers. A 4xx is the client's own fault and handled programmatically — a 409 above all, which the client resolves from `previousBlocks` — so nobody opens a ticket holding one, and the copy would cost a re-render of the whole body, siblings included.

### 204 is not an error

`no_data` is gone from the vocabulary. A 204 is the correct answer to a range that isn't produced yet, not a failure: it carries no body, so a code could never reach a client (and ADR-014 keeps it that way for OP-5), while on the metric `error_code="no_data"` only ever restated `status="204"`. Typing it `availability_error` made the steady state of every polling client read as degraded. `http_labels` now gates on status, so no 2xx can carry error labels whatever a handler tags it with.

### Proxied errors

Classified by status alone — hotblocks keeps its `ErrorCode` in response extensions, which never cross the wire, so its five 400-classes collapse into `malformed_request`. Faithful propagation needs an `x-sqd-error-class` header on the hotblocks side (separate PR in `data`). Per DC-4:

- the upstream body is **never** published — its prose is not public API and names instances, paths and internal ids — and the envelope carries the code's own message instead;
- it is **never read**, either, on any status but 409. Nothing consumes it: a server error is already logged with the pod that served it and hotblocks logs its own failures in full, so a fragment copied here duplicates diagnostics that are complete at their source — while buffering an unbounded body lets an upstream fault size portal memory;
- `previousBlocks` on a 409 is the one upstream field preserved, because clients walk it to recover, and the only reason to read at all. A 409 arriving without it is not a legal 409 under IB-5 and leaves the client nothing to walk — indistinguishable from a healthy reorg on the wire and on the metric, so it is logged at `error`. Refusing it as `unclassified` instead is left open (GAP-16);
- unmatched 4xx normalize to **400**; matched statuses (404, 409, 429/503/529, 5xx) are preserved;
- `Retry-After` is preserved when the upstream sent one and injected at the floor when it didn't (INV-26).

### `/ready`

A declining probe now answers with the `not_ready` envelope instead of bare prose — which `IB-6` and `/ready`'s own OpenAPI both already promised — carrying the live reason (`NoWorkers`, `InsufficientConnections { .. }`, shutting down) so a probe flip is attributable without log archaeology (OB-5). 200 stays plain text: there is no error to describe, and probes read the status either way.

### Observability

`portal_http_status` and `portal_http_seconds_to_first_byte` gain `error_code`/`error_type`, on **4xx/5xx only**, so success-path cardinality is unchanged. Anything unclassified is counted rather than dropped — an unclassified 4xx is re-typed `invalid_request_error` (a client hitting a bad route), so only unclassified 5xx pages. `not_ready` exists for the same reason: `/ready` returns 503 on every rolling deploy.

A `route_layer` cannot see a response the router never routed, so an outer layer normalizes, logs and counts those: an unmatched route, and the `RequestDecompressionLayer` 415 that every encoding but `gzip` earns — which previously answered a bodyless 415 on no metric at all. Their `endpoint` label is a constant, the path being client-supplied there.

### Mis-mappings fixed

SQL returned **400** when no worker held a chunk and when its own schema files failed to read/parse; the timestamp resolver returned **503** when hotblocks rejected a query the *portal itself* generated. The OpenAPI spec described a body nothing emitted (`openapi::ErrorResponse` was registered but referenced by no path; the emitted `types::GenericError` was registered nowhere) — 40 documented error responses now point at the real schema.

## Breaking

Clients parsing today's `text/plain` bodies, or the flat `{"message": ...}` JSON, must move to `error.message`. Status codes change in these cases:

| Case | Before | After |
|---|---|---|
| Integrity failure (worker returned data that cannot be right) | 503 | **500** |
| SQL: no worker holds the chunk; schema file unreadable | 400 | **503** / **500** |
| Timestamp: hotblocks refused the query the portal generated | 503 | the classified upstream status (400 / 429 / 502 …) |
| Timestamp: local upstream failure — now IB-5's 502, which master violated | 503 | **502** |
| `/stream`: every attempt refused for capacity (DC-1) | 503, no hint | **529** + `Retry-After` |
| Unmatched proxied 4xx (DC-4) | passed through | **400** |

The `/stream` capacity row is the one to read closely: a client that treats 503 as its only retry signal now needs 529 too, and gets a `Retry-After` on a path that never carried one.

Two deliberate deviations:
- **204** carries no body, so it conveys itself by status alone.
- **409** keeps `previousBlocks` at the **top level**, with `error` beside it. Nesting it would be tidier, but that's the documented reorg-recovery contract clients walk to find a shared ancestor.

## Spec (IB-8)

`DEF-10`, `IB-5` and `ADR-011` record that EMPTY leaves the taxonomy and why; `OB-3` records the new labels and the 4xx/5xx-only rule; `INV-26` moves from **Known-violated** to covered now that CT-5 exists; `GAP-16` is narrowed to its genuine remainder (ADR-014's EMPTY head metadata and integrity-exhaustion WORKER-FAILURE, plus the route-layer 404 gap) and `P-SLO-REFUSAL-CORRECTNESS` updated. `ADR-011` also gains the casing note, the `doc_url` rationale, the `request_id`-on-5xx rule and why the upstream body is neither published nor read.

## Verification

160 tests; clippy, rustfmt and spec-lint green.

CT-5 is the class `GAP-16`/`INV-26`/`GAP-7` all asked for and nothing implemented — table-driven over both emitters, since per-emitter unit tests cannot catch a divergence *between* them:

- `proxied_errors_use_the_envelope` — 9 upstream statuses → public status, code, type
- `both_stream_paths_emit_the_same_409_shape` — pins the two emitters against each other
- `a_proxied_error_never_leaks_the_upstream_body` — 8 statuses, asserts no instance name or path reaches the client
- `only_a_409_reads_the_upstream_body` — the upstream body is a stream with a poll flag; six statuses never touch it, 409 does. Asserts the *absence of the read*, which `a_huge_upstream_body_does_not_size_the_response` cannot: that one passes under full buffering too
- `a_409_without_previous_blocks_still_answers_the_envelope` — pins the shape when the recovery contract is missing, so it stays a decision
- `proxied_overload_always_carries_a_retry_hint` — the INV-26 floor
- `readiness_declines_with_the_envelope` — the IB-6 body and its reason
- `only_server_errors_echo_the_request_id_in_the_body` — 5xx carries it, 4xx does not, and `x-request-id` is present either way. Adds `PropagateRequestIdLayer` to the test router in the production order: without it the header half of that rule was untested, and that layer was found dead on an empty router once already
- `no_2xx_is_ever_labelled_as_an_error`, `no_data_is_not_an_error`, `proxied_204_is_untouched`

Also exercised against a locally running portal: `param` naming the bad field, a client-supplied `x-request-id` echoed into the body, and a bootstrapping `/ready` counted `availability_error` rather than paging.

## Not addressed

- ADR-014's remainder: EMPTY head metadata, integrity-exhaustion WORKER-FAILURE, and the timestamp overload mapping (GAP-4).
- A proxied 409 with no `previousBlocks` still answers 409. Logged at `error`, but the client gets an unactionable status; whether to refuse it as `unclassified` is a contract call left open.
- An unmatched proxied 4xx (403, 422) is indistinguishable from a genuine 400 on the metric — both `malformed_request` — so there is no signal for "hotblocks returned something we don't model". Deliberate: logging every 4xx body costs more than it is worth at storm rates.
- The portal's own error prose is still published verbatim, including worker PeerIds and a panic payload behind `internal_error` — the same class of detail DC-4 suppresses from the upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


