### PR TITLE
style: rustfmt datasets.rs

### DIFF
--- a/src/datasets.rs
+++ b/src/datasets.rs
@@ -210,7 +210,13 @@ async fn load_yaml<T: serde::de::DeserializeOwned>(url: &str) -> anyhow::Result<
             ExponentialBackoff::builder().build_with_max_retries(3),
         ))
         .build();
-        let text = client.get(url).send().await?.error_for_status()?.text().await?;
+        let text = client
+            .get(url)
+            .send()
+            .await?
+            .error_for_status()?
+            .text()
+            .await?;
         serde_yaml::from_str(&text).with_context(|| format!("failed to parse {url}"))
     }
 }


### PR DESCRIPTION
`cargo fmt --all -- --check` has failed on **master** since #130 (2026-07-09), so the Rustfmt job is red on every pull request in the repo, whatever it changes. `origin/master` reproduces it directly:

```
$ git checkout origin/master && cargo fmt --all -- --check; echo $?
Diff in src/datasets.rs:210
1
```

This is the whole change — one call chain rustfmt wants split across lines. Purely mechanical, no behaviour change, 82 tests pass.

Merging this unblocks the Rustfmt job for #133 and anything else open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)