### PR TITLE
fix(hotblocks): replay a real-time request once when the connection dies before the response head

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7853,6 +7853,7 @@ dependencies = [
  "flate2",
  "futures 0.3.31",
  "hex-literal",
+ "hyper 1.8.1",
  "itertools 0.12.1",
  "lazy_static",
  "libz-ng-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ dotenv = "0.15"
 flate2 = "1.0.33"
 futures = "0.3"
 hex-literal = "0.4.1"
+# ADR-015 fault classification; reqwest's error API can't see a pre-head connection death.
+hyper = "1"
 itertools = "0.12"
 lazy_static = "1.4.0"
 libz-ng-sys = "1.1.23"

--- a/spec/02-requirements.md
+++ b/spec/02-requirements.md
@@ -199,9 +199,16 @@ counterexample tracked as GAP-5.
 **REQ-22 — Bounded upstream interactions.** [MUST]
 Every outbound call carries a deadline. Deadlines on the request path are strictly below
 the deadlines of clients waiting on them (P-HOTBLOCKS-READ-TIMEOUT <
-P-CLIENT-SDK-TIMEOUT), so a stalled upstream surfaces as a Portal-attributed gateway
+P-CLIENT-TIMEOUT), so a stalled upstream surfaces as a Portal-attributed gateway
 error and a recorded metric — never as a silent client-side timeout the Portal did not
-observe.
+observe. The bound is per upstream call: a connection that dies late in the read budget
+is replayed with a fresh one (ADR-015), so a single call's worst case is
+2 × P-HOTBLOCKS-READ-TIMEOUT and can exceed P-CLIENT-TIMEOUT. The ordering still holds
+where it earns its keep — a stall is never replayed — and the tail costs one upstream
+attempt for a caller that has already disconnected, not a silent failure. No requirement
+bounds what one *client request* spends upstream: a handler that makes real-time calls in
+sequence multiplies the per-call worst case, and already exceeded P-CLIENT-TIMEOUT before
+ADR-015 doubled each call.
 *Acceptance:* stalling the real-time source makes the Portal answer 502 within
 P-HOTBLOCKS-READ-TIMEOUT and record the failure; no outbound call in the codebase is
 deadline-free. The chain-RPC status loop currently violates the latter clause (GAP-18).
@@ -221,11 +228,14 @@ to not-ready at SIGTERM before the listener closes.
 Shutdown is two-phase: on SIGTERM the Portal immediately advertises not-ready while
 continuing to serve for P-PRE-DRAIN-GRACE (letting load balancers drain it), then stops
 accepting work and drains in-flight streams for at most P-DRAIN-TIMEOUT. Total shutdown
-never exceeds P-PRE-DRAIN-GRACE + P-DRAIN-TIMEOUT plus a constant; the orchestrator's
-kill grace must exceed that sum.
+never exceeds P-PRE-DRAIN-GRACE + P-DRAIN-TIMEOUT plus a constant, and the deployment
+must give the process that long: P-KILL-GRACE exceeds that sum. The Portal cannot enforce
+its own grace — below it the process is killed mid-drain and this requirement is void,
+which is an environment defect rather than a Portal one.
 *Acceptance:* under load, SIGTERM → readiness 503 at once; new connections keep being
 served during the grace window; process exits within the budget; in-flight streams
-either complete or truncate per REQ-6.
+either complete or truncate per REQ-6; the deployment manifest sets P-KILL-GRACE above
+the budget.
 *Trace:* ADR-005.
 
 **REQ-25 — Fault isolation across upstreams.** [MUST]

--- a/spec/04-operations.md
+++ b/spec/04-operations.md
@@ -54,7 +54,8 @@ chunk in order, query a worker per DC-1 (choice and speculative retries are free
 variables, FV-1/FV-2, bounded by 1 + retries); concurrently fetch head markers from
 DC-4 (falling back to the archival head) for response metadata. Records from chunk
 results are emitted strictly in chunk order as the client drains.
-— Real-time path: a single proxied request to DC-4; records, conflict payloads, and
+— Real-time path: a proxied request to DC-4, replayed at most once on a connection-class
+fault before the response head (ADR-015); records, conflict payloads, and
 head metadata are streamed with internal upstream headers stripped. Non-success
 upstream responses are classified and rewritten into the Portal error envelope
 (ADR-003 as amended by ADR-011; IB-4/IB-5).

--- a/spec/05-dependencies.md
+++ b/spec/05-dependencies.md
@@ -64,15 +64,20 @@ permanent failure is fatal (the Portal cannot know what it serves).
 *Role.* Recent blocks near the head; the real-time path of OP-1, head reads (OP-2),
 timestamp fallback (OP-5).
 *Call contract.* Per-request proxy: connect deadline P-HOTBLOCKS-CONNECT-TIMEOUT;
-per-read idle deadline P-HOTBLOCKS-READ-TIMEOUT, strictly below P-CLIENT-SDK-TIMEOUT
-(ADR-010); no retries; no redirects. Success and 204 responses stream through with
-internal headers stripped; error responses are status-classified and rewritten into the
-Portal envelope (ADR-003, amended by ADR-011; IB-4/IB-5).
+per-read idle deadline P-HOTBLOCKS-READ-TIMEOUT, strictly below P-CLIENT-TIMEOUT
+(ADR-010); at most one replay, and only for a connection-class fault before the response
+head (ADR-015) — a replayed request gets a fresh read budget, so its worst case is twice
+the deadline and is not bounded by P-CLIENT-TIMEOUT; HTTP/1.1 only, since the replay's
+fault classification reads HTTP/1 error shapes (ADR-015); no redirects. Success and 204
+responses stream through with internal headers stripped; error responses are
+status-classified and rewritten into the Portal envelope (ADR-003, amended by ADR-011;
+IB-4/IB-5).
 *Error mapping.*
 
 | Fault | Own class |
 |---|---|
-| connect/transport failure, read stall past deadline | UPSTREAM-FAILURE (recorded — a stalled upstream must never be invisible, REQ-22) |
+| connect/transport failure before the response head | one replay (ADR-015); still failing ⇒ UPSTREAM-FAILURE (recorded) |
+| read stall past deadline | UPSTREAM-FAILURE, never replayed (recorded — a stalled upstream must never be invisible, REQ-22) |
 | upstream 429 / 503 / 529 | OVERLOADED / `overloaded`; preserve public retry/header semantics, injecting `Retry-After` = P-RETRY-AFTER-MIN when the upstream omitted it (INV-26, ADR-014) |
 | other upstream 5xx | UPSTREAM-FAILURE / `upstream_unavailable`; preserve public headers, never the upstream body |
 | other upstream 4xx (unmatched) | BAD-REQUEST / `malformed_request` (ADR-011 unmatched-4xx rule); status normalized to 400, upstream body never leaked |
@@ -80,7 +85,8 @@ Portal envelope (ADR-003, amended by ADR-011; IB-4/IB-5).
 | requested range below upstream retention (gap) | EMPTY after P-NO-DATA-DELAY |
 | upstream reports unknown dataset (404) | NOT-FOUND / `unknown_dataset`; log the possible configuration incoherence, never leak the upstream body |
 
-*Degradation.* Fail-fast per request; no caching, no health state. An outage affects
+*Degradation.* Fail-fast per request after at most one replay; no caching, no health
+state. An outage affects
 only real-time traffic (REQ-25); readiness ignores this dependency by design.
 
 ## DC-5 — Chain RPC & contracts

