### PR TITLE
Measure admission capacity, and document the error taxonomy

### DIFF
--- a/docs/openapi/03-getting-started.md
+++ b/docs/openapi/03-getting-started.md
@@ -17,9 +17,3 @@ can tell you if the chain reorged while you were away.
 
 For the full query language — filters, the other chain types, and every selectable field — see the
 [SQD docs](https://beta.docs.sqd.dev/en/portal/evm/overview).
-
-## Running your own portal
-
-This reference is for consuming data from a portal. If you want to operate your own, the
-[project README](https://github.com/subsquid/sqd-portal#initial-configuration) covers configuration and
-deployment.

--- a/docs/openapi/04-errors.md
+++ b/docs/openapi/04-errors.md
@@ -1,0 +1,87 @@
+## Error handling
+
+Every error the portal returns — on any endpoint, from any data source — uses one envelope:
+
+```json
+{
+  "error": {
+    "type": "rate_limit_error",
+    "code": "overloaded",
+    "message": "Service is overloaded, please try again later",
+    "param": "buffer_size",
+    "request_id": "0198c3f1-..."
+  }
+}
+```
+
+Two fields carry the meaning, and they answer different questions:
+
+- **`type`** — the coarse category. Four values, closed set. Branch on this.
+- **`code`** — the specific cause. Match on this when you need to handle one case.
+
+`message` is prose for humans. It is not stable and is not part of the contract — do not parse it,
+do not match on it. `param` appears when the error is about one request parameter. `request_id`
+appears on 5xx; the same id is on every response as the `x-request-id` header, so quote it when
+reporting a problem.
+
+> [!NOTE]
+> A **204 No Content** is not an error. It is the correct answer when the requested range has no
+> blocks yet, and it carries no body, no `type` and no `code`.
+
+### The four types
+
+| `type` | Whose fault | Retry the same request? |
+|---|---|---|
+| `invalid_request_error` | Yours | **No.** The same request reproduces it exactly. Fix the request. |
+| `rate_limit_error` | Nobody's — capacity | **Yes**, after the interval in `Retry-After`. |
+| `availability_error` | Ours or an upstream's, transiently | **Yes.** Honour `Retry-After` when present; otherwise use your own backoff. |
+| `api_error` | Ours — a bug | **No.** Retrying cannot succeed. Report it with `request_id`. |
+
+The split between the last two matters: `availability_error` means a later attempt can still work,
+`api_error` means an invariant broke and a retry loop only wastes your time and hides ours.
+
+### Codes
+
+| `code` | `type` | Status | What it means |
+|---|---|---|---|
+| `malformed_request` | `invalid_request_error` | 400 | The request or query does not parse or does not validate. `param` names the field when one is at fault. |
+| `method_not_allowed` | `invalid_request_error` | 405 | Right path, wrong verb. `Allow` lists what the path accepts. |
+| `unknown_dataset` | `invalid_request_error` | 404 | No such dataset on this portal. |
+| `not_found` | `invalid_request_error` | 404 | No such route or resource. |
+| `base_block_mismatch` | `invalid_request_error` | 409 | `parentBlockHash` does not match the canonical parent of the first requested block. The body carries a top-level `previousBlocks` list — see [Blockchain forks](#description/blockchain-forks) for the recovery procedure. |
+| `overloaded` | `rate_limit_error` | 529 locally; proxied 429/529 | The portal is at capacity, or the data source refused for capacity. Always carries `Retry-After`. |
+| `no_workers` | `availability_error` | 503 | No worker currently holds the requested data. |
+| `retries_exhausted` | `availability_error` | 503 | Workers were reachable; every attempt failed transiently until retries ran out. |
+| `upstream_unavailable` | `availability_error` | 502 locally; proxied 5xx | A data source the portal depends on is down. A proxied failure keeps the upstream's status. |
+| `not_ready` | `availability_error` | 503 | The portal is starting up or draining. Only `/ready` returns this. |
+| `worker_failure` | `api_error` | 500 | A worker returned something that cannot be right. |
+| `internal_error` | `api_error` | 500 | An invariant the portal owns was violated. |
+| `unclassified` | `api_error` | 5xx | An error that escaped classification. Always a bug — please report it. |
+
+Codes are added over time. Treat an unknown `code` as its `type`, which is why the two axes exist:
+a client that branches on `type` keeps working when a new code appears.
+
+### Backing off
+
+`Retry-After` is mandatory on every `overloaded` response and is always at least 1 second. Honour it:
+
+```text
+HTTP/1.1 529
+Retry-After: 10
+
+{"error":{"type":"rate_limit_error","code":"overloaded","message":"..."}}
+```
+
+For `overloaded`, the value is in seconds, never an HTTP date. When the portal proxies a refusal
+from a data source, it forwards that source's interval if it is usable and substitutes its own floor
+otherwise.
+
+An `upstream_unavailable` response can also preserve a `Retry-After` supplied by the data source.
+Honour it when present; unlike an overload hint, the portal does not invent or normalize it.
+
+### Browser clients
+
+`Retry-After` and `x-request-id` are exposed via CORS, alongside the stream metadata headers, so all
+of them are readable from JavaScript. Without that they would be invisible to a browser — the Fetch
+safelist for response headers contains none of ours — and a fetch client would see a status and
+nothing else.

--- a/spec/12-observability.md
+++ b/spec/12-observability.md
@@ -63,6 +63,21 @@ never log-only. (Sampled error reporting to DC-7 complements, never replaces, th
 **OB-10 — Congestion window trace.** Window size, grow/shrink counters — the LIV-8
 witness.
 
+**OB-11 — Admission capacity.** Refusals counted by *which* capacity ran out (stream-slot
+cap, download headroom, worker backoff, worker rate limit), the admission cap itself as a
+gauge, and occupancy as an accumulated time integral rather than a sampled level. Three
+reasons the OB-1 census cannot stand in for these. A slot-cap refusal is decided before
+the stream exists, so it is structurally absent from every stream family; a refusal raised
+mid-stream never reaches a status, since the response is already committed. And a gauge
+read at scrape time cannot witness saturation shorter than the scrape interval — the level
+moves many times between two reads, so a fleet pinned at the cap for seconds leaves no
+trace, which is precisely when clients are being refused. Integrating each admitted-stream
+transition under one serialized clock preserves exact elapsed intervals independently of
+the scrape cadence; a periodic flush bounds publication lag without becoming the source of
+truth. Publishing the cap keeps its literal out of the alert expression. All four
+reasons map to one wire code (IB-5 `overloaded`), and must: the client's move is identical,
+the operator's is not.
+
 ## Property → observable mapping
 
 | Property | Decided by |
@@ -73,7 +88,7 @@ witness.
 | LIV-6 | OB-6 identifier/age |
 | LIV-7 | OB-4 selection counters |
 | LIV-8 | OB-10 |
-| LIV-9 | OB-3 refusal counters |
+| LIV-9 | OB-3 refusal counters, OB-11 saturation integral |
 | LIV-10 | OB-1 gauges at quiescence |
 | LIV-12 | OB-9 |
 | INV-30/31 | OB-1, OB-5 (they are the invariant's subject) |

--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -44,6 +44,7 @@ use tracing::{instrument, Instrument};
 
 use crate::{
     controller::timeouts::TimeoutManager,
+    metrics::{self, RefusalReason},
     network::{ChunkNotFound, NetworkClient, NoWorker, QueryResult, StreamingNetwork, WorkerLease},
     types::{
         BlockRange, ChunkId, DataChunk, ErrorCode, ExhaustionClass, QueryError, RequestError,
@@ -558,6 +559,7 @@ impl<N: StreamingNetwork> StreamController<N> {
                 // All workers are rate-limited, try to pause and continue streaming
                 let duration = s.until.duration_since(Instant::now());
                 if duration > MAX_IDLE_TIME {
+                    metrics::report_stream_refused(RefusalReason::WorkersPaused);
                     return Poll::Ready(Some(Err(RequestError::BusyFor(duration))));
                 } else {
                     // TODO: fix calculation in case we're polling the same paused slot multiple times
@@ -599,7 +601,7 @@ impl<N: StreamingNetwork> StreamController<N> {
             self.buffer.push_front(chunk_slot);
         }
 
-        self.log_response(chunk_index, &read_range, &result);
+        self.observe_response(chunk_index, &read_range, &result);
         result
     }
 
@@ -608,26 +610,35 @@ impl<N: StreamingNetwork> StreamController<N> {
         response: BufferedResponse,
     ) -> Poll<Option<Result<ResponseChunk, RequestError>>> {
         let result = Poll::Ready(Some(response.result));
-        self.log_response(response.chunk_index, &response.read_range, &result);
+        self.observe_response(response.chunk_index, &response.read_range, &result);
         result
     }
 
-    fn log_response(
+    fn observe_response(
         &mut self,
         chunk_index: usize,
         read_range: &BlockRange,
         result: &Poll<Option<Result<ResponseChunk, RequestError>>>,
     ) {
-        if let Poll::Ready(Some(Ok(bytes))) = result {
-            self.stats
-                .sent_response_chunk(*read_range.end() - *read_range.start() + 1, bytes.len());
-            tracing::trace!(
-                chunk_index,
-                "Writing response blocks {}-{} ({} bytes)",
-                *read_range.start(),
-                *read_range.end(),
-                bytes.len()
-            );
+        match result {
+            Poll::Ready(Some(Ok(bytes))) => {
+                self.stats
+                    .sent_response_chunk(*read_range.end() - *read_range.start() + 1, bytes.len());
+                tracing::trace!(
+                    chunk_index,
+                    "Writing response blocks {}-{} ({} bytes)",
+                    *read_range.start(),
+                    *read_range.end(),
+                    bytes.len()
+                );
+            }
+            // Once per stream, not once per failed chunk: both consumers — `spawn_stream`
+            // and the test collector — stop at the first `Err`, so no later chunk's
+            // refusal is ever surfaced.
+            Poll::Ready(Some(Err(RequestError::RateLimitExceeded))) => {
+                metrics::report_stream_refused(RefusalReason::WorkersRateLimited);
+            }
+            _ => {}
         }
     }
 
@@ -1444,6 +1455,7 @@ mod tests {
         /// other event resolves instantly under the paused clock.
         Slow(u64),
         Retriable,
+        RateLimited,
         /// Never respond. Only used by the cancellation test; including it in
         /// the random generator would (correctly) fail the liveness property,
         /// because a slot whose every attempt hangs waits forever — in
@@ -1573,6 +1585,7 @@ mod tests {
                     QueryEvent::Retriable => {
                         return Err(QueryError::Retriable("scripted failure".to_owned()))
                     }
+                    QueryEvent::RateLimited => return Err(QueryError::RateLimitExceeded),
                     QueryEvent::Full => end,
                     QueryEvent::Slow(ms) => {
                         tokio::time::sleep(Duration::from_millis(ms)).await;
@@ -2018,6 +2031,36 @@ mod tests {
             Some(ErrorCode::RetriesExhausted),
             "one transient attempt means a later retry can still succeed: {:?}",
             mixed_outcome.error
+        );
+    }
+
+    /// A refusal is counted once even when all read-ahead slots fail.
+    #[tokio::test]
+    async fn buffered_rate_limits_count_one_refused_stream() {
+        let scenario = Scenario {
+            n_chunks: 3,
+            streams: vec![StreamSpec { from: 100, to: 399 }],
+            find_worker_script: Vec::new(),
+            query_script: vec![QueryEvent::RateLimited; 3],
+            buffer_size: 3,
+            retries: 0,
+            max_stored_results_per_chunk: 1,
+            max_chunks: None,
+        };
+        let network = ScriptedNetwork::new(
+            scenario.build_chunks(),
+            Vec::new(),
+            scenario.query_script.clone(),
+        );
+        let before = metrics::refused_streams(RefusalReason::WorkersRateLimited);
+
+        let outcome = collect_stream(scenario.request(&scenario.streams[0], 0), network, 0).await;
+
+        assert_eq!(outcome.code, Some(ErrorCode::Overloaded));
+        assert_eq!(
+            metrics::refused_streams(RefusalReason::WorkersRateLimited),
+            before + 1,
+            "three buffered chunk failures still interrupt only one stream"
         );
     }
 

--- a/src/controller/task_manager.rs
+++ b/src/controller/task_manager.rs
@@ -1,6 +1,6 @@
 use std::sync::{
     atomic::{AtomicU32, AtomicUsize, Ordering},
-    Arc,
+    Arc, Mutex, PoisonError,
 };
 use std::time::Duration;
 
@@ -8,20 +8,131 @@ use async_stream::stream;
 use futures::{Stream, StreamExt};
 use tracing_futures::Instrument;
 
+// The runtime clock, so paused-time tests drive the sampler the same way real time does.
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+
 use crate::{
     config::Config,
-    metrics,
+    metrics::{self, RefusalReason},
     network::NetworkClient,
     types::{RequestError, ResponseChunk, StreamRequest},
 };
 
 use super::stream::StreamController;
 
+/// Flush interval for unchanged occupancy.
+const OCCUPANCY_TICK: Duration = Duration::from_millis(100);
+
+#[derive(Clone, Copy, Debug)]
+enum OccupancyEvent {
+    Started,
+    Finished,
+    Flush,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct OccupancyInterval {
+    running: usize,
+    limit: usize,
+    elapsed: Duration,
+}
+
+/// Occupancy level serialized across transitions and flushes.
+struct OccupancyState {
+    running: usize,
+    limit: usize,
+    observed_at: Instant,
+}
+
+impl OccupancyState {
+    fn new(limit: usize) -> Self {
+        Self::at(limit, Instant::now())
+    }
+
+    fn at(limit: usize, observed_at: Instant) -> Self {
+        Self {
+            running: 0,
+            limit,
+            observed_at,
+        }
+    }
+
+    fn record(&mut self, event: OccupancyEvent, now: Instant) -> OccupancyInterval {
+        let interval = OccupancyInterval {
+            running: self.running,
+            limit: self.limit,
+            elapsed: now.saturating_duration_since(self.observed_at),
+        };
+        self.observed_at = now;
+
+        // Debug-only: an imbalance is an accounting bug, but this runs on the admission
+        // path, and a panic here would poison the mutex and refuse every later stream.
+        // Tests catch it; production degrades to a wrong counter.
+        match event {
+            OccupancyEvent::Started => {
+                debug_assert!(
+                    self.running < self.limit,
+                    "admitted stream occupancy must stay below its limit"
+                );
+                self.running += 1;
+            }
+            OccupancyEvent::Finished => {
+                debug_assert!(
+                    self.running > 0,
+                    "a finished stream must have been admitted"
+                );
+                self.running = self.running.saturating_sub(1);
+            }
+            OccupancyEvent::Flush => {}
+        }
+
+        interval
+    }
+}
+
+/// Occupancy meter: every transition and flush closes an interval under one clock.
+struct Occupancy(Mutex<OccupancyState>);
+
+impl Occupancy {
+    fn new(limit: usize) -> Self {
+        Self(Mutex::new(OccupancyState::new(limit)))
+    }
+
+    fn record(&self, event: OccupancyEvent) {
+        let interval = self
+            .0
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .record(event, Instant::now());
+        metrics::observe_stream_occupancy(interval.running, interval.limit, interval.elapsed);
+    }
+
+    /// Publish the standing level every tick, so a window that never transitions still
+    /// accumulates — the case a saturated fleet turning everything away produces.
+    async fn sample(&self, cancel: CancellationToken) {
+        let mut ticker = tokio::time::interval(OCCUPANCY_TICK);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    self.record(OccupancyEvent::Flush);
+                    return;
+                },
+                _ = ticker.tick() => {
+                    self.record(OccupancyEvent::Flush);
+                }
+            }
+        }
+    }
+}
+
 /// Tracks all existing streams
 pub struct TaskManager {
     network_client: Arc<NetworkClient>,
     running_tasks: AtomicUsize,
     max_tasks: usize,
+    occupancy: Occupancy,
     task_limit_retry_after: Duration,
     next_stream_index: AtomicU32,
     bandwidth_utilization_threshold: f64,
@@ -30,10 +141,12 @@ pub struct TaskManager {
 
 impl TaskManager {
     pub fn new(network_client: Arc<NetworkClient>, config: &Config) -> TaskManager {
+        metrics::STREAMS_LIMIT.set(config.max_parallel_streams as i64);
         TaskManager {
             network_client,
             running_tasks: 0.into(),
             max_tasks: config.max_parallel_streams,
+            occupancy: Occupancy::new(config.max_parallel_streams),
             task_limit_retry_after: config.task_limit_retry_after,
             next_stream_index: AtomicU32::new(0),
             bandwidth_utilization_threshold: config.congestion.headroom_threshold,
@@ -48,22 +161,27 @@ impl TaskManager {
         let running_tasks = self.running_tasks.fetch_add(1, Ordering::Relaxed);
         if running_tasks >= self.max_tasks {
             self.running_tasks.fetch_sub(1, Ordering::Relaxed);
+            metrics::report_stream_refused(RefusalReason::TaskLimit);
             return Err(RequestError::BusyFor(self.task_limit_retry_after));
         }
 
         if let Some(util) = self.network_client.download_utilization() {
             if util > self.bandwidth_utilization_threshold {
                 self.running_tasks.fetch_sub(1, Ordering::Relaxed);
+                metrics::report_stream_refused(RefusalReason::Bandwidth);
                 return Err(RequestError::BusyFor(Duration::from_secs(1)));
             }
         }
 
+        self.occupancy.record(OccupancyEvent::Started);
         metrics::ACTIVE_STREAMS.inc();
 
         let self_clone = self.clone();
         let guard = scopeguard::guard((), move |()| {
-            self_clone.running_tasks.fetch_sub(1, Ordering::Relaxed);
+            // Record the finish before releasing the admission slot.
+            self_clone.occupancy.record(OccupancyEvent::Finished);
             metrics::ACTIVE_STREAMS.dec();
+            self_clone.running_tasks.fetch_sub(1, Ordering::Relaxed);
             metrics::COMPLETED_STREAMS.inc();
         });
 
@@ -99,5 +217,93 @@ impl TaskManager {
             }
         }
         .in_current_span())
+    }
+
+    /// Periodically flush unchanged occupancy until cancelled.
+    pub async fn observe_occupancy(self: Arc<Self>, cancel: CancellationToken) {
+        self.occupancy.sample(cancel).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn occupancy_intervals_follow_admitted_stream_transitions() {
+        let start = Instant::now();
+        let mut state = OccupancyState::at(2, start);
+
+        let idle = state.record(OccupancyEvent::Started, start + Duration::from_millis(100));
+        let one = state.record(OccupancyEvent::Started, start + Duration::from_millis(300));
+        let saturated = state.record(OccupancyEvent::Finished, start + Duration::from_millis(450));
+        let draining = state.record(OccupancyEvent::Flush, start + Duration::from_secs(1));
+
+        assert_eq!(
+            (idle.running, idle.elapsed),
+            (0, Duration::from_millis(100))
+        );
+        assert_eq!((one.running, one.elapsed), (1, Duration::from_millis(200)));
+        assert_eq!(
+            (saturated.running, saturated.elapsed),
+            (2, Duration::from_millis(150))
+        );
+        assert_eq!(
+            (draining.running, draining.elapsed),
+            (1, Duration::from_millis(550))
+        );
+    }
+
+    #[test]
+    fn repeated_flushes_cannot_replay_a_missed_interval() {
+        let start = Instant::now();
+        let delayed = start + Duration::from_secs(5);
+        let mut state = OccupancyState::at(1, start);
+        state.record(OccupancyEvent::Started, start);
+
+        let first = state.record(OccupancyEvent::Flush, delayed);
+        let replay = state.record(OccupancyEvent::Flush, delayed);
+
+        assert_eq!((first.running, first.elapsed), (1, Duration::from_secs(5)));
+        assert_eq!(replay.elapsed, Duration::ZERO);
+    }
+
+    /// The one thing the state machine alone cannot show. A window pinned at the cap has
+    /// no transition to close its interval — that is the shape of the incident, every
+    /// slot taken and every arrival refused — so only the sampler can put it on the
+    /// counter, and it has to do so *while the window is still open*. Asserting after the
+    /// fact proves nothing: the flush on cancel would settle the whole interval at once.
+    #[tokio::test(start_paused = true)]
+    async fn a_saturated_window_is_visible_before_it_ends() {
+        let occupancy = Arc::new(Occupancy::new(1));
+        occupancy.record(OccupancyEvent::Started);
+
+        let streams_before = metrics::stream_seconds();
+        let saturated_before = metrics::saturated_seconds();
+
+        let cancel = CancellationToken::new();
+        let sampler = tokio::spawn({
+            let (occupancy, cancel) = (occupancy.clone(), cancel.clone());
+            async move { occupancy.sample(cancel).await }
+        });
+
+        // A scrape lands ten seconds in, with nothing having transitioned and nothing
+        // about to. Publication lag is bounded by one tick.
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        let unpublished = 10. - (metrics::saturated_seconds() - saturated_before);
+        assert!(
+            unpublished <= OCCUPANCY_TICK.as_secs_f64() + 1e-6,
+            "a scrape during the incident must witness it; {unpublished}s went unpublished"
+        );
+
+        cancel.cancel();
+        sampler.await.unwrap();
+
+        // And the integral is exact once the window closes, tick boundaries regardless.
+        let elapsed = metrics::stream_seconds() - streams_before;
+        assert!(
+            (elapsed - 10.).abs() < 1e-6,
+            "one stream held for ten seconds is ten stream-seconds, got {elapsed}"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,6 +159,12 @@ async fn main() -> anyhow::Result<()> {
         config.pre_drain_grace_period,
     ));
 
+    tokio::spawn(
+        task_manager
+            .clone()
+            .observe_occupancy(cancellation_token.clone()),
+    );
+
     let (server_res, ()) = tokio::try_join!(
         tokio::spawn(run_server(
             task_manager,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,4 +1,4 @@
-use std::iter;
+use std::{iter, time::Duration};
 
 use prometheus_client::{
     metrics::{
@@ -32,6 +32,30 @@ impl std::fmt::Display for MutexLockMode {
 }
 
 type Labels = Vec<(String, String)>;
+
+/// Capacity that caused an overloaded stream refusal.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RefusalReason {
+    /// `max_parallel_streams`: this pod's slot cap.
+    TaskLimit,
+    /// Download headroom, `congestion.headroom_threshold`.
+    Bandwidth,
+    /// Every worker is backing off beyond the stream's wait limit.
+    WorkersPaused,
+    /// Every attempt at a chunk was refused for capacity.
+    WorkersRateLimited,
+}
+
+impl RefusalReason {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::TaskLimit => "task_limit",
+            Self::Bandwidth => "bandwidth",
+            Self::WorkersPaused => "workers_paused",
+            Self::WorkersRateLimited => "workers_rate_limited",
+        }
+    }
+}
 
 /// Final transport outcome of one logical DC-4 request (ADR-015, OB-4).
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -89,6 +113,10 @@ lazy_static::lazy_static! {
 
     pub static ref ACTIVE_STREAMS: Gauge = Default::default();
     pub static ref COMPLETED_STREAMS: Counter = Default::default();
+    static ref REFUSED_STREAMS: Family<Labels, Counter> = Default::default();
+    static ref STREAM_SECONDS: Counter<f64> = Default::default();
+    static ref SATURATED_SECONDS: Counter<f64> = Default::default();
+    pub static ref STREAMS_LIMIT: Gauge = Default::default();
     pub static ref STREAM_DURATIONS: Family<Labels, Histogram> =
         Family::new_with_constructor(|| Histogram::new(exponential_buckets(0.01, 2.0, 20)));
     pub static ref STREAM_BYTES: Family<Labels, Histogram> =
@@ -162,6 +190,50 @@ pub fn hotblocks_requests(outcome: HotblocksRequestOutcome) -> u64 {
     HOTBLOCKS_REQUESTS
         .get_or_create(&hotblocks_request_labels(outcome))
         .get()
+}
+
+/// Count a capacity-based stream refusal.
+pub fn report_stream_refused(reason: RefusalReason) {
+    REFUSED_STREAMS.get_or_create(&refusal_labels(reason)).inc();
+}
+
+fn refusal_labels(reason: RefusalReason) -> Labels {
+    vec![("reason".to_owned(), reason.as_str().to_owned())]
+}
+
+#[cfg(test)]
+pub fn refused_streams(reason: RefusalReason) -> u64 {
+    REFUSED_STREAMS.get_or_create(&refusal_labels(reason)).get()
+}
+
+/// Add occupancy accumulated during one elapsed interval.
+pub fn observe_stream_occupancy(running: usize, limit: usize, elapsed: Duration) {
+    let (stream_seconds, saturated_seconds) = occupancy_increments(running, limit, elapsed);
+    STREAM_SECONDS.inc_by(stream_seconds);
+    if saturated_seconds > 0. {
+        SATURATED_SECONDS.inc_by(saturated_seconds);
+    }
+}
+
+#[cfg(test)]
+pub fn stream_seconds() -> f64 {
+    STREAM_SECONDS.get()
+}
+
+#[cfg(test)]
+pub fn saturated_seconds() -> f64 {
+    SATURATED_SECONDS.get()
+}
+
+/// Return `(stream_seconds, saturated_seconds)` for an interval.
+fn occupancy_increments(running: usize, limit: usize, elapsed: Duration) -> (f64, f64) {
+    let seconds = elapsed.as_secs_f64();
+    // A limit of zero would otherwise read as permanently saturated.
+    let saturated = limit > 0 && running >= limit;
+    (
+        running as f64 * seconds,
+        if saturated { seconds } else { 0. },
+    )
 }
 
 /// Carries the wire's `code`/`type`, prefixed — a bare `type` label says nothing on a
@@ -345,6 +417,26 @@ pub fn register_metrics(registry: &mut Registry) {
         COMPLETED_STREAMS.clone(),
     );
     registry.register(
+        "streams_refused",
+        "Streams turned away for want of capacity, by which capacity ran out",
+        REFUSED_STREAMS.clone(),
+    );
+    registry.register(
+        "stream_seconds",
+        "Cumulative stream-seconds; rate() is the mean number of active streams",
+        STREAM_SECONDS.clone(),
+    );
+    registry.register(
+        "streams_saturated_seconds",
+        "Cumulative seconds with every stream slot taken; rate() is the fraction of time at the cap",
+        SATURATED_SECONDS.clone(),
+    );
+    registry.register(
+        "streams_limit",
+        "Configured max_parallel_streams, so alerts need not hardcode it",
+        STREAMS_LIMIT.clone(),
+    );
+    registry.register(
         "stream_duration_seconds",
         "Durations of completed streams",
         STREAM_DURATIONS.clone(),
@@ -489,6 +581,47 @@ mod tests {
         let labels = labels_for(404, None);
         assert_eq!(get(&labels, "error_code"), Some("unclassified"));
         assert_eq!(get(&labels, "error_type"), Some("invalid_request_error"));
+    }
+
+    #[test]
+    fn occupancy_integrates_to_mean_concurrency() {
+        let interval = Duration::from_millis(100);
+        // One second of wall clock, three of twenty slots taken throughout.
+        let total: f64 = (0..10)
+            .map(|_| occupancy_increments(3, 20, interval).0)
+            .sum();
+        assert!((total - 3.0).abs() < 1e-9, "got {total}");
+    }
+
+    #[test]
+    fn saturation_is_counted_only_at_the_cap() {
+        let interval = Duration::from_millis(100);
+        assert_eq!(occupancy_increments(19, 20, interval).1, 0.);
+        assert_eq!(
+            occupancy_increments(20, 20, interval).1,
+            interval.as_secs_f64()
+        );
+        // A limit of zero is a misconfiguration, not 100% saturation forever.
+        assert_eq!(occupancy_increments(0, 0, interval).1, 0.);
+    }
+
+    /// The `reason` label is as public as a wire code: alerts match on it.
+    #[test]
+    fn refusal_reasons_are_distinct_and_frozen() {
+        use RefusalReason::*;
+
+        let reasons = [
+            (TaskLimit, "task_limit"),
+            (Bandwidth, "bandwidth"),
+            (WorkersPaused, "workers_paused"),
+            (WorkersRateLimited, "workers_rate_limited"),
+        ];
+        for (reason, wire) in reasons {
+            assert_eq!(reason.as_str(), wire);
+        }
+        let distinct: std::collections::HashSet<_> =
+            reasons.iter().map(|(_, wire)| *wire).collect();
+        assert_eq!(distinct.len(), reasons.len());
     }
 
     /// A rolling deploy fails /ready on every pod; that must not read as an api_error.

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -154,6 +154,8 @@ pub struct DatasetStateResponse {
             include_str!("../docs/openapi/02-blockchain-forks.md"),
             "\n\n",
             include_str!("../docs/openapi/03-getting-started.md"),
+            "\n\n",
+            include_str!("../docs/openapi/04-errors.md"),
         ),
         version = env!("CARGO_PKG_VERSION"),
     ),
@@ -355,5 +357,38 @@ mod tests {
             ops.iter().all(|op| !has_internal_ext(op)),
             "no surviving op should still carry x-internal when show_internal=true"
         );
+    }
+
+    /// The page is prose: nothing but this ties it to the code vocabulary.
+    #[test]
+    fn every_error_code_and_type_is_documented() {
+        use crate::types::ErrorCode;
+
+        const ERRORS_PAGE: &str = include_str!("../docs/openapi/04-errors.md");
+
+        let description = build_openapi_spec(false)
+            .info
+            .description
+            .expect("info.description carries the prose pages");
+        assert!(
+            description.contains(ERRORS_PAGE),
+            "the errors page is not rendered into the served docs"
+        );
+
+        // Against the page itself, not the whole description: a code named in passing on
+        // another page would otherwise pass for documented.
+        for code in ErrorCode::ALL {
+            // Backticked, so a passing mention does not count as documented.
+            assert!(
+                ERRORS_PAGE.contains(&format!("`{}`", code.as_str())),
+                "error code `{}` is missing from docs/openapi/04-errors.md",
+                code.as_str()
+            );
+            let error_type = code.error_type().as_str();
+            assert!(
+                ERRORS_PAGE.contains(&format!("`{error_type}`")),
+                "error type `{error_type}` is missing from docs/openapi/04-errors.md"
+            );
+        }
     }
 }


### PR DESCRIPTION
Two independent changes, one commit each.

## `feat(metrics)`: measure admission capacity directly

Four code paths refuse a stream for want of capacity. Two of them are unobservable by
construction:

- the stream-slot cap (`max_parallel_streams`) is decided *before* `ACTIVE_STREAMS.inc()`,
  so it appears in no `stream_*` family;
- the mid-stream give-up (every worker holding the chunk backing off past `MAX_IDLE_TIME`)
  is raised after the status is committed, so it reaches no HTTP series either.

The third problem is the measurement itself. Saturation has been read off
`portal_streams_active`, a gauge, compared against a hardcoded `20`. That worked during the
last incident only because the cap stayed pinned for twelve hours; a burst that fills every
slot for a few seconds leaves a 30s-scraped gauge no trace at all — which is exactly when
clients are being refused.

Four metrics:

| Metric | Answers |
|---|---|
| `portal_streams_refused_total{reason}` | who was turned away, and by which capacity — `task_limit`, `bandwidth`, `workers_paused`, `workers_rate_limited` |
| `portal_stream_seconds_total` | `rate()` is the **exact** mean number of active streams over the window |
| `portal_streams_saturated_seconds_total` | `rate()` is the fraction of the window spent at the cap |
| `portal_streams_limit` | the configured cap, so alerts stop restating it |

Occupancy is integrated by an in-process sampler (100 ms) rather than derived from
saturation transitions. Transition tracking races between the entry store and the exit
swap, and per-stream accounting at completion would lag by the stream's own length — at a
p99 of 60–71 s that is a minute of blindness during precisely the event being measured.
The sampler's error is bounded at one tick per transition.

All four reasons still map to the single wire code `overloaded` (IB-5). The client's move
is identical in every case; only the operator can act on the difference, so the
distinction belongs on a label, not on the wire.

Alert expressions this enables, none with a constant in them:

```promql
rate(portal_streams_saturated_seconds_total[5m]) > 0.05            # touched the ceiling
rate(portal_streams_refused_total{reason="task_limit"}[5m]) > 0    # clients getting 529
portal_streams_active / portal_streams_limit > 0.9                 # leading signal
```

Spec: adds **OB-11 — Admission capacity**, referenced from the LIV-9 row of the
property → observable matrix.

`portal_streams_active` is left in place. It should go, but only after dashboards move —
removing it in the same change would open a window with no slot signal at all.

## `docs(openapi)`: add an error taxonomy page

The taxonomy shipped with nothing telling a client how to use it. Both axes were on the
wire and in the spec, but the served docs described statuses per endpoint and never said
that `type` is what you branch on, `code` what you match, `message` what you must not
parse — so an unknown code had no documented fallback.

New page `docs/openapi/04-errors.md`, rendered into the Scalar sidebar: the envelope with
an example, the four types with retry guidance, all thirteen codes with type and status,
the `Retry-After` contract, `request_id`, and why the headers are CORS-exposed.

A test iterates `ErrorCode::ALL` against the rendered description — the page is prose,
nothing structural ties it to the vocabulary, and a variant added later would otherwise be
absent from it until a client found the gap.

## Checks

`cargo test --lib` 152 passed · clippy clean (no new warnings) · `spec-lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)