### PR TITLE
fix(stream): make the stream cap cheap and honest

### DIFF
--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -517,7 +517,7 @@ impl<N: StreamingNetwork> StreamController<N> {
             RequestState::Done(result) => (Poll::Ready(Some(result)), slot.data_range.range, None),
             RequestState::NoWorkers => {
                 // We don't know how long we'll have to wait, so give up immediately
-                return Poll::Ready(Some(Err(RequestError::Unavailable)));
+                return Poll::Ready(Some(Err(RequestError::NoAvailableWorkers)));
             }
             RequestState::Paused(ref s) => {
                 // All workers are rate-limited, try to pause and continue streaming

--- a/src/controller/task_manager.rs
+++ b/src/controller/task_manager.rs
@@ -16,11 +16,45 @@ use crate::{
 
 use super::stream::StreamController;
 
+/// Admission slots for concurrent streams. Split out of [`TaskManager`] so the
+/// accounting is testable without a `NetworkClient`.
+struct Slots {
+    running: AtomicUsize,
+    max: usize,
+}
+
+impl Slots {
+    /// Check and increment in one CAS: the count never reads above `max`, and a
+    /// rejection is a load and a compare — no counter churn, no `Arc` clone.
+    fn try_acquire(self: &Arc<Self>) -> Option<StreamPermit> {
+        self.running
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |running| {
+                (running < self.max).then_some(running + 1)
+            })
+            .ok()?;
+        metrics::ACTIVE_STREAMS.inc();
+        Some(StreamPermit {
+            slots: self.clone(),
+        })
+    }
+}
+
+/// One admitted stream's slot, released on drop.
+pub struct StreamPermit {
+    slots: Arc<Slots>,
+}
+
+impl Drop for StreamPermit {
+    fn drop(&mut self) {
+        self.slots.running.fetch_sub(1, Ordering::Relaxed);
+        metrics::ACTIVE_STREAMS.dec();
+    }
+}
+
 /// Tracks all existing streams
 pub struct TaskManager {
     network_client: Arc<NetworkClient>,
-    running_tasks: AtomicUsize,
-    max_tasks: usize,
+    slots: Arc<Slots>,
     next_stream_index: AtomicU32,
     bandwidth_utilization_threshold: f64,
     priority_stride: u32,
@@ -35,37 +69,42 @@ impl TaskManager {
     ) -> TaskManager {
         TaskManager {
             network_client,
-            running_tasks: 0.into(),
-            max_tasks: max_parallel_streams,
+            slots: Arc::new(Slots {
+                running: 0.into(),
+                max: max_parallel_streams,
+            }),
             next_stream_index: AtomicU32::new(0),
             bandwidth_utilization_threshold,
             priority_stride,
         }
     }
 
-    pub async fn spawn_stream(
-        self: Arc<Self>,
-        mut request: StreamRequest,
-    ) -> Result<impl Stream<Item = ResponseChunk>, RequestError> {
-        let running_tasks = self.running_tasks.fetch_add(1, Ordering::Relaxed);
-        if running_tasks >= self.max_tasks {
-            self.running_tasks.fetch_sub(1, Ordering::Relaxed);
-            return Err(RequestError::TooManyStreams);
-        }
+    /// Admission check, deliberately cheap: run it before any work a rejection
+    /// would throw away — parsing, head fetches, spawned tasks.
+    pub fn try_reserve(&self) -> Result<StreamPermit, RequestError> {
+        // Cap first: it's one CAS, while download_utilization takes the download
+        // scheduler's lock. A storm rejects here, so it must not contend on that.
+        let permit = self
+            .slots
+            .try_acquire()
+            .ok_or(RequestError::TooManyStreams)?;
 
         if let Some(util) = self.network_client.download_utilization() {
             if util > self.bandwidth_utilization_threshold {
-                self.running_tasks.fetch_sub(1, Ordering::Relaxed);
                 return Err(RequestError::BusyFor(Duration::from_secs(1)));
             }
         }
 
-        metrics::ACTIVE_STREAMS.inc();
+        Ok(permit)
+    }
 
-        let self_clone = self.clone();
-        let guard = scopeguard::guard((), move |()| {
-            self_clone.running_tasks.fetch_sub(1, Ordering::Relaxed);
-            metrics::ACTIVE_STREAMS.dec();
+    pub async fn spawn_stream(
+        self: Arc<Self>,
+        permit: StreamPermit,
+        mut request: StreamRequest,
+    ) -> Result<impl Stream<Item = ResponseChunk>, RequestError> {
+        // ACTIVE_STREAMS.dec() rides on the permit's Drop, inside this guard.
+        let guard = scopeguard::guard(permit, |_permit| {
             metrics::COMPLETED_STREAMS.inc();
         });
 
@@ -101,5 +140,97 @@ impl TaskManager {
             }
         }
         .in_current_span())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn slots(max: usize) -> Arc<Slots> {
+        Arc::new(Slots {
+            running: 0.into(),
+            max,
+        })
+    }
+
+    #[test]
+    fn admits_up_to_max_then_rejects() {
+        let slots = slots(2);
+
+        let _first = slots.try_acquire().expect("first");
+        let _second = slots.try_acquire().expect("second");
+
+        assert!(slots.try_acquire().is_none());
+    }
+
+    #[test]
+    fn dropping_a_permit_frees_its_slot() {
+        let slots = slots(1);
+
+        let permit = slots.try_acquire().expect("first");
+        assert!(slots.try_acquire().is_none());
+
+        drop(permit);
+        assert!(slots.try_acquire().is_some());
+    }
+
+    /// The slot used to be released by hand on each rejection path; one missed
+    /// decrement would wedge the portal at its cap until restarted.
+    #[test]
+    fn rejections_do_not_consume_slots() {
+        let slots = slots(1);
+        let permit = slots.try_acquire().expect("first");
+
+        for _ in 0..100 {
+            assert!(slots.try_acquire().is_none());
+        }
+
+        drop(permit);
+        assert!(slots.try_acquire().is_some(), "rejections leaked the slot");
+    }
+
+    /// The tests above would pass against a plain `Cell`. This is the one the
+    /// atomics are actually for.
+    #[test]
+    fn never_admits_more_than_max_under_contention() {
+        const MAX: usize = 4;
+        const THREADS: usize = 16;
+        const ATTEMPTS: usize = 500;
+
+        let slots = slots(MAX);
+        let live = AtomicUsize::new(0);
+        let peak = AtomicUsize::new(0);
+        let admitted = AtomicUsize::new(0);
+
+        std::thread::scope(|scope| {
+            for _ in 0..THREADS {
+                scope.spawn(|| {
+                    for _ in 0..ATTEMPTS {
+                        let Some(permit) = slots.try_acquire() else {
+                            continue;
+                        };
+                        admitted.fetch_add(1, Ordering::SeqCst);
+                        let now = live.fetch_add(1, Ordering::SeqCst) + 1;
+                        peak.fetch_max(now, Ordering::SeqCst);
+                        std::thread::yield_now();
+                        live.fetch_sub(1, Ordering::SeqCst);
+                        drop(permit);
+                    }
+                });
+            }
+        });
+
+        let peak = peak.load(Ordering::SeqCst);
+        assert!(admitted.load(Ordering::SeqCst) > 0, "nothing was admitted");
+        assert!(
+            peak <= MAX,
+            "{peak} streams held a slot at once, cap is {MAX}"
+        );
+        assert_eq!(
+            slots.running.load(Ordering::SeqCst),
+            0,
+            "contention leaked slots",
+        );
     }
 }

--- a/src/controller/task_manager.rs
+++ b/src/controller/task_manager.rs
@@ -50,7 +50,7 @@ impl TaskManager {
         let running_tasks = self.running_tasks.fetch_add(1, Ordering::Relaxed);
         if running_tasks >= self.max_tasks {
             self.running_tasks.fetch_sub(1, Ordering::Relaxed);
-            return Err(RequestError::Unavailable);
+            return Err(RequestError::TooManyStreams);
         }
 
         if let Some(util) = self.network_client.download_utilization() {

--- a/src/endpoints/block_number_by_timestamp.rs
+++ b/src/endpoints/block_number_by_timestamp.rs
@@ -16,7 +16,10 @@ use crate::{
     hotblocks::{HeadMode, HotblocksHandle, Status},
     network::NetworkClient,
     openapi::BlockNumberResponse,
-    types::{Compression, DatasetId, GenericError, ParsedQuery, StreamRequest},
+    types::{
+        server_overloaded, Compression, DatasetId, GenericError, ParsedQuery, RequestError,
+        StreamRequest,
+    },
     utils::{
         conversion::collect_to_string,
         internal_query::{build_blocknumber_query, find_block_in_chunk},
@@ -40,6 +43,7 @@ use super::stream::{DATA_SOURCE_HEADER, DATA_SOURCE_NETWORK_METRIC, DATA_SOURCE_
         (status = 404, description = "No block found for timestamp"),
         (status = 500, description = "Internal server error"),
         (status = 503, description = "Upstream data source unavailable"),
+        (status = 529, description = "Overloaded; retry after the Retry-After header"),
     ),
     tag = "Datasets"
 )]
@@ -104,18 +108,44 @@ pub enum BlockNumberLookupError {
     NotFound(String),
     Internal(String),
     Unavailable(String),
+    Overloaded {
+        message: String,
+        retry_after_secs: u64,
+    },
+}
+
+impl From<RequestError> for BlockNumberLookupError {
+    fn from(error: RequestError) -> Self {
+        match error.retry_after_secs() {
+            Some(retry_after_secs) => Self::Overloaded {
+                message: error.to_string(),
+                retry_after_secs,
+            },
+            None => Self::Unavailable(error.to_string()),
+        }
+    }
 }
 
 impl BlockNumberLookupError {
     /// Convert a resolver error into the timestamp endpoint's HTTP response.
     pub fn into_response(self) -> Response {
-        let (status, message) = match self {
-            Self::NotFound(message) => (StatusCode::NOT_FOUND, message),
-            Self::Internal(message) => (StatusCode::INTERNAL_SERVER_ERROR, message),
-            Self::Unavailable(message) => (StatusCode::SERVICE_UNAVAILABLE, message),
+        let (status, retry_after_secs, message) = match self {
+            Self::NotFound(message) => (StatusCode::NOT_FOUND, None, message),
+            Self::Internal(message) => (StatusCode::INTERNAL_SERVER_ERROR, None, message),
+            Self::Unavailable(message) => (StatusCode::SERVICE_UNAVAILABLE, None, message),
+            Self::Overloaded {
+                message,
+                retry_after_secs,
+            } => (server_overloaded(), Some(retry_after_secs), message),
         };
 
-        (status, axum::Json(GenericError { message })).into_response()
+        let mut response = (status, axum::Json(GenericError { message })).into_response();
+        if let Some(secs) = retry_after_secs {
+            response
+                .headers_mut()
+                .insert(axum::http::header::RETRY_AFTER, secs.into());
+        }
+        response
     }
 }
 
@@ -248,9 +278,7 @@ async fn get_archival_blocknumber_by_timestamp(
         Ok(stream) => stream,
         Err(e) => {
             tracing::warn!("spawn stream error: {:?}", e);
-            return Err(BlockNumberLookupError::Unavailable(
-                "SQD Network error".to_string(),
-            ));
+            return Err(e.into());
         }
     };
 
@@ -415,6 +443,39 @@ mod tests {
     use crate::hotblocks::StatusData;
 
     use super::*;
+
+    /// This endpoint used to flatten every spawn_stream error into a bare 503
+    /// "SQD Network error", losing the backoff hint along with the cause.
+    #[test]
+    fn overload_keeps_the_backoff_hint() {
+        let response = BlockNumberLookupError::from(RequestError::TooManyStreams).into_response();
+
+        assert_eq!(response.status(), server_overloaded());
+        assert_eq!(
+            response.headers().get(header::RETRY_AFTER),
+            Some(&header::HeaderValue::from_static("1")),
+        );
+    }
+
+    #[test]
+    fn busy_for_carries_its_own_duration() {
+        let error = RequestError::BusyFor(std::time::Duration::from_secs(7));
+        let response = BlockNumberLookupError::from(error).into_response();
+
+        assert_eq!(
+            response.headers().get(header::RETRY_AFTER),
+            Some(&header::HeaderValue::from_static("8")),
+        );
+    }
+
+    #[test]
+    fn non_overload_errors_stay_503() {
+        let response =
+            BlockNumberLookupError::from(RequestError::NoAvailableWorkers).into_response();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert!(!response.headers().contains_key(header::RETRY_AFTER));
+    }
 
     #[tokio::test]
     async fn get_blocknumber_by_timestamp_uses_archive_path_first() {

--- a/src/endpoints/block_number_by_timestamp.rs
+++ b/src/endpoints/block_number_by_timestamp.rs
@@ -274,7 +274,8 @@ async fn get_archival_blocknumber_by_timestamp(
         Some(1),
     );
 
-    let stream = match task_manager.clone().spawn_stream(request).await {
+    let permit = task_manager.try_reserve()?;
+    let stream = match task_manager.clone().spawn_stream(permit, request).await {
         Ok(stream) => stream,
         Err(e) => {
             tracing::warn!("spawn stream error: {:?}", e);

--- a/src/endpoints/stream.rs
+++ b/src/endpoints/stream.rs
@@ -90,6 +90,11 @@ pub(crate) async fn run_archival_stream(
     dataset_id: DatasetId,
     mut request: StreamRequest,
 ) -> Response {
+    let permit = match task_manager.try_reserve() {
+        Ok(permit) => permit,
+        Err(e) => return network_error_response(e),
+    };
+
     let mut res = Response::builder();
     res = res.header(DATA_SOURCE_HEADER, DATA_SOURCE_NETWORK);
     if let Some(head) = network.head(&dataset_id) {
@@ -103,7 +108,7 @@ pub(crate) async fn run_archival_stream(
     request.dataset_id = dataset_id;
     let compression = request.compression;
 
-    match task_manager.spawn_stream(request).await {
+    match task_manager.spawn_stream(permit, request).await {
         Ok(stream) => {
             let body = response_body(stream, compression, config.use_gzjoin);
             res.header(header::CONTENT_TYPE, "application/jsonl")
@@ -116,7 +121,7 @@ pub(crate) async fn run_archival_stream(
             tokio::time::sleep(Duration::from_secs(5)).await;
             res.status(StatusCode::NO_CONTENT).body(().into()).unwrap()
         }
-        Err(e) => e.into_response(),
+        Err(e) => network_error_response(e),
     }
 }
 
@@ -276,6 +281,14 @@ async fn run_stream_internal(
     }
 }
 
+fn network_error_response(e: RequestError) -> Response {
+    let mut response = e.into_response();
+    response
+        .headers_mut()
+        .insert(DATA_SOURCE_HEADER, DATA_SOURCE_NETWORK);
+    response
+}
+
 async fn stream_from_network(
     task_manager: Arc<TaskManager>,
     config: Arc<Config>,
@@ -286,6 +299,13 @@ async fn stream_from_network(
     dataset_id: DatasetId,
     hotblocks_name: String,
 ) -> Response {
+    // Before the head fetch below: that spawn outlives a rejection and would
+    // hit hotblocks for an answer nobody reads.
+    let permit = match task_manager.try_reserve() {
+        Ok(permit) => permit,
+        Err(e) => return network_error_response(e),
+    };
+
     let archival_head = network.head(&dataset_id);
     let head_task = tokio::spawn({
         let archival_head = archival_head.clone();
@@ -303,15 +323,9 @@ async fn stream_from_network(
     request.dataset_id = dataset_id;
     let compression = request.compression;
 
-    let stream = match task_manager.spawn_stream(request).await {
+    let stream = match task_manager.spawn_stream(permit, request).await {
         Ok(stream) => stream,
-        Err(e) => {
-            let mut response = e.into_response();
-            response
-                .headers_mut()
-                .insert(DATA_SOURCE_HEADER, DATA_SOURCE_NETWORK);
-            return response;
-        }
+        Err(e) => return network_error_response(e),
     };
 
     let mut res = Response::builder().header(DATA_SOURCE_HEADER, DATA_SOURCE_NETWORK);

--- a/src/types/errors.rs
+++ b/src/types/errors.rs
@@ -15,8 +15,11 @@ pub enum RequestError {
     InternalError(String),
     #[error("{0}")]
     Failure(String),
+    /// Not `NotReady::NoWorkers`: workers are known, none could be leased for this chunk.
     #[error("No available workers to serve the request")]
-    Unavailable,
+    NoAvailableWorkers,
+    #[error("Too many concurrent streams, please try again later")]
+    TooManyStreams,
     #[error("Rate limit exceeded")]
     RateLimitExceeded,
     #[error("Service is overloaded, please try again later")]
@@ -62,8 +65,29 @@ impl RequestError {
 }
 
 /// Non-standard "Site is overloaded" status used to signal clients to back off.
-fn server_overloaded() -> StatusCode {
+pub(crate) fn server_overloaded() -> StatusCode {
     StatusCode::from_u16(529).expect("529 should be a valid status code")
+}
+
+impl RequestError {
+    /// `Some` for the overload variants, which are the ones a client should retry
+    /// on a timer. Clients that get no hint fall back to their own schedule.
+    ///
+    /// Matched exhaustively on purpose: a new variant that means "overloaded" must
+    /// not inherit `None` by default — that omission is what made the cap's 503s
+    /// retry every 10ms.
+    pub fn retry_after_secs(&self) -> Option<u64> {
+        match self {
+            Self::TooManyStreams | Self::RateLimitExceeded => Some(1),
+            Self::BusyFor(duration) => Some(duration.as_secs().saturating_add(1)),
+            Self::BadRequest(_)
+            | Self::NoData
+            | Self::InternalError(_)
+            | Self::Failure(_)
+            | Self::NoAvailableWorkers
+            | Self::BaseBlockMismatch(_) => None,
+        }
+    }
 }
 
 impl axum::response::IntoResponse for RequestError {
@@ -76,7 +100,7 @@ impl axum::response::IntoResponse for RequestError {
 
             Self::NoData => (StatusCode::NO_CONTENT, ()).into_response(),
 
-            s @ Self::Unavailable => {
+            s @ Self::NoAvailableWorkers => {
                 (StatusCode::SERVICE_UNAVAILABLE, s.to_string()).into_response()
             }
 
@@ -84,17 +108,16 @@ impl axum::response::IntoResponse for RequestError {
                 (StatusCode::INTERNAL_SERVER_ERROR, s.to_string()).into_response()
             }
 
-            s @ Self::BusyFor(duration) => axum::http::Response::builder()
-                .status(server_overloaded())
-                .header(header::RETRY_AFTER, duration.as_secs() + 1)
-                .body(axum::body::Body::from(s.to_string()))
-                .unwrap(),
-
-            s @ Self::RateLimitExceeded => axum::http::Response::builder()
-                .status(server_overloaded())
-                .header(header::RETRY_AFTER, 1)
-                .body(axum::body::Body::from(s.to_string()))
-                .unwrap(),
+            s @ (Self::BusyFor(_) | Self::TooManyStreams | Self::RateLimitExceeded) => {
+                let retry_after = s
+                    .retry_after_secs()
+                    .expect("overload variants must define a retry hint");
+                axum::http::Response::builder()
+                    .status(server_overloaded())
+                    .header(header::RETRY_AFTER, retry_after)
+                    .body(axum::body::Body::from(s.to_string()))
+                    .unwrap()
+            }
 
             Self::InternalError(e) => (
                 StatusCode::SERVICE_UNAVAILABLE,
@@ -124,7 +147,10 @@ impl RequestError {
             Self::NoData => "no_data",
             Self::InternalError(_) => "internal_error",
             Self::Failure(_) => "failure",
-            Self::Unavailable | Self::BusyFor(_) | Self::RateLimitExceeded => "overloaded",
+            Self::NoAvailableWorkers => "no_available_workers",
+            Self::BusyFor(_) => "overloaded",
+            Self::RateLimitExceeded => "rate_limit_exceeded",
+            Self::TooManyStreams => "too_many_streams",
             Self::BaseBlockMismatch(_) => "base_block_mismatch",
         }
     }
@@ -133,4 +159,122 @@ impl RequestError {
 #[derive(Debug, Clone, Serialize)]
 pub struct GenericError {
     pub message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{http::header, response::IntoResponse};
+
+    /// One of each. The match is the only thing that can force a new variant to be
+    /// added to the list, since the list itself is unchecked.
+    fn every_variant() -> Vec<RequestError> {
+        let all = vec![
+            RequestError::BadRequest("bad".to_owned()),
+            RequestError::NoData,
+            RequestError::InternalError("internal".to_owned()),
+            RequestError::Failure("failure".to_owned()),
+            RequestError::NoAvailableWorkers,
+            RequestError::TooManyStreams,
+            RequestError::RateLimitExceeded,
+            RequestError::BusyFor(Duration::from_secs(3)),
+            RequestError::BaseBlockMismatch(sqd_primitives::BlockRef {
+                number: 1,
+                hash: "0x00".to_owned(),
+            }),
+        ];
+
+        for error in &all {
+            match error {
+                RequestError::BadRequest(_)
+                | RequestError::NoData
+                | RequestError::InternalError(_)
+                | RequestError::Failure(_)
+                | RequestError::NoAvailableWorkers
+                | RequestError::TooManyStreams
+                | RequestError::RateLimitExceeded
+                | RequestError::BusyFor(_)
+                | RequestError::BaseBlockMismatch(_) => {}
+            }
+        }
+
+        all
+    }
+
+    /// `retry_after_secs` and `into_response` decide the hint separately. This is
+    /// what stops them drifting: a hint implies 529 + that exact header, and no
+    /// hint implies no header.
+    #[test]
+    fn retry_hint_matches_the_response_for_every_variant() {
+        for error in every_variant() {
+            let hint = error.retry_after_secs();
+            let short_code = error.short_code();
+            let response = error.into_response();
+
+            match hint {
+                Some(secs) => {
+                    assert_eq!(response.status().as_u16(), 529, "{short_code}");
+                    assert_eq!(
+                        response.headers().get(header::RETRY_AFTER),
+                        Some(&header::HeaderValue::from(secs)),
+                        "{short_code} answered with a hint other than its own",
+                    );
+                }
+                None => assert!(
+                    !response.headers().contains_key(header::RETRY_AFTER),
+                    "{short_code} has no hint but answered with Retry-After",
+                ),
+            }
+        }
+    }
+
+    /// Each cause needs a different remedy, so none of them may share a code.
+    #[test]
+    fn short_codes_are_distinct() {
+        let mut codes: Vec<_> = every_variant().iter().map(|e| e.short_code()).collect();
+        codes.sort_unstable();
+        let total = codes.len();
+        codes.dedup();
+
+        assert_eq!(codes.len(), total, "two variants share a short_code");
+    }
+
+    /// Without Retry-After the squid-sdk falls back to its own schedule, first step 10ms.
+    #[test]
+    fn too_many_streams_is_529_with_retry_after() {
+        let response = RequestError::TooManyStreams.into_response();
+
+        assert_eq!(response.status().as_u16(), 529);
+        assert_eq!(
+            response.headers().get(header::RETRY_AFTER),
+            Some(&header::HeaderValue::from_static("1")),
+        );
+    }
+
+    /// No retry hint is possible here, so it must not drift into the overload path.
+    #[test]
+    fn no_available_workers_stays_503_without_retry_after() {
+        let response = RequestError::NoAvailableWorkers.into_response();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(response.headers().get(header::RETRY_AFTER), None);
+    }
+
+    #[test]
+    fn overload_variants_all_signal_backoff() {
+        for error in [
+            RequestError::TooManyStreams,
+            RequestError::RateLimitExceeded,
+            RequestError::BusyFor(Duration::from_secs(3)),
+        ] {
+            let short_code = error.short_code();
+            let response = error.into_response();
+
+            assert_eq!(response.status().as_u16(), 529, "{short_code}");
+            assert!(
+                response.headers().contains_key(header::RETRY_AFTER),
+                "{short_code} must carry Retry-After, or the sdk retries on its own schedule",
+            );
+        }
+    }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -9,5 +9,6 @@ pub use api_types::DatasetRef;
 pub use chunk::*;
 pub use common::*;
 pub use dataset::*;
+pub(crate) use errors::server_overloaded;
 pub use errors::{GenericError, QueryError, RequestError, SendQueryError};
 pub use request::*;


### PR DESCRIPTION
Two commits, one subject: what the stream cap **says** when it rejects, and what it **costs** to reject.

Context: public portal, 2026-07-17 10:01–10:17 UTC. `max_parallel_streams` is **20** (deliberate, set 2025-11-17 in `77c98de78` alongside `max_chunks_per_stream: 10`), so 4 pods = 80 slots. `portal_streams_active` sat pinned at exactly 20 on **all four pods for 14 minutes** while `portal_http_status_total{status="503"}` peaked at **314 rps** against ~150 rps of normal traffic. Readiness never dropped below 3/4 pods, so these came from the portal, not from nginx running out of upstreams. The cap did exactly what it is configured to do — the two bugs are around it.

## 1. `fix(errors)`: the rejection lied, and lost backpressure

Hitting the cap returned `RequestError::Unavailable` → **503, no `Retry-After`**:

- **It lies.** `Unavailable`'s message is *"No available workers to serve the request"* — blaming the network for the portal's own throttle. This is why the storm first looked like a network fault.
- **It loses backpressure.** The squid-sdk http client honours a pause only when `Retry-After` is present (`asRetryAfterPause`); otherwise a 503 falls back to its own `retrySchedule`, **whose first step is 10ms**. Shed load came straight back.

The bandwidth check three lines below already answered 529 + `Retry-After`. The two overload paths simply disagreed.

- `RequestError::TooManyStreams` — new variant for the cap: 529 + `Retry-After: 1`.
- `Unavailable` → **`NoAvailableWorkers`**, keeps its 503. It now means only what it says: no worker holds the chunk, and no honest retry hint exists. Distinct from `NotReady::NoWorkers` ("no workers known at all") — a pair that has already cost us one misdiagnosis.
- `RequestError::retry_after_secs()` — single source of truth for the hint, so `into_response` and the timestamp endpoint can't drift. Collapses three near-identical arms into one.
- `block_number_by_timestamp` no longer flattens every `spawn_stream` error into a bare 503 `"SQD Network error"`, losing both cause and hint.
- `short_code` separates `too_many_streams` / `no_available_workers` / `overloaded` instead of lumping all three — they need different remedies and were indistinguishable in logs.

## 2. `perf(stream)`: rejecting cost as much as serving

`spawn_stream` checked the cap **last**. Every rejected request first parsed the query (the extractor runs before the handler body), took the assignment lock, and spawned a *detached* task fetching `/head` from hotblocks-db — a real HTTP round-trip, orphaned on the reject path, answer discarded.

CPU tracked the 503 curve, not the 200 curve: **4.5 cores → 24** at peak, against a 2-core request with **no CPU limit** to stop it — plus ~300 rps of pointless load on hotblocks, re-paid on every 10ms retry.

- `TaskManager::try_reserve() -> Result<StreamPermit, _>` — cheap admission check (both the cap and the bandwidth threshold), called before any work a rejection would waste.
- The head fetch **stays concurrent** with the first-chunk wait inside `spawn_stream` — that overlap is the whole point of the spawn — it just no longer starts for a request we've already decided to reject.
- `StreamPermit` frees the slot on `Drop`, replacing two manual `fetch_sub` calls, so every early return is accounted for by construction.

## Trade-offs / notes

- **Neither commit fixes saturation.** 450 rps against 80 slots still sheds; clients just stop hammering every 10ms and rejects get cheap. Whether 20 is still right for the public portal is a separate question.
- 529 is non-standard and not in the sdk's retryable list — it retries it *because* of the `Retry-After` header. That is the existing contract here (`BusyFor`, `RateLimitExceeded`), not something this PR introduces.
- `Retry-After: 1` has no jitter, so rejected clients return in a herd at t+1s. Still strictly better than 10ms; worth revisiting if it shows.
- The query parse still happens before admission — killing that needs a tower layer in front of the body read, which is a bigger change than this.

## Test

`cargo test --lib` — 92 passed, clippy clean.

Six tests pin the response contract both ways: overload variants must carry `Retry-After` (or the sdk retries on its own schedule), and `NoAvailableWorkers` must not drift into the overload path.

Three cover admission. The counter is split out as `Slots` to get them: `TaskManager` holds a concrete `Arc<NetworkClient>`, and the existing `MockNetwork` only implements `StreamingNetwork`, which carries no `download_utilization` — so testing through `TaskManager` would have meant making it generic and threading `TaskManager<NetworkClient>` through every handler signature, for a check that never touches the network client anyway. The leak case is the one worth pinning: the slot used to be released by hand on each rejection path, so a future early return that forgot to decrement would wedge the portal at its cap until restarted.

Still untested: the bandwidth threshold (needs the network client, and was untested before), and the ordering constraint itself — nothing stops a future edit moving `try_reserve` back below the head spawn except the comment there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