--- a/spec/08-liveness.md
+++ b/spec/08-liveness.md
@@ -10,6 +10,9 @@ Liveness claims hold only under a declared environment:
 - **Healthy real-time source:** DC-4 answers within its deadlines.
 - **Adequate resources:** census below P-MAX-STREAMS, congestion utilization below
   P-HEADROOM-THRESHOLD, memory within P-MEMORY-BUDGET.
+- **Patient supervisor:** the orchestrator's kill grace P-KILL-GRACE exceeds
+  P-PRE-DRAIN-GRACE + P-DRAIN-TIMEOUT. Below it the process is killed mid-drain, and no
+  shutdown bound the Portal can offer holds.
 - **Draining client:** the client consumes the response at least as fast as it is
   produced (streams are client-paced; no liveness bound holds against a stalled
   reader).

--- a/spec/09-failure-model.md
+++ b/spec/09-failure-model.md
@@ -12,7 +12,8 @@ one stream's serving path truncates that stream only (INV-36, INV-35).
 
 **FM-2 — Transient vs integrity classification.** Transient faults (timeouts,
 connection failures, 5xx) are retried or rerouted only where the dependency contract
-declares it (DC-1); otherwise they fail-safe in the DEF-10 taxonomy (DC-4). Integrity
+declares it — rerouting across workers (DC-1), one connection-class replay before the
+response head (DC-4, ADR-015) — otherwise they fail-safe in the DEF-10 taxonomy. Integrity
 faults (corrupt artifact, signature failure, contradictory data) are never retried
 blindly: the offending input is rejected and alarmed; the last good state stays in
 service.
@@ -58,12 +59,12 @@ requests only; the publisher ⇒ freshness only; chain RPC ⇒ status only (REQ-
 
 | Fault | Required response |
 |---|---|
-| Down / connect refused | fail-safe UPSTREAM-FAILURE; archival traffic and readiness unaffected (FM-3) |
-| Stalled read | fail-safe UPSTREAM-FAILURE within P-HOTBLOCKS-READ-TIMEOUT, recorded (ADR-010) |
+| Down / connect refused / connection closed before the response head | mask one replay (ADR-015); still failing ⇒ fail-safe UPSTREAM-FAILURE; archival traffic and readiness unaffected (FM-3) |
+| Stalled read | fail-safe UPSTREAM-FAILURE within P-HOTBLOCKS-READ-TIMEOUT, never replayed, recorded (ADR-010) |
 | Upstream 429 / 503 / 529 | fail-safe `overloaded` envelope; public headers retained, `Retry-After` injected at P-RETRY-AFTER-MIN when absent (INV-26); upstream body never leaked (ADR-011) |
 | Other erroring 5xx | fail-safe `upstream_unavailable` envelope; public headers retained, upstream body never leaked (ADR-011) |
 | Erroring 4xx (unmatched) | fail-safe `malformed_request` envelope at 400; upstream body never leaked (DC-4) |
-| Mid-proxy failure | truncate per INV-25 |
+| Mid-proxy failure | truncate per INV-25; never replayed — a replay past the response head would duplicate a prefix (ADR-003, ADR-015) |
 | Retention gap | fail-safe EMPTY (INV-27) |
 
 ## Other dependencies
@@ -83,6 +84,7 @@ requests only; the publisher ⇒ freshness only; chain RPC ⇒ status only (REQ-
 | Panic inside a stream task | truncate that stream (INV-25); process lives (FM-1) |
 | Panic in a background loop | alarm; loop restarts or the failure is surfaced — a dead refresh loop must not be silent (ties to GAP-2) |
 | Memory pressure beyond P-MEMORY-BUDGET | fail-safe refusal preferred over process death — byte-budget admission is the pressure valve (REQ-27; today unmet — GAP-3/GAP-17) |
+| Kill grace below the shutdown budget (P-KILL-GRACE) | environment defect, outside the Portal's reach: the process dies mid-drain, streams are severed without a well-formed truncation (INV-25) and LIV-11's bound is void — the deployment must raise it (REQ-24) |
 | Invalid config values | fail-safe at startup: refuse to run (REQ-33) |
 | Unknown config keys | mask + warn (ADR-008) |
 | Dual instance behind one address | tolerated: no shared mutable state exists outside the process (NG5) |

--- a/spec/12-observability.md
+++ b/spec/12-observability.md
@@ -23,8 +23,17 @@ misdiagnosed for lack of this split.
 
 **OB-4 — Dependency health.** Per dependency (DC-1..DC-6): call outcomes by class,
 latency, and for workers: selections by priority group, penalties applied, backoff
-hints received. A wedged dependency must be visible from the Portal's own metrics
-alone (REQ-22).
+hints received. Every logical real-time-source request is counted exactly once in
+`hotblocks_requests`, with a closed `outcome`: `response`, `replay_response`,
+`replay_failed`, `canceled`, `replay_canceled`, `timeout`, or `transport_failed`
+(ADR-015). The first two mean that a response head was obtained, on the first attempt and
+on the replay respectively; every value states what the transport observed, never what the
+client ended up seeing — that axis lives in `http_status`. The replay outcomes keep an
+absorbed connection fault visible, and the two cancellation outcomes distinguish which
+attempt the caller abandoned without claiming an upstream result that was never observed.
+`timeout` is the expected non-replay decision; growth in `transport_failed` can expose a
+connection fault whose shape the replay classifier stopped recognising. A wedged
+dependency must be visible from the Portal's own metrics alone (REQ-22).
 
 **OB-5 — Readiness reason.** The readiness state as a gauge with a reason code
 (loading / insufficient-connectivity / shutting-down / ⚠ stale-artifact), and logged

--- a/spec/13-conformance.md
+++ b/spec/13-conformance.md
@@ -172,9 +172,9 @@ chunk-boundary records FV-6 licenses.
 | REQ-15 | P | Plan extraction/rewrite units; no e2e |
 | REQ-20 | P | **Known-violated** — cap exhaustion is not exercised and current master misclassifies it (GAP-4); taxonomy target is GAP-16 |
 | REQ-21 | P | Two crash regressions; latent panic (GAP-5, INV-36) |
-| REQ-22 | P | Real-time deadline units exist; **known-violated** because chain-RPC calls lack explicit deadlines (GAP-18) |
+| REQ-22 | P | Real-time deadline units exist, including ADR-015's exclusion of read stalls from replay; **known-violated** because chain-RPC calls lack explicit deadlines (GAP-18), and because a replayed request can spend the read budget twice (ADR-015). The per-call bound is tested; a client request's total upstream spend is neither bounded nor tested |
 | REQ-23 | P | Shutdown flip tested; other conjuncts not; staleness unimplemented (GAP-2, INV-31) |
-| REQ-24 | P | Drain race tested; in-flight behavior during drain untested (LIV-11) |
+| REQ-24 | P | Drain race tested; in-flight behavior during drain untested (LIV-11); the P-KILL-GRACE conjunct is environmental — no in-process test can assert it |
 | REQ-25 | U | No outage tests |
 | REQ-26 | U | **Known-violated** (GAP-1, ADR-002) |
 | REQ-27 | U | **Known-violated** — OOM incident plus no global byte budget (GAP-3, GAP-17, PF-1) |
@@ -188,7 +188,7 @@ chunk-boundary records FV-6 licenses.
 | REQ-43 | P | Positive path exercised by the smoke (signed stub responses verified and delivered); rejection path untested |
 | REQ-44 | U | — |
 
-## Gap register — 2026-07-17
+## Gap register — 2026-07-21
 
 Priorities: P0 blocks the program · P1 active production risk · P2 correctness hole
 with plausible trigger · P3 polish. "Next" = cheapest failing-test-first entry.
@@ -213,9 +213,18 @@ with plausible trigger · P3 polish. "Next" = cheapest failing-test-first entry.
 | GAP-19 | Conflict detection is not known to precede the beyond-frontier EMPTY: a real-time continuation at the head with a stale parent may poll empty instead of getting 409 (the pre-ADR-014 oracle ordered EMPTY first; master unverified) | REQ-3, INV-23, INV-27 (ADR-014) | P2 | CT-2: reorg-at-head stub world → assert 409 precedence |
 | GAP-20 | No regression guard on artifact application: a republished older artifact (different identifier) would be re-applied | REQ-40, INV-2, DEF-4 (ADR-014) | P2 | CT-2: regressive publisher stub → assert not applied |
 | GAP-21 | Debug stream variant bypasses clamps without an operator gate | INV-11, REQ-8 (ADR-014; closed OQ-6) | P2 | config test: route absent unless the operator flag enables it |
+| GAP-22 | Pre-first-byte outcomes of the real-time source now have one denominator in `hotblocks_requests`, but no objective. `response` and `replay_response` obtained a response head; `replay_failed`, `timeout`, and `transport_failed` did not; cancellation remains visible without inventing an upstream result. SLI-4 is readiness availability and excludes deploys, SLI-6 counts truncated streams, and neither turns this counter into a request-success SLI | SLI set, OB-4 (ADR-015) | P2 | define a DC-4 response-head SLI over `hotblocks_requests`, with cancellations explicitly included or excluded by policy |
 
 ### Closed findings
 
+- **GAP-22, original claim** (closed 2026-07-21): the ADR-015 replay landed in the DC-4
+  transport, with unit coverage for the clean close, the reset, the at-most-once bound,
+  and the two non-replay exclusions (mid-body, read stall). Writing the reset case found
+  a real defect in the first implementation: the classifier returned on the first
+  `hyper::Error` in the source chain, so a peer that resets rather than closing cleanly —
+  the common shape when a replica dies with the request still unread — was never
+  replayed, and the fix would have missed most of the incident it was written for.
+  GAP-22 now tracks only the indicator residual.
 - **GAP-9** (closed 2026-07-17): EMPTY delay occurs after the stream census permit is
   released. It can occupy an HTTP connection/task (HZ-3), but does not consume the
   stream cap.

--- a/spec/15-parameters.md
+++ b/spec/15-parameters.md
@@ -28,8 +28,8 @@ assumes, not knobs it owns.
 |---|---|---|---|
 | P-TRANSPORT-TIMEOUT | Worker query request deadline (REQ-41) | 60 s | 60 s |
 | P-HOTBLOCKS-CONNECT-TIMEOUT | Real-time source connect deadline (REQ-22) | 1 s | 1 s |
-| P-HOTBLOCKS-READ-TIMEOUT | Real-time source per-read deadline; must stay < P-CLIENT-SDK-TIMEOUT (REQ-22, ADR-010) | 20 s | 20 s |
-| P-CLIENT-SDK-TIMEOUT | *Environmental:* default request deadline of the dominant client SDK (ADR-010) | 30 s | ≥ 30 s assumed |
+| P-HOTBLOCKS-READ-TIMEOUT | Real-time source per-read deadline; must stay < P-CLIENT-TIMEOUT (REQ-22, ADR-010). A replayed request spends it twice (ADR-015) | 20 s | 20 s |
+| P-CLIENT-TIMEOUT | *Environmental:* the request deadline callers default to (ADR-010) | 30 s | ≥ 30 s assumed |
 | P-ASSIGNMENT-REFRESH | Assignment poll interval (REQ-40, REQ-11) | 60 s | 60 s |
 | P-ASSIGNMENT-FETCH-TIMEOUT | Assignment fetch connect/read deadlines (REQ-22) | 5 s / 5 s | 5 s / 5 s |
 | P-ASSIGNMENT-MAX-AGE | ⚠ Max tolerated assignment age before readiness degrades (REQ-23, ADR-013) | **unbounded — violated in intent** | ⚠ 15 min (draft; ratify via ADR-013) |
@@ -66,6 +66,7 @@ assumes, not knobs it owns.
 |---|---|---|---|
 | P-PRE-DRAIN-GRACE | Serve-while-not-ready window after SIGTERM (REQ-24, ADR-005) | 25 s | 25 s |
 | P-DRAIN-TIMEOUT | In-flight drain budget after intake stops (REQ-24, ADR-005) | 25 s | 25 s |
+| P-KILL-GRACE | *Environmental:* the orchestrator's grace between SIGTERM and SIGKILL — Kubernetes `terminationGracePeriodSeconds` (REQ-24, LIV-11, ADR-005) | deployment-set, unverified; the Kubernetes default of 30 s is **below** the 50 s budget | ≥ P-PRE-DRAIN-GRACE + P-DRAIN-TIMEOUT + slack (≥ 60 s) |
 | P-READY-CONNECTION-RATIO | Min fraction of known workers connected for readiness (REQ-23) | 3/4 *(fixed)* | 3/4 |
 | P-STARTUP-BOUND | ⚠ Start → ready bound, dominated by artifact fetch (LIV-5, S5) | unmeasured | ⚠ 10 min (proposed) |
 | P-STALL-BUDGET | ⚠ Max zero-progress interval on a healthy stream; also the first-record bound (LIV-1, LIV-2, OB-2) | unmeasured | ⚠ 2 × P-TRANSPORT-TIMEOUT (proposed) |

--- a/spec/README.md
+++ b/spec/README.md
@@ -45,7 +45,7 @@ not been ratified are explicitly `Proposed` and appear after the accepted log.
 |---|---|---|---|
 | ADR-001 | 2024-08-28 | [Mid-stream failure truncates the response; continuation is the recovery path](decisions/ADR-001-truncation-over-error.md) | Accepted (historical) |
 | ADR-002 | 2025-08-08 | [Assignment is loaded without structural verification](decisions/ADR-002-skip-assignment-verification.md) | Accepted (historical) |
-| ADR-003 | 2025-09-15 | [Real-time data is served through a streaming Portal proxy](decisions/ADR-003-real-time-proxy.md) | Accepted (historical; amended by ADR-011) |
+| ADR-003 | 2025-09-15 | [Real-time data is served through a streaming Portal proxy](decisions/ADR-003-real-time-proxy.md) | Accepted (historical; amended by ADR-011, ADR-015) |
 | ADR-004 | 2025-12-02 | [Asymmetric worker penalties; one query per worker](decisions/ADR-004-worker-penalties.md) | Accepted (historical) |
 | ADR-005 | 2026-05-27 | [Two-phase graceful shutdown](decisions/ADR-005-two-phase-shutdown.md) | Accepted (historical) |
 | ADR-006 | 2026-06-03 | [Network bandwidth is the modeled limiting resource](decisions/ADR-006-bandwidth-limiting-resource.md) | Accepted (historical) |
@@ -56,6 +56,7 @@ not been ratified are explicitly `Proposed` and appear after the accepted log.
 | ADR-011 | 2026-07-16 | [Portal API errors use a stable two-axis taxonomy](decisions/ADR-011-error-taxonomy.md) | Accepted |
 | ADR-012 | 2026-07-17 | [Every shed response carries an explicit retry hint](decisions/ADR-012-retry-after-on-shed.md) | Accepted |
 | ADR-014 | 2026-07-17 | [Contract reconciliation: overload hints, conflict precedence, artifact regression, archival finalized head, EMPTY metadata, timestamp frontier, gated debug surface](decisions/ADR-014-contract-reconciliation.md) | Accepted |
+| ADR-015 | 2026-07-21 | [One connection-class replay on the real-time path](decisions/ADR-015-real-time-connection-replay.md) | Accepted |
 | ADR-013 | 2026-07-17 | [Assignment staleness must be bounded and observable](decisions/ADR-013-assignment-staleness-bound.md) | **Proposed** |
 
 ## Conventions

--- a/spec/decisions/ADR-003-real-time-proxy.md
+++ b/spec/decisions/ADR-003-real-time-proxy.md
@@ -1,6 +1,7 @@
 # ADR-003 — Real-time data is served through a streaming Portal proxy
 
-Status: Accepted (historical, 2025-09-15); error handling amended by ADR-011
+Status: Accepted (historical, 2025-09-15); error handling amended by ADR-011, the
+no-retry rule narrowed to post-response-head faults by ADR-015
 
 ## Context
 
@@ -23,6 +24,11 @@ The original implementation also passed upstream error bodies through unchanged.
 part of the historical decision is amended by ADR-011: error statuses are classified
 into the Portal's public taxonomy and their bodies are rewritten into the Portal error
 envelope. Public upstream headers such as `Retry-After` and `x-sqd-*` remain preserved.
+
+The no-retry rule is narrowed by ADR-015 to the range this decision actually reasoned
+about: a connection-class fault *before* the response head is replayed once, since no
+byte has been delivered and no prefix can be duplicated. Any fault after the response
+head still truncates rather than retries.
 
 ## Consequences
 

--- a/spec/decisions/ADR-010-upstream-deadline-below-client.md
+++ b/spec/decisions/ADR-010-upstream-deadline-below-client.md
@@ -1,6 +1,7 @@
 # ADR-010 — Upstream deadlines sit strictly below client deadlines
 
-Status: Accepted (historical, 2026-07-09)
+Status: Accepted (historical, 2026-07-09); the ordering holds per upstream call, not per
+client request, once ADR-015 admits a replay
 
 ## Context
 
@@ -15,7 +16,7 @@ had no deadline at all.
 
 Every outbound call carries a deadline, and deadlines on the client-facing request path
 are ordered: the upstream read deadline (P-HOTBLOCKS-READ-TIMEOUT, default 20 s) sits
-strictly below the client SDK deadline (P-CLIENT-SDK-TIMEOUT, 30 s) and above the
+strictly below the caller's default deadline (P-CLIENT-TIMEOUT, 30 s) and above the
 upstream's own internal budgets (its 5 s long-poll + 10 s query), so a stall surfaces
 as the Portal's own 502 — attributed, logged, and counted — before the client gives up.
 
@@ -25,3 +26,12 @@ Stalled upstreams become a Portal-observable failure class with metrics and logs
 instead of a silent client-side mystery. The deadline ordering is a standing constraint
 on configuration: raising the upstream deadline above the client deadline silently
 reintroduces the blindness. Shapes REQ-22.
+
+The ordering is per upstream call, and always was — a client request that makes two
+real-time calls in sequence (a stream then a status probe, OP-5's status then stream)
+could already spend 2 × P-HOTBLOCKS-READ-TIMEOUT and outlast P-CLIENT-TIMEOUT. ADR-015
+doubles the per-call worst case on top of that. Neither weakens what this decision buys:
+the blindness it removed came from the Portal and the caller expiring *at the same
+instant* on one call, and a caller that gives up during a later call disconnects, which
+the Portal does observe. What the ordering does not provide, and never did, is a bound on
+the total a client request may spend upstream.

--- a/spec/decisions/ADR-015-real-time-connection-replay.md
+++ b/spec/decisions/ADR-015-real-time-connection-replay.md
@@ -1,0 +1,125 @@
+# ADR-015 — One connection-class replay on the real-time path
+
+Status: Accepted (2026-07-21)
+
+## Context
+
+ADR-003 made the real-time path a single un-replayed proxied request: retrying after
+response bytes have arrived would duplicate a prefix, and buffering to make retries safe
+would defeat streaming. That reasoning covers faults *after* the response head. It swept
+in the faults that happen before it too, and those turn out to be the common ones.
+
+Every replica replacement of the real-time source is client-visible today. The Portal
+reaches the source through one virtual address and holds pooled keepalive connections, so
+a terminating replica takes live connections down with it while its ready siblings sit
+idle. Two fault shapes escape the transport's own recovery: a request whose bytes already
+reached the wire when the peer closed — the connection dies before any response head, and
+the transport cannot know the request was not acted upon, so it refuses to replay it — and
+a connect-class failure against an endpoint being retired. A request the transport never
+wrote is already replayed for us, on any method; that class is not what fires in
+production. Observed 2026-07-21 09:14:10: a 502 burst one second after the upstream's
+SIGTERM.
+
+The failure is also invisible to the indicators: SLI-4 measures readiness and excludes
+deploys, SLI-6 counts truncated streams, and these are clean pre-first-byte refusals.
+
+## Decision
+
+A DC-4 request that fails **before its response head is received** is replayed exactly
+once, on a connection other than the failed one, when the fault is connection-class: the
+connect attempt failed, or the connection closed with no response head. The client sees
+the outcome of the replay.
+
+"Closed" includes a reset, not only a clean close. A replica that dies with our request
+still unread makes the kernel send RST rather than FIN, and that arrives as a bare I/O
+kind with none of the transport's own connection-loss predicates set. It is the more
+common shape of the incident, so classifying only the clean close would leave most of the
+fault this decision exists for unreplayed. For the same reason the classifier never stops at
+the first error it recognises: a layer that wraps the reset in an I/O error of its own
+would otherwise answer the question before the real cause is reached.
+
+Because the classification reads HTTP/1 error shapes, the real-time client is pinned to
+HTTP/1.1. The source is a plaintext in-cluster service today, so nothing negotiates
+otherwise — but over TLS, ALPN would select h2, and a GOAWAY before the head would arrive
+as a protocol error none of these predicates match. The replay would stop firing with
+every test still passing. Pinning makes the deployed protocol the tested one, and turns a
+silent narrowing into a visible constraint on how the source may be exposed.
+
+Two exclusions carry the weight of the decision.
+
+Any fault **after** the response head keeps ADR-003's rule: the response truncates on a
+record boundary (INV-25, ADR-001). Nothing already delivered is ever re-fetched, so no
+prefix can be duplicated.
+
+A read-idle deadline expiry is **not** connection-class. A stall consumes the whole read
+budget; replaying it would push the answer past the caller's deadline and reintroduce the
+blindness ADR-010 removed.
+
+No third rule models the caller's own deadline, and deliberately so. The Portal cannot
+know it — P-CLIENT-TIMEOUT is a sizing constraint on configuration, not a value to branch
+on at run time, and a guess about it is wrong in both directions with no way to notice. It
+also isn't needed: a caller that has given up disconnects, and disconnect reclamation
+(LIV-10) cancels the replay with everything else the stream held. The caller's deadline
+enforces itself. The residual case — the upstream dies late in a request, and the replay
+answers after the caller has already timed out — costs one upstream attempt for an absent
+client and is bounded by the same reclamation.
+
+That residual does widen the per-call bound REQ-22 states. A replay gets a fresh read
+budget, so the worst case is 2 × P-HOTBLOCKS-READ-TIMEOUT, and in that tail the Portal's
+deadline no longer sits below P-CLIENT-TIMEOUT. Accepted, and recorded in REQ-22 and DC-4
+rather than left implicit: the shape that fires in production is a pooled connection to a
+terminating replica, which dies in milliseconds, and the fault the ordering exists to
+catch — a stall — is never replayed. What a whole *client request* may spend upstream is a
+separate question this decision does not touch: handlers already made real-time calls in
+sequence, so that total was a multiple of the per-call bound before the replay doubled
+each call.
+
+Every logical DC-4 request is counted once in `hotblocks_requests` (OB-4), rather than
+splitting replay and non-replay paths into metric families that must be joined. Its closed
+`outcome` is `response` when the first attempt obtains a response head,
+`replay_response` when the replay obtains one, and `replay_failed` when the replay
+completes with another transport fault. `canceled` and `replay_canceled` preserve which
+attempt the caller abandoned without claiming an upstream result the Portal never observed.
+Every value names what the transport observed, and none asserts what the client received:
+a response head of any status counts as one. Mixing the two axes in one closed set would
+make the family read as a success rate it cannot support — what the client got is
+`http_status`.
+
+The same family records `timeout` for the expected non-replay decision and
+`transport_failed` for any other first-attempt failure that was not replayable. This makes
+healthy traffic the denominator, keeps an absorbed fault visible, and prevents zero replays
+from reading as health when the classifier has instead stopped recognising the fault.
+Growth in `transport_failed` is the classifier-miss signal. The HTTP/1 pin prevents one
+known cause of that rot; the counter is what finds the unknown ones.
+
+## Consequences
+
+One client request may now reach the real-time service twice. That is safe because every
+operation on that path is a read and the Portal keeps no dedup keys (04), and because the
+replay is gated on zero bytes delivered — ADR-003's prefix-duplication argument is not
+weakened, only narrowed to the range where it applies.
+
+Replica replacement stops being client-visible in the common case, which is the point.
+Masking is not a guarantee: behind one virtual address a replay can land on the same
+retiring replica, and a sustained outage still fails safe as UPSTREAM-FAILURE one attempt
+later. Bounded at one attempt and counted, it stays inside LIV-12 — this is not a retry
+loop and must not grow into one.
+
+The replay is immediate, with no backoff or jitter. A terminating replica fails every
+connection it holds within the same few milliseconds, so the survivors take a correlated
+burst of reconnects at exactly the moment they absorb the failover. Accepted: at one
+attempt the burst is bounded at twice the in-flight count and arrives once, which is what
+a connection pool refilling after any replica loss does anyway, while a delay would tax
+the common case — a pooled connection to a dead peer, replayable in microseconds — to
+smooth a spike the survivors already handle. Jitter becomes worth revisiting only if the
+replay ever gains a second attempt, which LIV-12 says it must not.
+
+The Portal now absorbs a class of upstream deploy fault instead of reporting it.
+`hotblocks_requests{outcome="replay_response"}` growing outside a deploy means the upstream
+is losing connections at a rate the client-visible error rate no longer reflects. How much
+of that was actually masked is derived rather than read off this counter: a replay that
+answers 503 is counted here and still reaches the client as an error, in `http_status`.
+`outcome="replay_failed"` is the residual the replay did not cover — no response head at
+all — and `outcome="replay_canceled"` makes an inconclusive replay visible
+without blaming the upstream. The unified counter supplies an SLI denominator, but no
+objective is defined for it yet (GAP-22).

--- a/src/config.rs
+++ b/src/config.rs
@@ -211,7 +211,7 @@ fn default_transport_timeout() -> Duration {
     Duration::from_secs(60)
 }
 
-// Must stay below caller-side request timeouts (SDK default: 30s), so a stalled
+// Must stay below caller-side request timeouts (callers default to 30s), so a stalled
 // upstream surfaces as our 502 rather than the caller's own timeout — a request
 // still in flight has no recorded status and is invisible in metrics.
 fn default_hotblocks_read_timeout() -> Duration {

--- a/src/hotblocks.rs
+++ b/src/hotblocks.rs
@@ -2,7 +2,10 @@ use std::{collections::BTreeMap, time::Duration};
 
 use sqd_primitives::BlockNumber;
 
-use crate::config::Config;
+use crate::{config::Config, metrics::HotblocksRequestOutcome};
+
+/// P-HOTBLOCKS-CONNECT-TIMEOUT.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
 
 pub struct HotblocksHandle {
     pub client: reqwest::Client,
@@ -82,7 +85,10 @@ pub async fn build_client(config: &Config) -> anyhow::Result<HotblocksHandle> {
         .no_deflate()
         .no_brotli()
         .no_zstd()
-        .connect_timeout(Duration::from_secs(1))
+        // ADR-015 classifies HTTP/1 error shapes; over TLS, ALPN would pick h2 and the
+        // replay would stop firing with every test still green.
+        .http1_only()
+        .connect_timeout(CONNECT_TIMEOUT)
         .read_timeout(config.hotblocks_read_timeout);
 
     if let Some(client_id) = &config.client_id {
@@ -99,7 +105,128 @@ pub async fn build_client(config: &Config) -> anyhow::Result<HotblocksHandle> {
     Ok(HotblocksHandle { client, urls })
 }
 
+/// Connection-class per ADR-015: never came up, or died with no response head. A read
+/// stall is excluded — it has spent the read budget already, so a replay answers too late.
+fn is_connection_class(err: &reqwest::Error) -> bool {
+    use std::{error::Error as _, io::ErrorKind};
+
+    // A connect timeout is both, and it is a failed connect. Only a stall reaches below.
+    if err.is_connect() {
+        return true;
+    }
+    if err.is_timeout() {
+        return false;
+    }
+
+    // Walk to the cause, stopping at no error merely recognised: a reset arrives as a bare
+    // I/O kind under hyper's predicates, and a wrapping layer can bury it further still.
+    let mut source = err.source();
+    while let Some(err) = source {
+        if let Some(err) = err.downcast_ref::<hyper::Error>() {
+            // What the transport hands back for a request it wrote and can't prove unserved.
+            if err.is_incomplete_message() || err.is_closed() || err.is_canceled() {
+                return true;
+            }
+        }
+        if let Some(err) = err.downcast_ref::<std::io::Error>() {
+            if matches!(
+                err.kind(),
+                ErrorKind::ConnectionReset
+                    | ErrorKind::ConnectionAborted
+                    | ErrorKind::BrokenPipe
+                    | ErrorKind::UnexpectedEof
+                    | ErrorKind::NotConnected
+            ) {
+                return true;
+            }
+        }
+        source = err.source();
+    }
+    false
+}
+
+/// Ensures every started DC-4 request has one final transport outcome even when its future
+/// is dropped. The pending cancellation outcome changes when the replay starts, preserving
+/// which attempt the caller abandoned without introducing a second metric family.
+struct RequestMetricGuard {
+    pending: Option<HotblocksRequestOutcome>,
+}
+
+impl RequestMetricGuard {
+    fn new() -> Self {
+        Self {
+            pending: Some(HotblocksRequestOutcome::Canceled),
+        }
+    }
+
+    fn replaying(&mut self) {
+        self.pending = Some(HotblocksRequestOutcome::ReplayCanceled);
+    }
+
+    fn complete(mut self, outcome: HotblocksRequestOutcome) {
+        self.pending = None;
+        crate::metrics::report_hotblocks_request(outcome);
+    }
+}
+
+impl Drop for RequestMetricGuard {
+    fn drop(&mut self) {
+        if let Some(outcome) = self.pending.take() {
+            crate::metrics::report_hotblocks_request(outcome);
+        }
+    }
+}
+
 impl HotblocksHandle {
+    /// Sends a DC-4 request, replaying it once on a connection-class fault (ADR-015).
+    ///
+    /// Wrapping `send` bounds this to faults before the response head — the future resolves
+    /// at the head, so a mid-body fault can't reach here (ADR-003, INV-25). A caller that
+    /// gave up disconnects, cancelling the replay, so its deadline needs no model (LIV-10).
+    async fn send_with_replay(
+        &self,
+        request: reqwest::RequestBuilder,
+    ) -> Result<reqwest::Response, reqwest::Error> {
+        let replay = request.try_clone();
+        let mut request_metric = RequestMetricGuard::new();
+
+        let err = match request.send().await {
+            Ok(response) => {
+                request_metric.complete(HotblocksRequestOutcome::Response);
+                return Ok(response);
+            }
+            Err(err) => err,
+        };
+
+        if !is_connection_class(&err) {
+            let outcome = if err.is_timeout() {
+                HotblocksRequestOutcome::Timeout
+            } else {
+                HotblocksRequestOutcome::TransportFailed
+            };
+            request_metric.complete(outcome);
+            return Err(err);
+        }
+        let Some(replay) = replay else {
+            // Unreachable while every DC-4 body is buffered; a streaming one would
+            // disable the replay silently.
+            tracing::warn!("hotblocks request is not clonable; not replaying");
+            request_metric.complete(HotblocksRequestOutcome::TransportFailed);
+            return Err(err);
+        };
+
+        tracing::info!(error = %err, "hotblocks connection lost before the response head; replaying once");
+        request_metric.replaying();
+        let result = replay.send().await;
+        let outcome = if result.is_ok() {
+            HotblocksRequestOutcome::ReplayResponse
+        } else {
+            HotblocksRequestOutcome::ReplayFailed
+        };
+        request_metric.complete(outcome);
+        result
+    }
+
     pub async fn request_head(
         &self,
         dataset: &str,
@@ -114,7 +241,9 @@ impl HotblocksHandle {
             HeadMode::RealTime => "head",
         };
 
-        let response = self.client.get(format!("{url}/{endpoint}")).send().await?;
+        let response = self
+            .send_with_replay(self.client.get(format!("{url}/{endpoint}")))
+            .await?;
 
         Ok(response)
     }
@@ -140,7 +269,9 @@ impl HotblocksHandle {
             return Err(HotblocksErr::UnknownDataset);
         };
 
-        let response = self.client.get(format!("{url}/status")).send().await?;
+        let response = self
+            .send_with_replay(self.client.get(format!("{url}/status")))
+            .await?;
 
         Ok(response)
     }
@@ -173,13 +304,301 @@ impl HotblocksHandle {
         };
 
         let response = self
-            .client
-            .post(format!("{url}/{endpoint}"))
-            .header("Content-Type", "application/json")
-            .body(query.to_string())
-            .send()
+            .send_with_replay(
+                self.client
+                    .post(format!("{url}/{endpoint}"))
+                    .header("Content-Type", "application/json")
+                    .body(query.to_string()),
+            )
             .await?;
 
         Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::SocketAddr,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+    };
+
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::{TcpListener, TcpStream},
+    };
+
+    use super::*;
+    use crate::metrics::{hotblocks_requests, HotblocksRequestOutcome};
+
+    /// Serializes the tests that assert deltas on the process-wide counters.
+    static COUNTERS: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    /// What a stub upstream does with one accepted connection.
+    #[derive(Clone, Copy)]
+    enum Act {
+        /// FIN with no response head — a replica terminating mid-request.
+        CloseBeforeHead,
+        /// RST instead: what a dying peer sends with our request still unread. Carries
+        /// none of hyper's predicates, only an I/O kind.
+        ResetBeforeHead,
+        /// Read the request and say nothing.
+        Stall,
+        Answer,
+        /// Head, then drop mid-body.
+        CloseMidBody,
+    }
+
+    /// Applies `acts` to successive connections; anything beyond them is closed unanswered.
+    async fn stub(acts: Vec<Act>) -> (SocketAddr, Arc<AtomicUsize>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let connections = Arc::new(AtomicUsize::new(0));
+
+        let seen = connections.clone();
+        tokio::spawn(async move {
+            loop {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let act = acts
+                    .get(seen.fetch_add(1, Ordering::SeqCst))
+                    .copied()
+                    .unwrap_or(Act::CloseBeforeHead);
+                tokio::spawn(async move {
+                    read_request(&mut socket).await;
+                    match act {
+                        Act::CloseBeforeHead => {}
+                        Act::ResetBeforeHead => {
+                            let _ = socket.set_linger(Some(Duration::ZERO));
+                        }
+                        Act::Stall => tokio::time::sleep(Duration::from_secs(30)).await,
+                        Act::Answer => {
+                            let _ = socket
+                                .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\n\r\nok")
+                                .await;
+                        }
+                        Act::CloseMidBody => {
+                            let _ = socket
+                                .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 64\r\n\r\nhalf")
+                                .await;
+                        }
+                    }
+                });
+            }
+        });
+
+        (addr, connections)
+    }
+
+    /// Reads the whole head, so the request demonstrably reached the wire — the condition
+    /// that makes the transport refuse to replay it itself.
+    async fn read_request(socket: &mut TcpStream) {
+        let mut seen = Vec::new();
+        let mut buf = [0u8; 1024];
+        while !seen.windows(4).any(|w| w == b"\r\n\r\n") {
+            match socket.read(&mut buf).await {
+                Ok(0) | Err(_) => return,
+                Ok(n) => seen.extend_from_slice(&buf[..n]),
+            }
+        }
+    }
+
+    fn handle(addr: SocketAddr, read_timeout: Duration) -> HotblocksHandle {
+        HotblocksHandle {
+            client: reqwest::Client::builder()
+                .http1_only()
+                .connect_timeout(CONNECT_TIMEOUT)
+                .read_timeout(read_timeout)
+                .build()
+                .unwrap(),
+            urls: BTreeMap::from([("ds".to_owned(), format!("http://{addr}/datasets/ds"))]),
+        }
+    }
+
+    async fn wait_for_connections(connections: &AtomicUsize, expected: usize) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while connections.load(Ordering::SeqCst) < expected {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the request did not reach the upstream");
+    }
+
+    #[tokio::test]
+    async fn replays_once_when_the_peer_closes_before_the_response_head() {
+        let _counter = COUNTERS.lock().await;
+        let replayed = hotblocks_requests(HotblocksRequestOutcome::ReplayResponse);
+        let (addr, connections) = stub(vec![Act::CloseBeforeHead, Act::Answer]).await;
+        let handle = handle(addr, Duration::from_secs(5));
+
+        let response = handle.stream("ds", "{}", HeadMode::RealTime).await.unwrap();
+
+        assert_eq!(response.status(), 200);
+        assert_eq!(
+            connections.load(Ordering::SeqCst),
+            2,
+            "one replay, on a new connection"
+        );
+        assert_eq!(
+            hotblocks_requests(HotblocksRequestOutcome::ReplayResponse) - replayed,
+            1,
+            "a fault the client never saw must still be counted"
+        );
+    }
+
+    /// The common shape: a reset carries none of hyper's predicates, so matching only the
+    /// clean close would leave most of the incident unreplayed.
+    #[tokio::test]
+    async fn replays_a_reset_before_the_response_head() {
+        let _counter = COUNTERS.lock().await;
+        let replayed = hotblocks_requests(HotblocksRequestOutcome::ReplayResponse);
+        let (addr, connections) = stub(vec![Act::ResetBeforeHead, Act::Answer]).await;
+        let handle = handle(addr, Duration::from_secs(5));
+
+        let response = handle.stream("ds", "{}", HeadMode::RealTime).await.unwrap();
+
+        assert_eq!(response.status(), 200);
+        assert_eq!(connections.load(Ordering::SeqCst), 2, "one replay");
+        assert_eq!(
+            hotblocks_requests(HotblocksRequestOutcome::ReplayResponse) - replayed,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn replays_at_most_once() {
+        let _counter = COUNTERS.lock().await;
+        let replayed = hotblocks_requests(HotblocksRequestOutcome::ReplayResponse);
+        let failed = hotblocks_requests(HotblocksRequestOutcome::ReplayFailed);
+        let (addr, connections) = stub(vec![Act::CloseBeforeHead, Act::CloseBeforeHead]).await;
+        let handle = handle(addr, Duration::from_secs(5));
+
+        handle
+            .stream("ds", "{}", HeadMode::RealTime)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            connections.load(Ordering::SeqCst),
+            2,
+            "one replay, never a retry loop (LIV-12)"
+        );
+        assert_eq!(
+            hotblocks_requests(HotblocksRequestOutcome::ReplayFailed) - failed,
+            1,
+            "a replay that obtained no head must not land with the ones that did"
+        );
+        assert_eq!(
+            hotblocks_requests(HotblocksRequestOutcome::ReplayResponse) - replayed,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn counts_a_replay_canceled_with_its_caller() {
+        let _counter = COUNTERS.lock().await;
+        let canceled = hotblocks_requests(HotblocksRequestOutcome::ReplayCanceled);
+        let failed = hotblocks_requests(HotblocksRequestOutcome::ReplayFailed);
+        let (addr, connections) = stub(vec![Act::CloseBeforeHead, Act::Stall]).await;
+        let handle = handle(addr, Duration::from_secs(5));
+
+        let request =
+            tokio::spawn(async move { handle.stream("ds", "{}", HeadMode::RealTime).await });
+        wait_for_connections(&connections, 2).await;
+
+        request.abort();
+        assert!(request.await.unwrap_err().is_cancelled());
+        assert_eq!(
+            hotblocks_requests(HotblocksRequestOutcome::ReplayCanceled) - canceled,
+            1,
+            "a replay dropped with its caller must remain observable"
+        );
+        assert_eq!(
+            hotblocks_requests(HotblocksRequestOutcome::ReplayFailed) - failed,
+            0,
+            "caller cancellation is not an observed upstream failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn counts_a_request_canceled_before_replay() {
+        let _counter = COUNTERS.lock().await;
+        let canceled = hotblocks_requests(HotblocksRequestOutcome::Canceled);
+        let replay_canceled = hotblocks_requests(HotblocksRequestOutcome::ReplayCanceled);
+        let (addr, connections) = stub(vec![Act::Stall]).await;
+        let handle = handle(addr, Duration::from_secs(5));
+
+        let request =
+            tokio::spawn(async move { handle.stream("ds", "{}", HeadMode::RealTime).await });
+        wait_for_connections(&connections, 1).await;
+
+        request.abort();
+        assert!(request.await.unwrap_err().is_cancelled());
+        assert_eq!(
+            hotblocks_requests(HotblocksRequestOutcome::Canceled) - canceled,
+            1,
+            "a dropped initial attempt must remain observable"
+        );
+        assert_eq!(
+            hotblocks_requests(HotblocksRequestOutcome::ReplayCanceled) - replay_canceled,
+            0,
+            "the request never reached the replay phase"
+        );
+    }
+
+    #[tokio::test]
+    async fn does_not_replay_after_the_response_head() {
+        let _counter = COUNTERS.lock().await;
+        let responses = hotblocks_requests(HotblocksRequestOutcome::Response);
+        let (addr, connections) = stub(vec![Act::CloseMidBody, Act::Answer]).await;
+        let handle = handle(addr, Duration::from_secs(5));
+
+        let response = handle.stream("ds", "{}", HeadMode::RealTime).await.unwrap();
+
+        assert!(response.bytes().await.is_err(), "the body truncates");
+        assert_eq!(
+            connections.load(Ordering::SeqCst),
+            1,
+            "replaying past the head would duplicate the delivered prefix"
+        );
+        assert_eq!(
+            hotblocks_requests(HotblocksRequestOutcome::Response) - responses,
+            1,
+            "transport accounting ends at the response head"
+        );
+    }
+
+    #[tokio::test]
+    async fn does_not_replay_a_read_stall() {
+        let _counter = COUNTERS.lock().await;
+        let timed_out = hotblocks_requests(HotblocksRequestOutcome::Timeout);
+        let failed = hotblocks_requests(HotblocksRequestOutcome::TransportFailed);
+        let (addr, connections) = stub(vec![Act::Stall, Act::Answer]).await;
+        let handle = handle(addr, Duration::from_millis(200));
+
+        let err = handle
+            .stream("ds", "{}", HeadMode::RealTime)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(&err, HotblocksErr::Request(e) if e.is_timeout()));
+        assert_eq!(
+            connections.load(Ordering::SeqCst),
+            1,
+            "a stall has already spent the read budget; replaying it answers too late"
+        );
+        assert_eq!(
+            hotblocks_requests(HotblocksRequestOutcome::Timeout) - timed_out,
+            1,
+            "the non-replayed timeout must remain visible in the unified metric"
+        );
+        assert_eq!(
+            hotblocks_requests(HotblocksRequestOutcome::TransportFailed) - failed,
+            0,
+            "a read stall has its own outcome"
+        );
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -30,6 +30,39 @@ impl std::fmt::Display for MutexLockMode {
 
 type Labels = Vec<(String, String)>;
 
+/// Final transport outcome of one logical DC-4 request (ADR-015, OB-4).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HotblocksRequestOutcome {
+    /// The first attempt obtained a response head.
+    Response,
+    /// A replay obtained a response head.
+    ReplayResponse,
+    /// A replay completed with another transport fault.
+    ReplayFailed,
+    /// The caller went away during the first attempt.
+    Canceled,
+    /// The caller went away during the replay.
+    ReplayCanceled,
+    /// The first attempt exhausted its read-idle budget and was not replayed.
+    Timeout,
+    /// The first attempt failed for another non-replayable transport reason.
+    TransportFailed,
+}
+
+impl HotblocksRequestOutcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Response => "response",
+            Self::ReplayResponse => "replay_response",
+            Self::ReplayFailed => "replay_failed",
+            Self::Canceled => "canceled",
+            Self::ReplayCanceled => "replay_canceled",
+            Self::Timeout => "timeout",
+            Self::TransportFailed => "transport_failed",
+        }
+    }
+}
+
 fn buckets(start: f64, count: usize) -> impl Iterator<Item = f64> {
     iter::successors(Some(start), |x| Some(x * 10.))
         .flat_map(|x| [x, x * 1.5, x * 2.5, x * 5.0])
@@ -67,6 +100,8 @@ lazy_static::lazy_static! {
     pub static ref STREAM_BLOCKS_PER_SECOND: Family<Labels, Histogram> =
         Family::new_with_constructor(|| Histogram::new(exponential_buckets(1., 3.0, 20)));
     pub static ref STREAM_THROTTLED_RATIO: Histogram = Histogram::new(iter::empty());
+
+    static ref HOTBLOCKS_REQUESTS: Family<Labels, Counter> = Default::default();
 
     pub static ref CONGESTION_WINDOW: Gauge = Default::default();
     pub static ref CONGESTION_IN_FLIGHT: Gauge = Default::default();
@@ -106,6 +141,24 @@ pub fn report_backoff(worker: &PeerId) {
     QUERY_BACKOFF
         .get_or_create(&vec![("worker".to_owned(), worker.to_string())])
         .inc();
+}
+
+/// Records exactly one final transport outcome for a logical DC-4 request.
+pub fn report_hotblocks_request(outcome: HotblocksRequestOutcome) {
+    HOTBLOCKS_REQUESTS
+        .get_or_create(&hotblocks_request_labels(outcome))
+        .inc();
+}
+
+fn hotblocks_request_labels(outcome: HotblocksRequestOutcome) -> Labels {
+    vec![("outcome".to_owned(), outcome.as_str().to_owned())]
+}
+
+#[cfg(test)]
+pub fn hotblocks_requests(outcome: HotblocksRequestOutcome) -> u64 {
+    HOTBLOCKS_REQUESTS
+        .get_or_create(&hotblocks_request_labels(outcome))
+        .get()
 }
 
 pub fn report_http_response(
@@ -295,6 +348,12 @@ pub fn register_metrics(registry: &mut Registry) {
         "stream_throttled_ratio",
         "Throttled time of completed streams relative to their duration",
         STREAM_THROTTLED_RATIO.clone(),
+    );
+
+    registry.register(
+        "hotblocks_requests",
+        "Logical DC-4 requests by final response-head transport outcome: response, replay_response, replay_failed, canceled, replay_canceled, timeout, or transport_failed",
+        HOTBLOCKS_REQUESTS.clone(),
     );
 
     registry.register(


### PR DESCRIPTION
Replica replacement of the real-time source has been client-visible: on 2026-07-21 09:14:10 a 502 burst landed one second after the upstream pod's SIGTERM, while a ready sibling sat idle behind the same ClusterIP.

The transport replays only requests it never wrote, which leaves exactly the shapes that fire in production: a request already on the wire when the peer closed — the transport cannot know it went unserved — and a connect against an endpoint being retired. Both surfaced as `502` to the client. Pooled keepalive connections are what pin us to the dying replica.

## What changes

One replay, on a connection-class fault, **before the response head**. It is implemented by wrapping `send` — that future resolves at the head, so a mid-body fault physically cannot reach the replay path. Two exclusions carry the decision:

- after the response head, ADR-003's rule stands: truncate on a record boundary, never re-fetch a delivered prefix;
- a read-idle timeout is not connection-class — a stall has already spent the read budget, and replaying it answers past the caller's deadline.

The caller's own deadline is deliberately not modelled: a caller that has given up disconnects, and disconnect reclamation cancels the replay. Guessing it would be wrong in both directions with no way to notice.

## Classifying the fault

The classifier walks the whole error chain and stops at no error it merely recognises. A replica that dies with our request still unread makes the kernel send RST rather than FIN, and that carries none of hyper's own connection-loss predicates — it is identifiable only as a bare I/O kind underneath them. Matching the predicates alone would have left the *more common* shape of the incident unmasked, and stopping at the first I/O error hands the decision to whichever layer happened to wrap the cause.

That classification reads HTTP/1 error shapes, so the client is pinned to HTTP/1.1. The source is plaintext in-cluster today, but over TLS ALPN would select h2, where a GOAWAY before the head matches none of these predicates — the replay would quietly stop firing with every test still passing.

## Observability

One counter, `hotblocks_requests_total`, records exactly one terminal transport outcome per logical DC-4 request:

- `response` — the first attempt obtained a response head;
- `replay_response` — the replay obtained a response head and hid the initial connection fault;
- `replay_failed` — the replay completed with another transport fault;
- `canceled` — the caller dropped the initial attempt;
- `replay_canceled` — the caller dropped the replay;
- `timeout` — the initial attempt exhausted its read-idle budget and was intentionally not replayed;
- `transport_failed` — another first-attempt transport failure was not replayable.

The unit is a request, not a connection: pooled connections are reused, while one logical request may use two connections when replayed. A single family also supplies the healthy-traffic denominator and avoids joining replay and non-replay counters. `replay_response` keeps an absorbed upstream fault visible; `transport_failed` growing can expose a connection-fault shape that the replay classifier stopped recognising.

Cancellation is split by phase because accounting only at completion would silently lose a started request, while folding cancellation into failure would claim an upstream result never observed. A drop guard covers the complete logical request and changes its pending cancellation outcome when replay begins.

It is a `replay`, not a `retry`: the spec reserves "retry" for the worker path (different worker, `1 + retries` attempts, `retries_exhausted`), and FM-2 distinguishes the two explicitly.

## Tests

Seven stub-upstream tests over a real socket:

- close before the head → two connections, client gets 200, `outcome="replay_response"`;
- reset before the head → same, and this is the case that caught a real defect in the first classifier;
- two closes → exactly two connections and `outcome="replay_failed"`, never a retry loop;
- initial request dropped mid-flight → `outcome="canceled"`;
- replay dropped mid-flight → `outcome="replay_canceled"`, not an invented upstream failure;
- close mid-body → one connection, body truncates, and transport accounting ends at `outcome="response"` because the head was obtained;
- read stall → one connection, `is_timeout`, and `outcome="timeout"` rather than a replay.

The last two are the controls that the replay is ours and selective, not the transport's own.

## Spec

- **ADR-015** (new) records the decision; ADR-003's status and body note the narrowing.
- **ADR-010** amended: its deadline ordering holds per upstream call, not per client request. Handlers already made real-time calls in sequence, so a client request could outlast the caller deadline before this change. REQ-22 says so now, rather than leaving the replay to look like the cause of a total it only widened.
- DC-4 call contract, the 09 fault rows, FM-2, OP-1 and OB-4 follow.
- GAP-22 rewritten: its mechanism claim was wrong (the transport *does* replay unwritten requests, on any method), which would have sent CT-2 at the wrong stub behaviour, and SLI-6 does not actually cover a pre-first-byte refusal. `hotblocks_requests_total` now supplies the outcome denominator, but no response-head SLI objective is defined yet.
- **P-KILL-GRACE** recorded as an environmental parameter (REQ-24, LIV-11 §0, 09, registry): the shutdown budget is 50 s and the Kubernetes default grace is 30 s. Nothing in this repo can fix that — it is a deployment value, now written down as a requirement.
- `P-CLIENT-SDK-TIMEOUT` → `P-CLIENT-TIMEOUT` (mechanical; it is a config constraint, not an SDK fact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

