### PR TITLE
spec: portal-side authorization contract (ahead of #143)

### DIFF
--- a/spec/01-overview.md
+++ b/spec/01-overview.md
@@ -32,6 +32,9 @@ status**. Worker-health bookkeeping is in-memory only and resets on restart.
 | head / finalized head | Highest available block / highest finalized block of a dataset |
 | data frontier | Highest block servable for a request right now (archival head or real-time head) |
 | stream | One request/response pair; may end early at any time and be resumed by a follow-up request |
+| API key | A credential a client presents: a public key id plus a secret the Portal only ever sees as a digest (DEF-16) |
+| key snapshot | The Portal's in-memory mirror of the control plane's key set, refreshed by cursor-paged deltas (DEF-18) |
+| gated route | A route that requires a key on a commercial deployment; which routes are gated is the operator's gate scope (DEF-19) |
 
 ## Actors
 
@@ -45,6 +48,7 @@ status**. Worker-health bookkeeping is in-memory only and resets on restart.
 | Real-time source | Serves head/stream requests for recent blocks; proxied per request | outbound |
 | Chain RPC + contracts | On-chain registry: epoch, stake, compute units, worker set | outbound |
 | Error-reporting sink | Receives sampled error/trace reports | outbound |
+| Control plane | Mints and revokes API keys; publishes the key feed the Portal mirrors (DC-8). Present only on a commercial deployment | outbound |
 
 ## Design goals
 
@@ -56,13 +60,14 @@ status**. Worker-health bookkeeping is in-memory only and resets on restart.
 | G4 | Be a good network citizen: self-regulate bandwidth, spread load across workers, account for usage | REQ-40..REQ-44, ADR-006, ADR-004 |
 | G5 | Operable: truthful readiness, observable behavior, forgiving configuration | REQ-23, REQ-24, REQ-30..REQ-33 |
 | G6 | Robust against hostile clients and flaky upstreams | REQ-21, REQ-22, REQ-25, REQ-26 |
+| G7 | Commercial access is decided by the Portal, not by whatever sits in front of it — and only where an operator asked for it | REQ-50..REQ-56, ADR-016, ADR-017 |
 
 ## Non-goals
 
 | Non-goal | Rationale |
 |---|---|
-| NG1 — No per-request authentication or authorization | The Portal runs behind a trusted perimeter; any per-client policy (identity, tiers, head lag) originates upstream of it (ADR-009). A Portal reachable directly by untrusted clients has no client-level defenses beyond input validation. |
-| NG2 — No per-client quotas or fairness | All capacity limits are global. One client can exhaust shared capacity; isolation between clients is not promised. |
+| ~~NG1~~ — *retired by ADR-016.* Per-request authentication is now an opt-in capability (REQ-50..REQ-56). A Portal without commercial configuration still authenticates nothing and has no client-level defenses beyond input validation; that is a deployment choice, no longer a property of the system. Other per-client policy (tiers, head lag) still originates upstream (ADR-009). |
+| NG2 — No per-client quotas or fairness | All capacity limits are global. One client can exhaust shared capacity; isolation between clients is not promised. **An authenticated key is no exception:** admission (REQ-50) decides whether a request is served, never how much of the shared capacity it may take. Quota and metering are explicitly out of scope for ADR-016. |
 | NG3 — No head subscription or long-poll | Clients poll. A request beyond the frontier gets a throttled empty response (REQ-5), never a held-open wait for new blocks. |
 | NG4 — No cross-source splicing within one response | Each response is served entirely by one source (archival or real-time). Crossing the boundary is the client's follow-up request (REQ-4). |
 | NG5 — No durable local state | Restart amnesia is by design: everything is refetched or relearned. There is nothing to back up or recover. |
@@ -73,12 +78,13 @@ status**. Worker-health bookkeeping is in-memory only and resets on restart.
 
 | Actor | Verified | Trusted | Must never be able to cause |
 |---|---|---|---|
-| Data consumer | Query syntax, size caps, parameter ranges | Nothing | Crash/wedge the process, corrupt another stream, bypass operator caps (REQ-21) |
+| Data consumer | Query syntax, size caps, parameter ranges; on a commercial deployment, the presented credential against the mirrored key set (REQ-50) | Nothing | Crash/wedge the process, corrupt another stream, bypass operator caps (REQ-21); on a commercial deployment, reach a gated route without a key that covers it (INV-14), or learn from a completed credential verdict or keyless metrics which key ids exist (INV-39; authorize-on-miss residual: GAP-32) |
 | Archival worker | Response signature (when enabled, REQ-43); response size cap; result range plausibility | Data content within its signed response | Process crash, unbounded memory, permanently poisoning the worker pool (penalties decay, REQ-41) |
 | Assignment publisher | Transfer integrity only — structural validity is currently **trusted, not verified** (ADR-002, GAP-1) | Artifact correctness | *Intent:* crash or false readiness via a corrupt artifact (REQ-26) — presently not enforced |
 | Real-time source | Streamed success data and public headers; errors normalized by ADR-011 | Data content, conflict responses | Stalling a client past bounded deadlines (REQ-22) |
 | Chain RPC | Nothing beyond transport | Status values | Any effect on data serving — status only (REQ-25) |
-| Operator | Config validity at startup | Fully | — |
+| Control plane | Transport integrity and feed-envelope well-formedness; an unparseable key record is fail-closed, never dropped (INV-6) | The key set it publishes: status, scopes, expiry, and the secret digest | Admit a request the published key set does not cover; open the data API by going silent — an outage freezes the snapshot, it never empties it (REQ-54, FM table) |
+| Operator | Config validity at startup | Fully | Configure a commercial block that silently serves everything (REQ-56) |
 
 ## Lifecycle at a glance
 
@@ -94,7 +100,9 @@ status**. Worker-health bookkeeping is in-memory only and resets on restart.
                                              └── proxy ──▶ real-time source
 ```
 
-- **Request lifecycle:** validate → clamp to operator bounds → route by range → serve
-  from one source → end (complete, empty, or truncated) → client resumes (REQ-2).
-- **Process lifecycle:** start → fetch catalog + first assignment → ready → serve ⟲
-  refresh world view → SIGTERM → advertise not-ready, drain two-phase (REQ-24) → exit.
+- **Request lifecycle:** *authorize, where the route is gated (REQ-50)* → validate →
+  clamp to operator bounds → route by range → serve from one source → end (complete,
+  empty, or truncated) → client resumes (REQ-2).
+- **Process lifecycle:** start → fetch catalog + first assignment *(+ mirror the key set,
+  where commercial)* → ready → serve ⟲ refresh world view → SIGTERM → advertise
+  not-ready, drain two-phase (REQ-24) → exit.

--- a/spec/02-requirements.md
+++ b/spec/02-requirements.md
@@ -1,8 +1,8 @@
 # 02 — Requirements
 
 Bands: 1–9 core data delivery · 10–16 discovery & metadata · 20–29 robustness &
-overload · 30–34 operability · 40–44 network integration. Gaps in numbering are
-reserved; additions never renumber. Acceptance status lives in
+overload · 30–34 operability · 40–44 network integration · 50–56 commercial access
+control. Gaps in numbering are reserved; additions never renumber. Acceptance status lives in
 [13-conformance.md](13-conformance.md), not here.
 
 ## Core data delivery (1–9)
@@ -354,6 +354,114 @@ bounded (queue of P-LOGS-QUEUE); under pressure logs are dropped rather than eve
 delaying or failing data serving.
 *Acceptance:* saturating the log queue never blocks a stream; drops are observable.
 
+## Commercial access control (50–56)
+
+This band applies only to a Portal the operator has configured commercially (REQ-56).
+On any other deployment every requirement here is vacuous: there is no gate, no key set,
+and no control-plane dependency. Admission decided here is binary — it never shapes how
+much capacity an admitted request may consume (NG2).
+
+**REQ-50 — Gated routes require a valid key.** [MUST]
+On a commercial deployment, every request to a gated route (DEF-19) is authorized before
+any other work: the presented credential (DEF-16) must resolve to a key record (DEF-17)
+that authenticates, is active, is unexpired, and covers this portal and the requested
+dataset. A request that fails any of these is refused in the DEF-10 taxonomy and reaches
+no handler or serving dependency. OP-11 may make its one declared control-plane lookup on
+a snapshot miss, and may canonicalize a dataset only after the credential has
+authenticated and only when its dataset scope requires that name (INV-14).
+*Acceptance:* against a gated route, a request with no credential, an unparseable token,
+an unknown key id, a wrong secret, a revoked key retaining its digest, a digestless
+tombstone, an expired key, a key scoped to another portal, and a key scoped to another
+dataset each receive the refusal ADR-017 binds to it; no serving-dependency stub records a
+call for any of them; only a snapshot miss may call the DC-8 lookup, and only an
+authenticated dataset-scoped case may canonicalize the dataset. A valid unscoped key is
+served exactly as the same request is served on a non-commercial deployment.
+
+**REQ-51 — Gate scope is an operator choice with a closed set of modes.** [MUST]
+The operator selects which surface requires a key: `data` gates block delivery, queries,
+and block lookups while leaving metadata public; `all` additionally gates every route
+that describes the Portal or its datasets. Readiness, metrics, and the served API schema
+are never gated under either mode. Because metrics are client-readable, their public
+families never expose dataset identities under `all`, nor any internal authorization
+reason or lookup detail beyond the client-visible wire outcome under either mode
+(OB-12/13). An unrecognized mode is a startup error, never a fallback to the more
+permissive one.
+*Acceptance:* under `data`, a keyless metadata read succeeds and a keyless stream is
+refused; under `all`, both are refused; under both, `/ready`, `/metrics` and the API
+schema answer without a credential. A route added to the surface without being
+classified fails the build rather than defaulting to ungated. A keyless scrape under
+`all` names no dataset of the served catalog in any series or label; and under either
+mode, two keyless scrapes bracketing each case of REQ-50's corpus differ only in ways
+that case's own response already disclosed — no series distinguishes the four
+`invalid_credential` reasons from each other, nor a snapshot hit from an
+authorize-on-miss.
+
+**REQ-52 — Credential presentation.** [MUST]
+A credential is presented either as an HTTP bearer token or as a query parameter, the
+latter because some browser transports cannot set headers. Only tokens in a form the
+control plane can actually mint are accepted; anything else is refused as an invalid
+credential without being looked up (INV-39). The secret itself is never logged, stored,
+echoed, or compared other than as a digest, in constant time (INV-38).
+*Acceptance:* a valid key is accepted through either channel and refused when its token
+is truncated, over-long, carries an unknown prefix, or contains bytes outside the minted
+alphabet; no log record, metric label, error body, or stored value produced by any of
+these contains the secret.
+
+**REQ-53 — The ladder has a fixed precedence.** [MUST]
+Authorization evaluates in one order — credential present → key known → secret matches →
+not revoked → not expired → portal allowed → dataset allowed — and reports the first rung
+that fails. A record carrying no secret digest — including a tombstone — cannot establish
+that the caller holds the secret, so it fails at `secret matches` as BAD-CREDENTIAL rather
+than disclosing the later revoked rung. Absent scope means unrestricted (a key with no
+portal list is valid on any portal; a key with no dataset list covers every dataset); an
+empty scope list means nothing, not everything. A dataset-scoped key may not use a route
+that names no dataset.
+*Acceptance:* a key failing several rungs at once reports the earliest — a digestless
+tombstone that is also revoked reports the secret rung, not the revoked one; a null scope
+list admits where an empty list refuses; a dataset-scoped key is refused on a route with
+no dataset; scope matching is exact, with aliases resolved to canonical names first, and
+never by prefix or wildcard. The no-dataset case makes the SQL surface unusable for every
+dataset-scoped key, which is fail-closed but may not be the intent — OQ-13.
+
+**REQ-54 — Fail closed on the key, fail static on the feed.** [MUST]
+A key the Portal cannot positively establish as valid is refused. A control-plane outage
+does not invalidate any snapshot hit: the last good snapshot keeps answering. A snapshot
+miss that cannot be resolved because the lookup budget is exhausted is refused as
+OVERLOADED; one that cannot be resolved because the lookup failed is refused as
+UPSTREAM-FAILURE. Neither is mislabeled as a non-retryable bad credential. A malformed or
+unrecognized feed record becomes a non-authenticating tombstone rather than being skipped.
+Where a snapshot has never been established, an enforcing Portal declines readiness
+instead of serving refusals (INV-31).
+*Acceptance:* with the control plane stopped, previously valid keys keep being served and
+previously revoked keys keep being refused; a fresh valid key absent from the snapshot
+receives retryable UPSTREAM-FAILURE rather than BAD-CREDENTIAL; a snapshot miss denied by
+the local lookup budget receives OVERLOADED with `Retry-After`; a record carrying a status
+this build does not recognize is refused; a Portal started with the control plane already
+unreachable never reports ready while enforcing.
+
+**REQ-55 — Shadow enforcement.** [MUST]
+The operator may attempt the full ladder without acting on it: every available verdict is
+recorded in protected structured observability, and a snapshot miss whose lookup cannot
+produce a verdict is recorded there as indeterminate. Every request is admitted regardless
+— including requests presenting no credential at all. Shadow mode never refuses, never
+withholds readiness for a reason only enforcement would care about, and never projects
+the would-be verdict onto the keyless metrics surface (OB-12).
+*Acceptance:* in shadow mode every request of REQ-50's acceptance corpus is served, each
+having recorded the verdict enforcement would have returned or the lookup outcome that
+prevented one; valid, invalid, and indeterminate cases all increment the same neutral
+public shadow counter; a shadow-mode Portal whose key set has never synced still reports
+ready.
+
+**REQ-56 — Open by default, never open by accident.** [MUST]
+Absent commercial configuration the Portal authorizes nothing, opens no control-plane
+dependency, and installs no authorization middleware. Configuration that is present but
+carries no settings is a startup error: the one outcome an operator writing it cannot
+have intended is the open portal. Which mode is in effect is stated once at startup.
+*Acceptance:* with no commercial configuration, gated routes are served without a
+credential and no control-plane call is ever made; an empty commercial block fails
+startup naming the field it lacks; startup output states whether authorization is on and,
+if so, in which enforcement mode.
+
 ## Explicitly unspecified
 
 Deliberately left open — tests and clients must not pin these:
@@ -368,6 +476,11 @@ Deliberately left open — tests and clients must not pin these:
   offer); negotiation mechanics beyond the binding's contract.
 - Worker identity, ranking internals, and how throughput is measured (REQ-41 pins
   outcomes, not scores).
+- The shape of a key id or secret beyond the acceptance grammar (REQ-52), and the
+  control plane's own issuance, rotation, and organization model — the Portal mirrors a
+  key set, it does not define one.
+- Which internal rejection reason underlies a given `invalid_credential` response: the
+  three are deliberately indistinguishable to a client (INV-39, ADR-017).
 
 ## Open questions
 
@@ -381,6 +494,8 @@ Deliberately left open — tests and clients must not pin these:
 | OQ-7 | A stream body without a first block silently defaults to block 0, while the API description marks it required — reject instead? | REQ-7 | portal team |
 | OQ-9 | Ratify a global P-BUFFERED-BYTES-BUDGET and its accounting/admission semantics. | REQ-27, GAP-17 | portal team |
 | OQ-10 | Ratify the draft SLO target parameters and their benchmark gating policy. | 11 SLO table | portal team |
+| OQ-12 | Ratify P-KEY-SNAPSHOT-MAX-AGE and what an enforcing Portal does once its key set is older than it — decline readiness (the ADR-013 answer for assignments) or keep serving and alarm only? Revocation latency and a control-plane outage pull in opposite directions. | REQ-54, GAP-31, ADR-016 | portal team |
+| OQ-13 | Should a dataset-scoped key be able to use the SQL surface, which names its datasets in the body rather than the path? Today such a key is refused there outright (REQ-53), which is fail-closed but makes the surface unusable for exactly the customers most likely to be scoped. | REQ-53, OP-10 | portal team |
 | OQ-11 | REQ-40's fleet-cutover premise assumes workers also honor `effective_from`; workers currently apply assignments immediately (recorded in the worker suite's open questions, `worker-rs/spec/02`), so each publication opens a window of routing to reshuffling workers (transient `no_workers`/`retries_exhausted` churn). Size the window for worker convergence, or have workers delay too? | REQ-40, REQ-41 | network team |
 
 Closed: **OQ-6** (should the clamp-bypassing debug stream variant be exposed unconditionally,

--- a/spec/03-data-model.md
+++ b/spec/03-data-model.md
@@ -101,6 +101,8 @@ additional public values.
 | `rate_limit_error` | yes, after hint | Capacity is exhausted |
 | `availability_error` | yes | Data or a dependency is temporarily unavailable |
 | `api_error` | no | A Portal-owned invariant failed; page |
+| `authentication_error` | no | The credential is absent, unreadable, or does not authenticate (ADR-017) |
+| `permission_error` | no | The credential authenticated but does not cover this request (ADR-017) |
 
 | Spec outcome | Wire `type` / `code` | Meaning |
 |---|---|---|
@@ -114,14 +116,78 @@ additional public values.
 | NOT-READY | `availability_error` / `not_ready` | Readiness probe declines traffic |
 | WORKER-FAILURE | `api_error` / `worker_failure` | Worker results violated an owned integrity invariant and rerouting was exhausted (DC-1) |
 | INTERNAL | `api_error` / `internal_error` or `unclassified` | Portal invariant failed or a failure escaped classification |
+| NO-CREDENTIAL | `authentication_error` / `missing_credential` | A gated route was reached with no credential (REQ-50) |
+| BAD-CREDENTIAL | `authentication_error` / `invalid_credential` | The token is unparseable, names no known key, its secret does not match, or the held record has no digest — one code for all four, by design (INV-39) |
+| REVOKED | `authentication_error` / `revoked_credential` | The key authenticated but the control plane has withdrawn it |
+| EXPIRED | `authentication_error` / `expired_credential` | The key authenticated but its expiry has passed |
+| WRONG-PORTAL | `permission_error` / `portal_not_allowed` | The key is scoped to portals not including this one |
+| WRONG-DATASET | `permission_error` / `dataset_not_allowed` | The key is scoped to datasets not including the requested one, or the route names no dataset and the key is dataset-scoped |
 
 EMPTY is deliberately absent: a bodyless poll result is the correct answer to a range
 that is not produced yet (INV-27), not a failure, so it carries no `type` and no `code`.
 It is bound by IB-4 and observed as `status="204"`, which is exactly what a code on it
 would have restated.
 
+The last six rows exist only on a commercial deployment (REQ-56) and are never
+`api_error`: refusing an unauthenticated request is the system working, and must not
+page (ADR-017). None of them is retryable and none carries a retry hint.
+
 Exact statuses and envelope exceptions are fixed by IB-5. No dependency-specific body
 or code extends this set.
+
+## Access control (commercial deployments only)
+
+Every definition in this section is vacuous on a Portal with no commercial
+configuration: nothing constructs these objects and no route consults them (REQ-56).
+
+**DEF-16 — Credential.** What a client presents: the pair (**key id**, **secret**). The
+key id is public and identifies a key record; the secret is proof of holding it. The
+Portal handles the secret only as a digest — it is reduced to one at the moment the
+request is parsed and the original is discarded, so no later stage can log, store, or
+echo what it never received (INV-38). A credential is *well-formed* iff it is presented
+through a channel IB-9 names and both segments fall within the grammar the control plane
+can mint; anything else is an invalid credential and is refused as BAD-CREDENTIAL without
+a lookup. NO-CREDENTIAL is reserved for a gated request that presents neither channel.
+
+**DEF-17 — Key record.** The control plane's statement about one key: (key id; **status**
+∈ {active, revoked}; **sequence**, a feed position that only ever moves forward; an
+optional secret digest; **portal scope**; **dataset scope**; optional expiry). A usable
+active record carries a digest. A record without one cannot prove which caller holds its
+secret and therefore authenticates nobody; on the request path it maps to BAD-CREDENTIAL,
+not the more specific REVOKED outcome (REQ-53, INV-39). A scope is either
+*absent*, meaning unrestricted, or a list matched exactly — an empty list therefore
+matches nothing, and the two are never conflated (REQ-53). A record whose status this
+build does not recognize, or which fails to parse while still naming its key, is not
+dropped: it becomes a **tombstone** — a record with no usable digest that authenticates
+nobody — because dropping it would leave an older, possibly usable version of that key
+in service (REQ-54).
+
+**DEF-18 — Key snapshot.** The Portal's in-memory mirror of the control plane's key set:
+(records by key id; a **cursor**, the feed position read so far; an **epoch**, the
+identity of the feed's history; a **generation**, incremented by every wholesale
+replacement). The snapshot is established by reading the feed from its start and kept
+current by cursor-paged deltas (DC-8). A delta applies a record only if its sequence
+exceeds the held one. An epoch change, or a feed head below the held cursor, means the
+history the cursor refers to no longer exists, and the snapshot is rebuilt from the start
+rather than advanced. Nothing about the snapshot survives restart (NG5).
+
+**DEF-19 — Route class and gate scope.** Every route carries exactly one class: **data**
+(delivers blocks, query results, or block lookups), **metadata** (describes the Portal or
+its datasets), or **always-open** (readiness, metrics, the served API schema). The
+operator's **gate scope** — `data` or `all` — selects which classes require a credential:
+`data` gates the data class, `all` gates data and metadata. Always-open is gated under
+neither (REQ-51). The classification is a property of the route, not of the request.
+
+**DEF-20 — Authorization verdict.** The outcome of evaluating DEF-16 against DEF-17 for
+one request: **admit**, or **reject** carrying the first failed rung of REQ-53's ladder.
+The verdict is a pure function of (credential, key record, portal identity, requested
+dataset, current time) — it consults no capacity, no load, and no prior request (INV-15).
+A snapshot miss may fail before a verdict exists: lookup-budget exhaustion is OVERLOADED
+and lookup failure is UPSTREAM-FAILURE (DC-8), both retryable system outcomes rather than
+claims about the credential. A verdict is separately *acted on* or not, per the
+enforcement mode (REQ-55): shadow mode discards a verdict when one exists, and records an
+indeterminate lookup when one does not. The rung is the internal reason; what reaches the
+client is the DEF-10 row it maps to, which is deliberately coarser (INV-39).
 
 ## Shared state (the frame of the stateless shape)
 
@@ -135,9 +201,10 @@ request: no sessions, no per-client identity, no response cache.
 in-memory and reset by restart: (a) the applied artifact (DEF-4) and catalog snapshots;
 (b) the **worker health map** — per worker: open-lease count, error/timeout cooldown
 marks, backoff-until, throughput estimate; (c) the **congestion window** (DEF-13);
-(d) the **stream census** (count of active streams, monotone stream sequence). Shared
-adaptive state may influence *admission, worker choice, coverage extent, and timing* —
-never record content (INV-28).
+(d) the **stream census** (count of active streams, monotone stream sequence); and, on a
+commercial deployment, (e) the key snapshot, negative-answer cache, and lookup limiters
+(DEF-18, DC-8). Shared adaptive state may influence *admission, worker choice, coverage
+extent, and timing* — never record content (INV-28).
 
 **DEF-13 — Congestion window.** An adaptive bound on concurrent chunk-body downloads,
 within [P-CONGESTION-MIN-WINDOW, P-CONGESTION-MAX-WINDOW]; grows additively on success,
@@ -159,6 +226,7 @@ and the dataset map. Static per process lifetime.
 | Artifact publication | New assignment artifact (DEF-4) | Routing world changed | Polled every P-ASSIGNMENT-REFRESH; at-least-once; deduplicated by identifier |
 | Catalog update | Dataset catalog/metadata | Served-dataset set changed | Polled every P-DATASETS-REFRESH; last-write-wins |
 | Chain status update | Epoch, stake, compute units, worker registry | Accounting/status only | Polled every P-CHAIN-REFRESH; never affects serving (REQ-25) |
+| Key-set delta | Key records past the held cursor (DEF-17) | The served key set changed | Polled every P-KEY-SYNC-INTERVAL; ordered by sequence; applied only forward; epoch change forces a rebuild (DC-8) |
 
 ## Operation summary
 
@@ -176,6 +244,7 @@ Semantics in [04-operations.md](04-operations.md).
 | OP-8 | Readiness probe | Can this instance serve correctly now |
 | OP-9 | Metrics read | Observability snapshot (12) |
 | OP-10 | SQL route plan | Experimental: relational plan → worker/chunk routing |
+| OP-11 | Request authorization | Admission step preceding OP-1..OP-10 on a commercial deployment (REQ-50) |
 
 ## Terminology cross-reference (codebase → spec)
 
@@ -193,3 +262,8 @@ Semantics in [04-operations.md](04-operations.md).
 | `BaseBlockMismatch`, `previousBlocks` | CONFLICT (DEF-9, DEF-10) |
 | hotblocks | Real-time source (DC-4) |
 | `x-sqd-data-source` | Serving source marker (DEF-6) |
+| commercial block / gate | Commercial configuration, authorization gate (REQ-56, DEF-19) |
+| snapshot store, feed cursor/epoch | Key snapshot (DEF-18) |
+| ladder, rung | REQ-53's ordered precedence; the rung is DEF-20's internal reason |
+| `log_only` / `enforce` | Shadow and enforcing modes (REQ-55) |
+| authorize-on-miss | Bounded direct lookup for a key absent from the snapshot (DC-8) |

--- a/spec/04-operations.md
+++ b/spec/04-operations.md
@@ -29,6 +29,7 @@ capacity limits (stream census, congestion window, worker health). Restated as I
 | OP-8 Readiness probe | naturally idempotent | trivial |
 | OP-9 Metrics read | naturally idempotent | trivial |
 | OP-10 SQL route plan | naturally idempotent | trivial |
+| OP-11 Request authorization | naturally idempotent | trivial (no upstream work is started before it succeeds) |
 
 Every operation is safe to retry; the Portal maintains no dedup keys (client retries
 are new requests).
@@ -37,11 +38,12 @@ are new requests).
 
 *Pre.* In order: (1) resolve alias → dataset, else NOT-FOUND; (2) parse tuning
 parameters, reject zero/unparsable as BAD-REQUEST; (3) decode and validate the query
-per DEF-7, else BAD-REQUEST — **no dependency call happens before validation completes
-(INV-10)**; (4) clamp tuning to operator caps (INV-11); (5) admission: if the stream
-census is at P-MAX-STREAMS or congestion utilization exceeds P-HEADROOM-THRESHOLD,
-refuse OVERLOADED with a retry hint (INV-12) — admission is checked before any
-upstream work.
+per DEF-7, else BAD-REQUEST — **no serving-dependency call happens before validation
+completes**; OP-11's bounded authentication lookup may already have occurred on a
+snapshot miss (INV-10/14); (4) clamp tuning to operator caps (INV-11); (5) admission: if
+the stream census is at P-MAX-STREAMS or congestion utilization exceeds
+P-HEADROOM-THRESHOLD, refuse OVERLOADED with a retry hint (INV-12) — admission is checked
+before any upstream work.
 
 *Effect.* In real-time mode with validation enabled, a parent hash whose height is at
 or below the frontier is validated before any emptiness decision — conflict detection
@@ -121,7 +123,12 @@ of the conformance surface beyond existence and freshness.
 
 *Effect.* Pure read of local state — never calls a dependency. *Post.* Ready iff:
 an artifact is applied ∧ worker connectivity ≥ P-READY-CONNECTION-RATIO ∧ not shutting
-down (INV-31). Intent (ADR-013 ⚠): also degrade when artifact age > P-ASSIGNMENT-MAX-AGE.
+down ∧ (on a commercial deployment that is *enforcing*, a key snapshot has been
+established — REQ-54) (INV-31). Shadow enforcement adds no such condition: it admits
+regardless of what the snapshot knows, so withholding readiness for it would cause the
+outage shadow mode exists to avoid (REQ-55). Intent (ADR-013 ⚠): also degrade when
+artifact age > P-ASSIGNMENT-MAX-AGE; the key-set analogue,
+P-KEY-SNAPSHOT-MAX-AGE ⚠, is open on OQ-12.
 
 ## OP-9 — Metrics read
 
@@ -133,6 +140,38 @@ gauge honesty per INV-30.
 *Pre.* Plan decode, else BAD-REQUEST. *Effect.* Applied artifact + embedded schemas;
 no data queries. *Post.* A routing plan naming only workers present in the applied
 artifact; no rows (NG6). Experimental: shape unspecified beyond this.
+
+## OP-11 — Request authorization
+
+Not a client-callable operation: an admission step that runs before OP-1..OP-10 on every
+gated route (DEF-19) of a commercial deployment, and does not exist at all on any other
+(REQ-56). It is listed as an operation because it has a contract, a failure mapping, and
+tests of its own.
+
+*Pre.* The route's class is gated under the operator's gate scope. An ungated route skips
+this operation entirely and costs exactly what it costs on a non-commercial deployment —
+the credential is not read and the dataset is not resolved.
+
+*Effect.* Reads the key snapshot (DEF-18). On a snapshot miss, and only then, it may
+consult the control plane directly (DC-8), under that contract's rate and concurrency
+bounds; a lookup it is not allowed to make is an immediate OVERLOADED outcome, not a
+delay or a BAD-CREDENTIAL claim, and a failed lookup is UPSTREAM-FAILURE. It resolves the
+requested dataset to a canonical name **only** for a key that is dataset-scoped and has
+already authenticated — the one rung that needs it — so an unauthenticated request cannot
+buy that work (INV-14). No serving dependency is consulted, and no shared state is
+mutated beyond the snapshot's own caches and authorization observability.
+
+*Post.* Admit, and the request proceeds to its operation unchanged; reject with the first
+failed rung of REQ-53's ladder, mapped to its DEF-10 row; or fail before a verdict with
+OVERLOADED/UPSTREAM-FAILURE when a required lookup could not run or answer. Any such
+outcome is terminal while enforcing: no handler runs, no stream slot is taken, and no
+serving dependency is called. Under shadow enforcement the verdict or indeterminate
+lookup outcome is recorded and the request proceeds regardless (REQ-55).
+
+*Timing.* The rejection path is O(1) in request size and consults no dependency in the
+snapshot-hit and syntactically-invalid cases (PF-7). The evaluation itself is a pure
+function (INV-15); only snapshot-miss resolution may wait on its DC-8 deadline, and local
+lookup saturation refuses immediately as OVERLOADED rather than queuing.
 
 ## Concurrency
 

--- a/spec/05-dependencies.md
+++ b/spec/05-dependencies.md
@@ -7,7 +7,8 @@ otherwise need.
 
 **The no-undeclared-dependencies rule.** Every network or system interaction of the
 Portal appears in this document. Any interaction not listed here observed in operation
-is a conformance violation (INV-37).
+is a conformance violation (INV-37). DC-8 is conditional on commercial configuration:
+observing it on a Portal without one is the same violation (REQ-56).
 
 ## DC-1 — Archival workers
 
@@ -113,6 +114,59 @@ never delays or fails serving.
 *Role.* Sampled error/trace reports (P-ERROR-SAMPLE-RATE).
 *Contract.* Fire-and-forget; failure has no client-visible effect.
 
+## DC-8 — Control plane (key feed)
+
+Exists only on a commercial deployment (REQ-56); on any other the Portal opens no
+connection to it and this contract is vacuous.
+
+*Role.* Publishes the key set the Portal mirrors (DEF-17, DEF-18) and answers direct
+lookups for a single key; the source of every authorization decision (OP-11).
+*Call contract.* Two interactions, both authenticated with a portal-held service
+credential and neither following redirects — a redirected request carries that credential
+somewhere the operator did not configure, and a redirected key set is not the control
+plane's answer.
+
+1. *Feed read* — a background loop only, never on a request path. Polls every
+   P-KEY-SYNC-INTERVAL, reading pages of at most P-KEY-PAGE-LIMIT records forward from
+   the held cursor with a per-page deadline P-KEY-FETCH-TIMEOUT. Ticks are serialized; a
+   slow drain never overlaps the next poll. One tick drains up to
+   P-KEY-MAX-PAGES-PER-TICK rather than applying exactly one page; a larger backlog
+   continues on the next tick, and the resulting convergence bound is LIV-13's function
+   of page count. A page that carries records without advancing the cursor, or a short
+   page whose cursor remains below the head the feed reports, is a broken answer, not an
+   empty one — it fails the tick.
+2. *Direct lookup (authorize-on-miss)* — on the request path, and only for a key the
+   snapshot does not hold, so a key minted seconds ago works before the next tick
+   (LIV-14). Bounded by P-KEY-RESOLVE-RATE and at most P-KEY-RESOLVE-INFLIGHT concurrent
+   calls; a negative answer is remembered for P-KEY-NEGATIVE-TTL across at most
+   P-KEY-NEGATIVE-CAPACITY entries. Every bound is a fail-*closed* bound: exceeding one
+   produces an immediate OVERLOADED response with a retry hint, never a delay or an
+   admission (HZ-10).
+
+*Error mapping.* No control-plane fault ever reaches a client as itself.
+
+| Fault | Own class / action |
+|---|---|
+| Feed unreachable, timeout, or non-success status | keep serving the established snapshot; alarm on age (OB-13). Never fails a request by itself (REQ-54) |
+| Feed envelope missing a required field | treat as a broken answer, not an empty page — fail the tick, keep the snapshot. A 200 from a wrong route or a half-deployed replica must not read as "the key set is now empty", which would quietly stop delivering revocations |
+| Record malformed but identifiable | tombstone that key (DEF-17): it stops authenticating, and the older version it replaces does not survive |
+| Record unidentifiable | fail the page; keep the snapshot |
+| Record status this build predates | tombstone — an unknown status is fail-closed by the same path as any other unusable record |
+| Epoch change, or reported head below the held cursor | the cursor's history is gone: rebuild the snapshot from the start rather than advance (DEF-18) |
+| Epoch change *mid-drain* | fail the tick; pages from two epochs compose into a snapshot of neither |
+| Lookup: key unknown | refuse the request (BAD-CREDENTIAL); remember the answer for P-KEY-NEGATIVE-TTL |
+| Lookup: rate/concurrency bound reached | refuse immediately as OVERLOADED with `Retry-After` ≥ P-RETRY-AFTER-MIN; never queue or claim the credential is bad |
+| Lookup: call fails, times out, or returns an unusable answer | refuse as UPSTREAM-FAILURE; the same credential may succeed after recovery, so this is never BAD-CREDENTIAL |
+| Lookup: answer names a different key than was asked about | discard the answer and refuse as UPSTREAM-FAILURE |
+
+*Degradation.* Fail-static and unbounded today: the established snapshot serves for as
+long as the outage lasts, so a revocation issued during it does not land until the feed
+returns (GAP-31). Intent bounds this at P-KEY-SNAPSHOT-MAX-AGE ⚠ (OQ-12). Before the
+*first* complete bootstrap there is no snapshot to be static about, and an enforcing
+Portal declines readiness instead of refusing every key (INV-31). Nothing survives
+restart (NG5): every replica re-reads the feed from the start on boot, which puts the
+whole key set on the startup path and in every replica's memory (HZ-11).
+
 ## Caches & refreshed snapshots (lifecycle)
 
 | Snapshot | Refreshed by | Staleness bound | Staleness visible? |
@@ -122,6 +176,8 @@ never delays or fails serving.
 | Chain status | DC-5 poll | none (status only) | loading state before first fetch |
 | Worker health map (DEF-12) | per-query outcomes | rolling windows (P-WORKER-ERROR-COOLDOWN / P-WORKER-TIMEOUT-COOLDOWN) | operator debug view |
 | Heads | artifact (archival) / per-request (real-time) | one successful P-ASSIGNMENT-REFRESH cycle / live; archival outage unbounded | response metadata (INV-24) |
+| Key snapshot (DEF-18) | DC-8 feed poll, plus authorize-on-miss for absent keys | LIV-13's page-count-dependent bound while healthy; none during outage today; ⚠ P-KEY-SNAPSHOT-MAX-AGE (OQ-12) | intent: age gauge + alarm (OB-13, GAP-31) |
+| Negative key answers | DC-8 lookup | P-KEY-NEGATIVE-TTL; cleared wholesale by a snapshot rebuild | protected lookup events (OB-13) |
 
 There is no response cache: no client-visible value is ever served from a cache other
 than these declared snapshots.

--- a/spec/07-invariants.md
+++ b/spec/07-invariants.md
@@ -3,7 +3,8 @@
 Scope tags: `[state]` holds in every observable state · `[transition]` across
 consecutive states · `[response]` for every response · `[recovery]` across restart.
 Bands: structural 1–9 · operation legality 10–19 · response semantics 20–29 ·
-reporting 30–34 · isolation 35–39 · recovery 40–44. *Check* names the test class
+reporting 30–34 · isolation 35–39 · recovery 40–44. Access-control invariants sit in
+the band their scope puts them in, not in one of their own. *Check* names the test class
 (CT-n, [13-conformance.md](13-conformance.md)).
 
 ## Structural (1–9)
@@ -47,13 +48,30 @@ admitted stream decrements exactly once at its end.
 *Why:* census drift silently shrinks (or unbounds) global capacity.
 *Check:* CT-3 — concurrent admit/finish/disconnect storm; compare census to truth.
 
+**INV-6 — Key snapshot coherence.** [transition]
+Every read of the key snapshot (DEF-18) sees exactly one generation: a rebuild replaces
+the record set wholesale and is never partially observable, and a direct lookup that
+began under an earlier generation never inserts its answer into a later one. Within a
+generation a key only moves forward — a delta applies a record only if its sequence
+exceeds the held one, so a replayed or reordered page cannot resurrect a revoked key.
+A record that cannot be used is held as a tombstone, never dropped (DEF-17).
+*Why:* the two ways a mirror silently un-revokes a key are applying a stale record over a
+newer one, and letting an in-flight lookup write into a snapshot that has since been
+rebuilt beneath it.
+*Check:* CT-10 — feed stub replays and reorders pages, and flips epoch while a lookup is
+in flight; assert no key regresses and no answer lands in the wrong generation.
+
 ## Operation legality (10–19)
 
-**INV-10 — Validation precedes work.** [response]
-A request failing DEF-7 validation triggers no dependency call and no shared-state
-mutation beyond metrics.
-*Why:* invalid input must be free to reject — no amplification channel.
-*Check:* CT-4 — invalid-request corpus against dependency stubs; assert zero calls.
+**INV-10 — Validation precedes serving work.** [response]
+A request failing DEF-7 validation triggers no serving-dependency call and no shared-state
+mutation beyond authorization caches and observability. Because OP-11 precedes operation
+validation, a syntactically valid credential naming a snapshot-miss key may already have
+made the one bounded DC-8 lookup INV-14 permits; no other dependency exception exists.
+*Why:* invalid input must be cheap to reject and must never buy the work that serves it;
+the earlier authorization exception has its own explicit bounds.
+*Check:* CT-4/CT-10 — invalid-request corpus against dependency stubs; assert zero
+serving-dependency calls and at most the one DC-8 lookup for a snapshot miss.
 
 **INV-11 — Clamping.** [response]
 Effective tuning = min(requested, operator cap) with defaults for absent values; no
@@ -77,6 +95,34 @@ Every routed stream/timestamp response is served entirely by one serving source
 Pre-routing validation, alias, and admission failures have no source marker.
 *Why:* silent source mixing breaks continuation and fork semantics at the seam.
 *Check:* CT-5 — marker vs stub ledger (which stub actually served).
+
+**INV-14 — Authorization precedes work.** [response]
+On a gated route (DEF-19), a request that does not pass OP-11 causes no serving-dependency
+call, no handler execution, no stream-census admission, and no shared-state mutation
+beyond the snapshot's own caches and authorization observability. A snapshot miss may
+make the one bounded DC-8 lookup OP-11 declares. Dataset canonicalization is itself work:
+it happens only for a credential that has already authenticated and only where the key's
+scope requires it (REQ-53). On an ungated route, or a Portal with no commercial
+configuration, no part of this runs.
+*Why:* an unauthenticated request must not be able to buy unbounded or serving-path work.
+The one attacker-reachable exception — authorize-on-miss — has explicit rate,
+concurrency, cache, and deadline bounds so the gate does not become an open cost amplifier.
+*Check:* CT-10 — keyless and bad-key corpus against every gated route with dependency
+stubs and a counting catalog; assert zero serving-dependency calls, a DC-8 call only for
+a snapshot miss, and canonicalization only after authentication on the dataset rung.
+
+**INV-15 — Verdict determinism.** [response]
+The authorization verdict (DEF-20) is a pure function of (credential, key record, portal
+identity, requested dataset, current time). It never depends on load, capacity, prior
+requests, or which replica served, and the ladder's precedence (REQ-53) is total: a
+request failing several rungs always reports the earliest. Two replicas holding the same
+record state and evaluating at the same time return the same verdict for the same request;
+a local generation counter alone does not establish equivalent state.
+*Why:* a verdict that varies with load is an availability bug wearing an authorization
+costume, and a precedence that varies makes the refusal reason — the operator's only
+diagnostic — untrustworthy.
+*Check:* CT-10 — the multi-failure corpus of REQ-53 against a fixed snapshot, replayed
+under saturation and on a second replica; assert identical verdicts.
 
 ## Response semantics (20–29)
 
@@ -181,8 +227,11 @@ through them).
 
 **INV-31 — Readiness honesty.** [state]
 Ready ⇒ (an artifact is applied ∧ connectivity ≥ P-READY-CONNECTION-RATIO ∧ not
-shutting down). Shutdown flips readiness before intake stops (ADR-005). Intent ⚠:
-ready also ⇒ artifact age ≤ P-ASSIGNMENT-MAX-AGE (ADR-013, GAP-2).
+shutting down ∧ (enforcing commercial ⇒ a key snapshot has been established)). A Portal
+that would refuse every valid key is not ready (REQ-54); a shadow-mode one has no such
+conjunct, since it refuses nobody (REQ-55). Shutdown flips readiness before intake stops
+(ADR-005). Intent ⚠: ready also ⇒ artifact age ≤ P-ASSIGNMENT-MAX-AGE (ADR-013, GAP-2),
+and the key-set analogue P-KEY-SNAPSHOT-MAX-AGE ⚠ if OQ-12 ratifies it.
 *Why:* orchestrators route by this; a lying probe turns deploys into outages.
 *Check:* CT-2 — drive each conjunct false via stubs; probe.
 
@@ -202,9 +251,43 @@ serving task (which truncate only that stream, FM-1).
 *Check:* CT-4/CT-9 — fuzz all client surfaces; process liveness probe.
 
 **INV-37 — Declared side effects only.** [state]
-The Portal's only external interactions are those declared in 05 (DC-1..DC-7).
+The Portal's only external interactions are those declared in 05 (DC-1..DC-8; DC-8 only
+where the operator configured it — REQ-56).
 *Why:* undeclared calls are unbudgeted failure modes and security surface.
 *Check:* CT-2 — harness observes all egress; anything not stub-addressed fails.
+
+**INV-38 — Credential confidentiality.** [state]
+A presented secret exists only as the digest the request parser reduces it to. No log
+record, metric label, span field, error body, stored value, or outbound request ever
+carries the secret, and comparison against the published digest completes in time
+independent of how many leading bytes matched.
+*Why:* an API key that reaches a log line has been disclosed to everyone with log access,
+and a comparison that exits early lets a wrong secret be refined byte by byte from
+response timing — the digest would then be no better than the secret itself.
+*Check:* CT-10 — drive the full corpus with a marked secret; grep every emitted log,
+metric, span, and body for it; assert the comparison is the constant-time one by
+construction.
+
+**INV-39 — No enumeration oracle.** [response]
+On every completed credential verdict, an unparseable token, an authoritatively unknown
+key id, a known key id with a wrong secret, and a digestless tombstone are
+indistinguishable to the client: same status, same code, same body (ADR-017). The reasons
+that *are* distinguishable — revoked, expired, wrong portal, wrong dataset — are reachable
+only by a client already holding the correct secret. The distinction survives on the
+internal axis only, in protected structured logs — never as a label or
+request-synchronous counter on the keyless metrics surface (OB-12/13).
+*Why:* telling a caller that a key id exists turns the endpoint into a key-id oracle, and
+the whole point of a public key id plus a secret is that the id alone is worthless.
+*Check:* CT-10 — assert the four responses are byte-identical apart from the request id;
+assert the specific reasons appear only for correct-secret requests; bracket every case
+under both enforcement modes with metrics scrapes and assert no public series reveals the
+internal reason or lookup path beyond the response that case received. In shadow mode,
+where every case is admitted, their authorization projections are identical.
+*Known deviation:* a snapshot miss may consult the control plane while a hit answers
+locally, so timing differs; if that lookup cannot run or answer, its retryable
+OVERLOADED/UPSTREAM-FAILURE response also differs from a hit's BAD-CREDENTIAL. The
+residual reveals snapshot membership under lookup pressure, but public metrics must not
+amplify it beyond the response the caller already received (GAP-32).
 
 ## Recovery (40–44)
 
@@ -220,5 +303,6 @@ window) may change only routing, timing, and coverage extent per INV-28.
 Structural validators (13 §validators) enforce INV-20/21/25 on every response for
 free. The dependency-fault matrix (CT-2) owns INV-2/23/25/31/37/40. Concurrency swarms
 (CT-3) own INV-1/3/4/5/12/28/30/35. The fuzz corpus (CT-4/9) owns INV-10/36. Interface
-conformance (CT-5) owns INV-13/24/26. Every response in every class re-checks the
-`[response]` band via the validators.
+conformance (CT-5) owns INV-13/24/26. Authorization (CT-10) shares INV-10 and owns
+INV-6/14/15/38/39. Every response in every class re-checks the `[response]` band via the
+validators.

--- a/spec/08-liveness.md
+++ b/spec/08-liveness.md
@@ -8,6 +8,8 @@ Liveness claims hold only under a declared environment:
   correct responses within P-TRANSPORT-TIMEOUT and is not rate-limiting.
 - **Healthy publisher/registry:** DC-2/DC-3 fetches succeed within their deadlines.
 - **Healthy real-time source:** DC-4 answers within its deadlines.
+- **Healthy control plane:** DC-8 feed reads and lookups succeed within their deadlines.
+  Vacuous on a Portal with no commercial configuration.
 - **Adequate resources:** census below P-MAX-STREAMS, congestion utilization below
   P-HEADROOM-THRESHOLD, memory within P-MEMORY-BUDGET.
 - **Patient supervisor:** the orchestrator's kill grace P-KILL-GRACE exceeds
@@ -45,11 +47,15 @@ by endpoint. Check: CT-6 under S3.
 P-NO-DATA-DELAY + slack — bounded above as well as below (the throttle must not hold
 connections indefinitely). Witness: OB-3. Check: CT-1 timing.
 
-**LIV-5 — Startup bound, accept/ready decoupled.** From process start with healthy
-publisher: the listener accepts connections early (probes answerable while loading),
-and readiness is achieved within P-STARTUP-BOUND ⚠, dominated by the artifact
-download. Startup never blocks on the real-time source or chain RPC. Witness: OB-8
-lifecycle timestamps. Check: CT-2 cold-start scenario (S5).
+**LIV-5 — Startup bound, accept/ready decoupled.** From process start with a healthy
+publisher — and, for an enforcing commercial deployment, a healthy control plane whose
+initial snapshot is `K ≤ P-KEY-MAX-PAGES-PER-TICK` pages — the listener accepts
+connections early (probes answerable while loading). Readiness is achieved within the
+artifact fetch time + `K × P-KEY-FETCH-TIMEOUT` + snapshot-apply time + scheduling slack;
+a supported deployment sizes the feed so that sum is ≤ P-STARTUP-BOUND ⚠. Neither
+startup input is assumed to dominate the other. Startup never blocks on the real-time
+source or chain RPC. Witness: OB-8 lifecycle timestamps. Check: CT-2/CT-10 cold-start
+scenario (S5), including a multi-page key set and an unavailable control plane.
 
 **LIV-6 — Artifact convergence.** A newly published artifact (effective time passed)
 is applied within P-ASSIGNMENT-REFRESH + fetch time; routing reflects it for all new
@@ -82,6 +88,30 @@ INV-30 audit.
 **LIV-11 — Shutdown bound.** SIGTERM ⇒ readiness flips immediately; process exits
 within P-PRE-DRAIN-GRACE + P-DRAIN-TIMEOUT + slack, regardless of client behavior
 (ADR-005). Witness: OB-8/OB-5. Check: CT-2 — shutdown under load with stalled readers.
+
+**LIV-13 — Revocation convergence.** Healthy control plane, commercial deployment ⇒ a
+key revoked at the control plane stops being served by every replica after the pending
+pages through that record have been read. For `N` such pages and
+`M = P-KEY-MAX-PAGES-PER-TICK`, a conservative time bound is
+`ceil(N / M) × P-KEY-SYNC-INTERVAL + N × P-KEY-FETCH-TIMEOUT` plus snapshot-apply and
+scheduling slack; when `N ≤ M`, one tick drains the backlog. Convergence is therefore
+bounded but not independent of backlog size. It is per replica and needs no coordination
+— each mirrors the same feed independently. Witness: OB-13 snapshot age/cursor against
+the feed's head; per-request lookup details remain off the keyless metrics surface. Check:
+CT-10 — with a test-small `M ≥ 2`, revoke one key, a bulk of P-KEY-PAGE-LIMIT + 1, and
+a backlog of `M + 1` pages; assert one-, one-, and two-cycle convergence respectively.
+
+**LIV-14 — New-key admission.** Healthy control plane ⇒ a key minted after the last
+successful tick is served without waiting for the next one: a snapshot miss resolves
+directly against the control plane (DC-8), so admission latency for a fresh key is one
+lookup, not up to P-KEY-SYNC-INTERVAL. The bound holds only within the lookup budget —
+P-KEY-RESOLVE-RATE and P-KEY-RESOLVE-INFLIGHT — and outside it the key is refused as
+OVERLOADED with a retry hint until the next tick rather than delayed or mislabeled as an
+invalid credential (HZ-10). A failed lookup is UPSTREAM-FAILURE and likewise retryable.
+Witness: protected OB-13 lookup events plus the control-plane stub ledger. Check: CT-10 —
+mint a key between ticks; assert it is served, that saturation returns OVERLOADED, and
+that a control-plane failure returns UPSTREAM-FAILURE before the same credential succeeds
+after recovery.
 
 **LIV-12 — No silent infinite retry.** Any divergence converges or alarms: chunk
 attempts are bounded by 1 + retries, then surface RETRIES-EXHAUSTED (WORKER-FAILURE

--- a/spec/09-failure-model.md
+++ b/spec/09-failure-model.md
@@ -67,6 +67,28 @@ requests only; the publisher ⇒ freshness only; chain RPC ⇒ status only (REQ-
 | Mid-proxy failure | truncate per INV-25; never replayed — a replay past the response head would duplicate a prefix (ADR-003, ADR-015) |
 | Retention gap | fail-safe EMPTY (INV-27) |
 
+## Control-plane faults (DC-8)
+
+Commercial deployments only. The governing asymmetry: a fault in the *key* fails closed,
+a fault in the *feed* fails static. Refusing every request because the control plane is
+unreachable would convert its outage into the Portal's (REQ-54).
+
+| Fault | Required response |
+|---|---|
+| Feed unreachable / timeout / error status | degrade serve-static on the established snapshot + alarm on age (OB-13); no request fails for this reason. ⚠ Unbounded today — GAP-31 |
+| Feed answers 200 with a malformed envelope | integrity: fail the tick, keep the snapshot, alarm. Never read as "the key set is empty" — that would silently stop delivering revocations |
+| Record malformed but identifiable | integrity: tombstone the key (fail-closed), count, keep serving everything else |
+| Record unidentifiable | integrity: fail the page; snapshot unchanged |
+| Record with an unrecognized status | fail-closed tombstone — a status this build predates must never admit traffic |
+| Feed epoch change / head below cursor | mask: rebuild the snapshot from the start (DEF-18); mid-drain, fail the tick and rebuild on the next |
+| No snapshot ever established, enforcing | fail-safe: decline readiness (INV-31) — leave rotation rather than 401 every valid key |
+| No snapshot ever established, shadow mode | mask: admit everything, stay ready (REQ-55) |
+| Lookup rate-limited or over the in-flight cap | fail-safe: refuse immediately as OVERLOADED with a retry hint; never admit, queue, or claim the credential is invalid (HZ-10) |
+| Lookup unavailable, times out, or returns an unusable answer | fail-safe: refuse as UPSTREAM-FAILURE; the unchanged credential may succeed after recovery |
+| Lookup answers about a different key | integrity: discard and refuse as UPSTREAM-FAILURE |
+| Service credential missing or empty at startup | fail-safe at startup: refuse to run (REQ-33) |
+| Commercial block present but empty | fail-safe at startup: refuse to run — the open portal is the one outcome nobody configuring it intended (REQ-56) |
+
 ## Other dependencies
 
 | Fault | Required response |
@@ -98,3 +120,4 @@ requests only; the publisher ⇒ freshness only; chain RPC ⇒ status only (REQ-
 | Publisher | INV-1, INV-2, INV-31, LIV-6, REQ-26 | CT-2 |
 | Real-time source | INV-25, INV-26, LIV-2, REQ-22, REQ-25 | CT-2 |
 | Process/operator | FM-1, INV-30, LIV-11, REQ-33 | CT-2, CT-7 |
+| Control plane | INV-6, INV-31, REQ-54, REQ-55, LIV-13, LIV-14 | CT-10 |

--- a/spec/11-performance.md
+++ b/spec/11-performance.md
@@ -53,7 +53,7 @@ register ([13-conformance.md](13-conformance.md)), and seed the regression gates
 | SLI-4 | any | ≥ P-SLO-AVAILABILITY monthly ⚠ |
 | SLI-5 | S1/S4 | ≤ P-SLO-MEMORY-HEADROOM ⚠ |
 | SLI-6 | S1 | ≥ P-SLO-COMPLETION-INTEGRITY ⚠ |
-| readiness time | S5 | ≤ P-STARTUP-BOUND ⚠ (dominated by the artifact download, LIV-5) |
+| readiness time | S5 | ≤ P-STARTUP-BOUND ⚠ (artifact fetch + enforcing-commercial key bootstrap, LIV-5) |
 | shutdown time | any | ≤ P-PRE-DRAIN-GRACE + P-DRAIN-TIMEOUT + slack (hard, LIV-11) |
 
 ## Resource-bound requirements
@@ -74,18 +74,31 @@ consumption within its buffer bound; it never grows unbounded queues anywhere
 new work (INV-12), never by degrading admitted work past its liveness bounds or by
 process death (FM: memory row).
 
-**PF-4 — Refresh budget, two-sided.** Background refreshes (artifact, catalog, chain)
-must complete within their intervals (keep-up) **and** must not consume more than a
-bounded share of serving resources while doing so — an artifact apply must not stall
-request routing beyond a scheduling pause (HZ-5).
+**PF-4 — Refresh budget, two-sided.** Background refreshes (artifact, catalog, chain,
+key feed where commercial) must complete within their declared convergence bounds
+(keep-up) **and** must not consume more than a bounded share of serving resources while
+doing so — an artifact or key-snapshot apply must not stall request routing beyond a
+scheduling pause (HZ-5/HZ-11).
 
-**PF-5 — Startup work scheduling.** Startup-critical work (artifact fetch) is
-prioritized; nothing else on the startup path may push readiness past
-P-STARTUP-BOUND (LIV-5).
+**PF-5 — Startup work scheduling.** Startup-critical work (artifact fetch and, on an
+enforcing commercial deployment, complete key bootstrap) is prioritized; nothing else on
+the startup path may push readiness past P-STARTUP-BOUND (LIV-5).
 
-**PF-6 — Refusal cheapness.** The refusal path allocates O(1) work and memory per
-refused request — surviving S3 requires refusals to be at least an order of magnitude
-cheaper than admissions.
+**PF-6 — Refusal cheapness.** Every refusal allocates O(1) work and memory per request.
+Locally decidable refusals are at least an order of magnitude cheaper than serving an
+admission. A snapshot-miss refusal may spend PF-7's one deadline-bounded DC-8 lookup; it
+is benchmarked separately and never waits in an unbounded queue.
+
+**PF-7 — Authorization cheapness.** On a commercial deployment, an authorization refusal
+costs O(1) in request size and performs no dependency call on a snapshot hit or
+syntactically invalid token. A snapshot miss may spend one deadline-bounded DC-8 lookup;
+an authenticated dataset-scoped key may spend one canonicalization at the dataset rung.
+Neither cost is reachable by a keyless, malformed-token, or wrong-secret hit request
+(INV-14). An ungated route costs exactly what it costs on a non-commercial deployment:
+the gate returns before reading the credential. The common admitted path adds one snapshot
+hash lookup under a read lock; miss and scoped-key benchmarks are measured separately.
+Rationale: the gate is the first thing every request meets and the only thing an
+unauthenticated flood reaches, so each attacker-reachable cost needs its own bound.
 
 ## Hazard register
 
@@ -103,6 +116,8 @@ defects live in the gap register (13).
 | HZ-7 | Usage-log queue drops silently at P-LOGS-QUEUE | accounting fidelity (REQ-44) | drop counter vs stub-sink ledger |
 | HZ-8 | Chain RPC calls carry no explicit deadline | LIV-3 for the status loop | stalled-RPC stub; loop aliveness (GAP-18) |
 | HZ-9 | Congestion waiter queue is unbounded | PF-1 under S3 | waiter census at saturation |
+| HZ-10 | Authorize-on-miss is keyed on attacker-chosen ids: a flood of distinct unknown keys drains P-KEY-RESOLVE-RATE and fills the P-KEY-NEGATIVE-CAPACITY map, and every bound is fail-closed — so the traffic that exhausts the budget also denies *newly minted legitimate keys* with retryable OVERLOADED until the next sync tick lands them in the snapshot | LIV-14, REQ-50 | CT-10: saturate with distinct unknown ids, then present a key minted since the last tick; assert OVERLOADED + hint and measure admission delay against P-KEY-SYNC-INTERVAL |
+| HZ-11 | The snapshot is a per-replica in-memory map of the entire key set, rebuilt from the feed on every start and on every epoch change; nothing bounds how large the control plane may let it grow | PF-1, LIV-5 (startup) | RSS and time-to-ready against a feed stub serving a key set at the projected ceiling |
 
 ## Benchmarking requirements
 

--- a/spec/12-observability.md
+++ b/spec/12-observability.md
@@ -3,11 +3,20 @@
 Required signals, numbered. The harness treats a signal that contradicts ledger truth
 as a failure (INV-30): **lying metrics are failures**. Cardinality of every labeled
 family is bounded (intent — GAP-6): labels come from closed sets (endpoint, class,
-outcome, dataset) — per-worker labels must be bounded or evicted.
+outcome, dataset) — per-worker labels must be bounded or evicted. `/metrics` is a
+keyless, client-readable surface (IB-9), so commercial deployments apply an additional
+confidentiality rule: under gate scope `all`, no public series carries a dataset identity;
+under either scope, no public series exposes an internal authorization rung or lookup
+detail beyond the client-visible wire outcome (INV-39).
 
 **OB-1 — State gauges.** Active streams (census), in-flight congestion permits and
 window size, open leases (or an equivalent worker-busy gauge), known workers, known
-chunks and highest block per dataset. At quiescence each equals modeled truth.
+chunks and highest block per dataset. At quiescence each equals modeled truth. On an
+`all`-scope commercial deployment, the public scrape aggregates additive dataset gauges
+and omits the dataset label; a per-dataset value with no truthful aggregate, such as
+highest block, is omitted. Per-dataset state remains available only through authenticated
+metadata/operator routes and protected logs. A keyless metrics scrape must not reconstruct
+the catalog that `all` exists to hide (REQ-51).
 
 **OB-2 — Progress heartbeat.** Per active stream: periodic progress (coverage cursor,
 bytes) at P-HEARTBEAT-INTERVAL, plus time-to-first-byte per response. Distinguishes
@@ -41,8 +50,9 @@ connection fault whose shape the replay classifier stopped recognising. A wedged
 dependency must be visible from the Portal's own metrics alone (REQ-22).
 
 **OB-5 — Readiness reason.** The readiness state as a gauge with a reason code
-(loading / insufficient-connectivity / shutting-down / ⚠ stale-artifact — ADR-013,
-GAP-2), and logged transitions. A probe flip is attributable without log archaeology.
+(loading / insufficient-connectivity / shutting-down / no-key-snapshot on an enforcing
+commercial deployment / ⚠ stale-artifact — ADR-013, GAP-2), and logged transitions. A
+probe flip is attributable without log archaeology.
 
 **OB-6 — Artifact provenance.** Applied artifact identifier and ⚠ age
 (ADR-013/GAP-2), application timestamps, skipped/unchanged fetch counts. A wedged
@@ -78,6 +88,31 @@ truth. Publishing the cap keeps its literal out of the alert expression. All fou
 reasons map to one wire code (IB-5 `overloaded`), and must: the client's move is identical,
 the operator's is not.
 
+**OB-12 — Authorization decisions.** Commercial deployments only. In enforcing mode,
+every completed verdict (DEF-20) is counted on the public scrape by decision × actual
+**wire code** (or success) × route class × enforcement mode; a lookup that produced no
+verdict is counted only by the OVERLOADED or UPSTREAM-FAILURE code actually returned. The
+four internal reasons sharing `invalid_credential` are deliberately one public label
+value. In `log_only`, every request increments the same neutral `shadow_evaluated` public
+outcome: the would-be verdict and an indeterminate lookup are distinguishable only in
+protected structured logs. No metric label or request-synchronous counter may let a
+client bracket two keyless scrapes and learn more than its response revealed (INV-39,
+ADR-017). Auth refusals in enforcing mode must still be distinguishable from every other
+refusal on the OB-3 error-code axis — an auth 401 counted as `malformed_request` is a lying
+metric (INV-30, GAP-29). None of this exists yet (GAP-30).
+
+**OB-13 — Key snapshot freshness and provenance.** Commercial deployments only.
+Snapshot age since the last successful feed read (a gauge — the LIV-13 and GAP-31
+witness), the held cursor, last reported head and epoch, applied-delta and rebuild
+counters, and sync failures by cause. These public values change on background feed
+activity, not synchronously with one presented key. Record count and authorize-on-miss
+outcomes are omitted from the keyless scrape: either can reveal whether an
+attacker-chosen id caused a lookup or inserted a record. Lookup outcomes instead emit
+protected structured events (resolved, unknown, rate-limited, over the in-flight cap,
+failed), and CT-10 uses those events plus the control-plane stub ledger as the
+LIV-14/HZ-10 witness. A control plane that has stopped answering remains visible publicly
+as monotone age growth without exposing a key id or request path.
+
 ## Property → observable mapping
 
 | Property | Decided by |
@@ -91,6 +126,8 @@ the operator's is not.
 | LIV-9 | OB-3 refusal counters, OB-11 saturation integral |
 | LIV-10 | OB-1 gauges at quiescence |
 | LIV-12 | OB-9 |
+| LIV-13, LIV-14 | OB-13 age/cursor; protected lookup events + stub ledger |
+| INV-6, INV-15, INV-39 | protected OB-12 reason logs + public non-disclosure; OB-13 epoch/rebuild counters |
 | INV-30/31 | OB-1, OB-5 (they are the invariant's subject) |
 | SLI-1..6 | OB-2, OB-3, OB-1 + process RSS |
 
@@ -99,4 +136,6 @@ the operator's is not.
 Per-request correlated spans keyed by the request identifier (REQ-9, REQ-31); stream
 completion summaries carrying coverage, bytes, outcome class; readiness and artifact
 transitions logged at state-change only. Log content is diagnostic, not contract —
-tests assert on metrics and responses, not log text.
+except for the credential-confidentiality and no-oracle checks that explicitly inspect it
+(INV-38/39). Logs are an operator-protected sink and are never served by the client HTTP
+surface.

--- a/spec/13-conformance.md
+++ b/spec/13-conformance.md
@@ -1,6 +1,6 @@
 # 13 — Conformance & TDD plan
 
-**Mutable doc.** Statuses as of **2026-07-27** (0.11.9,
+**Mutable doc.** Statuses as of **2026-08-05** (0.11.9,
 `master@15fcaeeea803b39e4985a7c91dada20203f411ef`). Statuses: **C** covered · **P** partial · **U**
 unchecked; *known-violated* / *known-suspect* where reality contradicts the property.
 The **Phase-0 harness exists** (`harness/` crate: IB-7 stubs with ledgers — including
@@ -115,6 +115,7 @@ chunk-boundary records FV-6 licenses.
 | CT-7 | Soak/endurance: S4 churn for hours; leak & cardinality audits | HZ-1/5/6, INV-30, SLI-5 |
 | CT-8 | Isolation/noisy-neighbor: S6 | INV-35 |
 | CT-9 | Fuzz, both surfaces: client inputs and stub responses (payloads, artifacts) | INV-36, FM-1, GAP-1 |
+| CT-10 | Authorization: credential corpus × gate scope × enforcement mode against a control-plane stub; feed-fault/convergence cases; bracketed metrics scrapes proving no catalog or key-id side channel, including neutral shadow-mode projection | INV-6/10/14/15/38/39, INV-31, LIV-13/14, REQ-50..REQ-56, DC-8, IB-9, HZ-10 |
 
 ## Structural validators (kind-agnostic, applied to every response)
 
@@ -129,9 +130,10 @@ chunk-boundary records FV-6 licenses.
    selected (retention-gap case). Pre-routing failures have no source marker.
 6. Errors: type/code ∈ DEF-10; a hint on every OVERLOADED — on proxied ones too,
    preserved or injected at the floor — never on DATA-UNAVAILABLE, and on no other class
-   unless the upstream sent one (ADR-014); no data alongside errors (INV-26).
+   unless the upstream sent one (ADR-014); `WWW-Authenticate: Bearer` on every 401; no
+   data alongside errors (INV-26, IB-5).
 
-## Traceability matrix — properties (2026-07-27)
+## Traceability matrix — properties (2026-08-05)
 
 | Property | CT | Status | Note |
 |---|---|---|---|
@@ -139,7 +141,7 @@ chunk-boundary records FV-6 licenses.
 | INV-3 | CT-3 | P | quiescent lease census asserted zero after every randomized scheduling case and after client disconnect (controller-level, mock network); CT-3 swarm still absent |
 | INV-4 | CT-1/3 | P | window grow/shrink/priority unit tests |
 | INV-5 | CT-3 | U | transient overshoot untested |
-| INV-10 | CT-4 | U | — |
+| INV-10 | CT-4/10 | U | invalid-request corpus has no dependency-ledger assertion, including the bounded authorization exception |
 | INV-11 | CT-1 | U | clamping untested (GAP-8 adjacent) |
 | INV-12 | CT-3/6 | P | mapping unit-tested; cap never driven (GAP-4) |
 | INV-13 | CT-5 | P | resolver units; source marker asserted on both sources by the CT-1 smoke |
@@ -160,7 +162,7 @@ chunk-boundary records FV-6 licenses.
 | INV-37 | CT-2 | U | — |
 | INV-40 | CT-2 | U | — |
 | LIV-1..LIV-4 | CT-1/2/6 | U | stall budget unmeasured |
-| LIV-5, LIV-6 | CT-2 | U | startup bound unmeasured (S5) |
+| LIV-5, LIV-6 | CT-2 | U | startup bound unmeasured (S5), including enforcing-commercial key bootstrap |
 | LIV-7 | CT-2 | P | CT-2 waits for the pool to serve again between fault cases and after exhaustion; a latched penalty fails the run. Cooldown *durations* are unmeasured |
 | LIV-8 | CT-6 | P | regrowth unit-tested at scheduler level |
 | LIV-9 | CT-6 | U | — |
@@ -171,8 +173,16 @@ chunk-boundary records FV-6 licenses.
 | FM-2 | CT-2 | P | the DC-4 replay classifier is unit-tested on both sides of the transient/integrity line (clean close, reset, the two non-replay exclusions — ADR-015). Worker-side classification now exists and is CT-2-tested: wrong-range and bad-signature responses are integrity — discarded, rerouted, never delivered — and all-integrity exhaustion is a distinguishable outcome from transient exhaustion. Corrupt artifact (GAP-1) is still untested; the *taxonomy* of both exhaustion outcomes is inside GAP-16 |
 | FM-3 | CT-2/3 | U | per-dependency confinement never exercised: no outage tests (REQ-25), no isolation swarm (INV-35) |
 | SLI-1..SLI-6 | CT-6 | U | no benchmarks; baselines from incidents only |
+| INV-6 | CT-10 | P | PR #143 unit-tests forward-only sequence application, generation-guarded lookup insertion, wholesale rebuild on epoch change and head rollback, and tombstoning of malformed and unknown-status records. No harness stub exists, so nothing exercises a *concurrent* rebuild against an in-flight lookup — the race the generation counter is there for |
+| INV-14 | CT-10 | P | a counting catalog proves canonicalization happens only on the dataset rung of an authenticated request, and the ungated path is asserted to read neither credential nor dataset. Zero serving-dependency calls and the one-DC-8-call-on-miss bound are not asserted against stubs, because CT-10 has no harness (GAP-33) |
+| INV-15 | CT-10 | P | ladder precedence and the multi-failure corpus are unit-tested at the evaluate layer; determinism under saturation and across replicas is untested |
+| INV-38 | CT-10 | P | constant-time comparison is used and unit-tested for equality semantics; the credential's debug rendering redacts the secret. No test greps emitted logs, metrics, or spans for a marked secret, and the query-parameter channel puts the secret in a URL that intermediaries may record (IB-9) |
+| INV-39 | CT-10 | P | unknown key and wrong secret are asserted to return the same reason; the *response* identity and metrics non-disclosure are not asserted end-to-end, the timing channel is a known deviation (GAP-32), and digestless tombstones currently expose `revoked` (GAP-34) |
+| LIV-13 | CT-10 | P | one tick is unit-tested to drain a multi-page backlog; convergence itself is not measured against a clock, and the `M + 1`-page two-cycle boundary is untested |
+| LIV-14 | CT-10 | P | authorize-on-miss is unit-tested including the rate-limited and in-flight-capped refusals, but both currently collapse onto BAD-CREDENTIAL rather than the retryable outcomes DC-8 requires; the admission bound and HZ-10 interference case are untested (GAP-34) |
+| DC-8 | CT-10 | P | feed faults are well covered at unit level — non-success status, malformed envelope, missing envelope fields, non-advancing cursor, short-of-head bootstrap, mid-bootstrap epoch flip, redirect refusal. Nothing runs against a stub in the harness, so none of it is CT-2-style fault injection (GAP-33) |
 
-## Acceptance matrix — requirements (2026-07-27)
+## Acceptance matrix — requirements (2026-08-05)
 
 | REQ | Status | Note |
 |---|---|---|
@@ -207,8 +217,15 @@ chunk-boundary records FV-6 licenses.
 | REQ-42 | P | Scheduler units; headroom refusal untested (INV-4, LIV-8), and its observable — shrink cause, download utilization, headroom-refusal counter (OB-7) — is unasserted |
 | REQ-43 | P | Positive path exercised by the smoke (signed stub responses verified and delivered); CT-2 now drives the rejection path — a wrongly-signed response is not delivered and the attempt is retried elsewhere, meeting the acceptance criterion. Integrity failures are counted per worker but raise no OB-9 alarm state (GAP-24) |
 | REQ-44 | U | — |
+| REQ-50 | P | The ladder and every rung are unit-tested, and a source-scanning test forces each route in the table to be classified or fail the build. **Known-violated on the wire**: the refusal carries no taxonomy code, so the middleware rewrites it to 400 `malformed_request` and the client never sees a 401 or 403 (GAP-29). The zero-serving-call and bounded-DC-8-call claims lack a harness (GAP-33) |
+| REQ-51 | P | Both gate scopes are tested at the route-classification level, and the always-open set is pinned. Whether an `all`-scope deployment actually refuses each metadata route end-to-end, and whether keyless metrics omit every dataset identity and unsafe auth projection, are untested (GAP-30/33) |
+| REQ-52 | P | Token grammar, both presentation channels, length caps and the alphabet are unit-tested; digest-only handling is structural. Log/metric non-disclosure is unasserted (INV-38) |
+| REQ-53 | P | Precedence, absent-vs-empty scope, exact matching, alias resolution, and the no-dataset route case are unit-tested, including the earliest-rung-wins corpus. **Known-violated for digestless tombstones:** #143 returns `revoked` before a secret can match (GAP-34) |
+| REQ-54 | P | Fail-closed on unknown keys and fail-static across feed faults are unit-tested, as is readiness withholding before the first snapshot. Lookup budget/failure currently collapses onto non-retryable BAD-CREDENTIAL instead of OVERLOADED/UPSTREAM-FAILURE (GAP-34); staleness is unbounded and invisible (GAP-31) |
+| REQ-55 | P | Shadow mode is asserted to admit the whole rejection corpus, record ordinary verdicts, and not withhold readiness. An indeterminate lookup outcome and the identical neutral public projection of valid, invalid, and indeterminate cases are unimplemented or untested (GAP-30/33) |
+| REQ-56 | C | Absent configuration is asserted to install no middleware on either route class, an empty block fails startup naming the missing field through both deserializer paths, and the mode is logged once at startup |
 
-## Gap register — 2026-07-27
+## Gap register — 2026-08-05
 
 Priorities: P0 blocks the program · P1 active production risk · P2 correctness hole
 with plausible trigger · P3 polish. "Next" = cheapest failing-test-first entry.
@@ -241,6 +258,13 @@ with plausible trigger · P3 polish. "Next" = cheapest failing-test-first entry.
 | GAP-26 | No aggregate deadline bounds a worker attempt: connect is a 10 s crate default (P-WORKER-CONNECT-TIMEOUT, not operator-bound), first byte 60 s, and the body is read in 1 s-stall-bounded reads with no total bound — DC-1's single "request deadline P-TRANSPORT-TIMEOUT" is not what runs, and the transport's `request_timeout` is set but unused on this path | DC-1, REQ-22, HZ-2 | P2 | stub worker trickles a body at just under the per-read stall bound indefinitely; assert the attempt is bounded |
 | GAP-27 | Penalty classification diverges from ADR-004's cost rationale: an instant stream reset (the worker's documented flood-shed posture) draws the 300 s timeout-class cooldown plus a congestion signal, and integrity penalties are split (bad signature 300 s vs undecodable/wrong-range 30 s) though DC-1 treats them as one class — a brief worker-side flood can push the whole pool to AllUnavailable | REQ-41, DC-1, LIV-7 | P2 | CT-2: instant-reset injector; assert the cooldown class matches observed cost and the pool recovers within the error-cooldown window |
 
+| GAP-29 | Authorization refusals are emitted outside the ADR-011 envelope, so they carry no `ErrorCode` and the routed middleware normalizes them: a 401 reaches the client as **400 `malformed_request`** with the auth message nested as a JSON string, and a 403 likewise. No 401 or 403 is observable on the wire, clients cannot distinguish an invalid key from a malformed query, every auth refusal lands on the metric as `error_code="malformed_request"`, and no Bearer challenge is emitted — the signals and recovery surface a cutover depends on do not exist. Demonstrated by running the PR #143 gate behind the master middleware stack | REQ-50, IB-5, IB-9, DEF-10, INV-30, OB-12 (ADR-017) | **P0** | CT-5: assert an unauthenticated request to a gated route answers 401 with `authentication_error`/`missing_credential` and `WWW-Authenticate: Bearer`; it fails today at the status line |
+| GAP-30 | Authorization emits no metrics at all: verdicts, snapshot age and sync failures exist only as log lines. OB-12 and OB-13 are unimplemented, so shadow-mode analysis requires protected-log aggregation and a control plane that stopped answering is invisible on a dashboard. The implementation may expose actual enforcement wire codes and a neutral shadow total only: internal rungs, hypothetical shadow verdicts, record count and request-path resolve outcomes stay in protected logs because `/metrics` is keyless | OB-12, OB-13, REQ-55, INV-30, INV-39 | P1 | add the safe decision counter, then bracket scrapes: enforcing unknown-key/wrong-secret cases share a series, while shadow valid/invalid/indeterminate cases all share the neutral series |
+| GAP-31 | Key-snapshot staleness is unbounded and unexported. A control-plane outage freezes the key set indefinitely — revocations issued during it never land — and nothing degrades, alarms, or reports age. Exactly the assignment-staleness hole of GAP-2, on a surface where the stale data is an access-control decision | REQ-54, DC-8, INV-31 ⚠, OB-13 (ADR-016, OQ-12) | P1 | age gauge first; then ratify P-KEY-SNAPSHOT-MAX-AGE via OQ-12 and test the degradation |
+| GAP-32 | INV-39's wire identity holds only while authorize-on-miss can answer authoritatively. A key id absent from the snapshot may take longer than a hit; if its lookup budget is exhausted or the control plane fails, it receives retryable OVERLOADED/UPSTREAM-FAILURE while a present id with a wrong secret receives BAD-CREDENTIAL. The accurate retry contract therefore reveals snapshot membership under lookup pressure. Public metrics must not amplify that accepted residual beyond the outcome the caller already received (OB-12/13) | INV-39 | P2 | decide whether the residual is accepted, or close it by making hits and misses share the lookup-failure outcome; bracketed scrapes must expose no internal detail either way |
+| GAP-33 | CT-10 has no harness: DC-8 has no stub in `harness/`, so every claim in the CT-10 row set is unit-tested inside the crate rather than driven black-box. Nothing exercises a concurrent rebuild against an in-flight lookup (INV-6's race), zero serving-dependency calls and one bounded DC-8 call under refusal (INV-14), verdict determinism across replicas (INV-15), secret/non-oracle disclosure in emitted signals (INV-38/39), or HZ-10's interference with legitimate new keys. All the phase-1 constants are hard-coded rather than operator-bound (15 §commercial) | CT-10, DC-8, INV-6/14/15/38/39, HZ-10 | P1 | build the DC-8 stub per IB-7; the cheapest first case is INV-14's call-ledger assertion, which needs only the stub's ledger |
+| GAP-34 | Snapshot-miss failures and digestless tombstones violate the authorization contract in #143. Rate/in-flight exhaustion and control-plane errors all return `None`, so a valid fresh key receives non-retryable BAD-CREDENTIAL instead of OVERLOADED/UPSTREAM-FAILURE. A revoked or malformed tombstone carries no digest, yet the evaluator returns `revoked` before comparing the presented secret, exposing that the guessed key id exists and violating INV-39's secret-first rule | REQ-53/54, DC-8, INV-39, ADR-017 | P1 | split `get_or_resolve` into authoritative unknown vs overloaded vs unavailable; map the latter two to retryable taxonomy outcomes, and map every digestless record to BAD-CREDENTIAL; CT-10 pins all four paths |
+
 ### Closed findings
 
 - **Wrong-range worker responses** (closed 2026-07-25): a worker reporting a last block
@@ -268,9 +292,9 @@ with plausible trigger · P3 polish. "Next" = cheapest failing-test-first entry.
 
 ## Build order
 
-- **Phase 1 — P1 gaps, failing tests first:** GAP-1/2/4/16/17/23 tests red → fixes;
-  GAP-3 probe + heap profile → refresh-copy fix. GAP-23 already has its failing case
-  parked in `ct2_worker_faults`'s known-violated list.
+- **Phase 1 — P1 gaps, failing tests first:** GAP-1/2/4/16/17/23/29/30/31/33/34 tests
+  red → fixes; GAP-3 probe + heap profile → refresh-copy fix. GAP-23 already has its
+  failing case parked in `ct2_worker_faults`'s known-violated list.
 - **Phase 2 — correctness core:** full CT-1 oracle diffing; the rest of the CT-2 fault
   matrix (DC-2/DC-3/DC-4 injectors, kill/restart) on the `Fixture` + worker-injector
   scaffolding; CT-4 corpus; burn down P2 gaps.

--- a/spec/14-interface-binding.md
+++ b/spec/14-interface-binding.md
@@ -5,7 +5,8 @@ encodings — as *observable contract*, still no internals. **Anything not speci
 here is unspecified: clients and tests must not pin it** (IB-8).
 
 **IB-1 — Transport generalities.** HTTP/1.1+; permissive CORS (any origin/method/
-header), exposing `Retry-After`, `x-request-id` and the `x-sqd-*` stream metadata —
+header), exposing `Retry-After`, `WWW-Authenticate`, `x-request-id` and the `x-sqd-*`
+stream metadata —
 allowing an origin does not make a response header readable, and the CORS-safelisted set
 contains none of ours, so a browser client would otherwise see the status and nothing
 else. Request bodies may be gzip-compressed. Every response carries `x-request-id`
@@ -30,7 +31,8 @@ UUID). Stream responses are chunked `application/jsonl`, compressed:
 | OP-8 | `GET /ready` | 200 / 503 + reason |
 | OP-9 | `GET /metrics` | OpenMetrics text |
 | OP-10 | `POST /sql/query` · `GET /sql/metadata` | build-time capability; experimental |
-| — | `/docs`, `/api-docs/openapi.json` | self-description (REQ-32) |
+| OP-11 | — (admission step on every gated route, IB-9) | commercial deployments only |
+| — | `/docs`, `/api-docs/openapi.json` | self-description (REQ-32); never gated |
 | — | deprecated: `/height` variants, `/{start_block}/worker`, `/query/{worker_id}`, `/debug/*` | NG7 — unspecified, don't pin |
 
 **IB-3 — Stream request.** Query string: `buffer_size` (int ≥ 1, default
@@ -86,6 +88,20 @@ closed mapping is:
 | `api_error` / `worker_failure` | 500 | envelope |
 | `api_error` / `internal_error` | 500 | envelope |
 | `api_error` / `unclassified` | contextual 5xx | envelope; must be counted and investigated |
+| `authentication_error` / `missing_credential` | 401 | envelope; `WWW-Authenticate: Bearer`; no `Retry-After` |
+| `authentication_error` / `invalid_credential` | 401 | envelope; `WWW-Authenticate: Bearer`; identical byte-for-byte apart from the request id whether the token was unparseable, named an unknown key, carried a wrong secret, or named a digestless tombstone (INV-39) |
+| `authentication_error` / `revoked_credential` | 401 | envelope; `WWW-Authenticate: Bearer` |
+| `authentication_error` / `expired_credential` | 401 | envelope; `WWW-Authenticate: Bearer` |
+| `permission_error` / `portal_not_allowed` | 403 | envelope |
+| `permission_error` / `dataset_not_allowed` | 403 | envelope |
+
+The last six rows appear only on a commercial deployment (REQ-56) and only on a gated
+route (IB-9). None is retryable and none carries a retry hint: retrying with the same
+credential cannot succeed, and treating an auth refusal as transient reproduces the
+ADR-012 refusal storm. Every 401 carries the Bearer challenge HTTP requires. None is an
+`api_error`, so none pages. A snapshot miss that could not be resolved is not one of these
+six rows: lookup-budget exhaustion maps to retryable `overloaded`, and lookup failure to
+retryable `upstream_unavailable` (DC-8).
 
 EMPTY (204) is not in this table: it is a success, not a refusal, and carries no
 `type`/`code`. It is bound by IB-4 — no body, head-marker headers, emitted after
@@ -97,9 +113,11 @@ block also on the client's chain; re-request from its number + 1 with its hash a
 resolve (OP-5) uses the same envelope and code vocabulary.
 
 **IB-6 — Status & introspection surfaces.** `/ready`: 200 or 503 with the ADR-011
-`not_ready` envelope (OB-5). `/metrics`: OpenMetrics; families under the `portal_` prefix with a constant
-portal-identity label. `/status`, `/state`, `/debug/*`: bodies explicitly unstable
-(REQ-14).
+`not_ready` envelope (OB-5). `/metrics`: OpenMetrics; families under the `portal_` prefix
+with a constant portal-identity label. On commercial deployments the keyless scrape obeys
+12's confidentiality rule: no internal auth rung or lookup detail beyond the public wire
+outcome under either gate scope, and no dataset identity under `all`. `/status`, `/state`,
+`/debug/*`: bodies explicitly unstable (REQ-14).
 
 **IB-7 — Input-side binding (what harness stubs implement).** Worker stub (DC-1): the
 peer-to-peer query protocol — signed query in, sized/compressed result or typed error
@@ -109,10 +127,49 @@ and metadata documents. Real-time stub (DC-4): `/head`, `/finalized-head`, `/sta
 `/stream`, `/finalized-stream` under `datasets/{name}`, honoring the portal-supplied
 client-identity header, emitting head headers and `x-internal-*` noise for
 strip-testing, plus every 4xx/5xx/409 shape needed to assert error normalization. RPC
-stub (DC-5): the contract read set. Log-sink stub (DC-6) and error-report stub (DC-7):
+stub (DC-5): the contract read set. Control-plane stub (DC-8): the cursor-paged key feed
+with its four-field envelope, plus the single-key lookup — and, as a fault injector, the
+epoch flip, head rollback, non-advancing cursor, short-of-head page, malformed record and
+unrecognized status the DC-8 error table names (⚠ unbuilt — GAP-33). Log-sink stub (DC-6) and error-report stub (DC-7):
 fire-and-forget receivers with ledgers, so egress audits (INV-37) and drop accounting
 (HZ-7) have ground truth. Stubs double as fault
 injectors for the CT-2 matrix.
+
+**IB-9 — Authorization binding.** Commercial deployments only (REQ-56); on any other
+deployment nothing in this rule is observable.
+
+*Presentation.* A credential is accepted as `Authorization: Bearer <token>` or as the
+`api_key` query parameter, in that precedence. The query channel exists because some
+browser transports cannot set headers on every request; operators should assume a token
+presented that way is recorded by intermediaries and access logs, which is a property of
+URLs, not of this binding.
+
+*Token grammar.* `<prefix><key_id>_<secret>`, where the prefix is one the control plane
+mints, the two segments draw from `[A-Za-z0-9~-]`, and their lengths are at most
+P-KEY-ID-MAX-LEN and P-KEY-SECRET-MAX-LEN. A token outside this grammar is refused as
+`invalid_credential` without a lookup — it is not something the control plane could have
+issued (REQ-52).
+
+*Gated surface.* Every route in IB-2 carries exactly one class (DEF-19). Under gate scope
+`data`, the gated set is the stream routes, the timestamp-to-block lookup, the direct
+worker query, and the SQL query plan. Under `all`, it additionally includes every
+metadata route: the catalog, per-dataset metadata and state, all head and height
+variants, `/status`, the worker lookup and the debug surfaces. `/ready`, `/metrics` and
+`/api-docs/openapi.json` are gated under neither, and the docs UI is deliberately open
+because it serves the same schema on every deployment and names no dataset. A route whose
+class is unstated is a build failure, not an ungated route (REQ-51).
+
+Because `/metrics` is deliberately keyless, its commercial representation is part of the
+authorization boundary rather than an exemption from it: it must not reveal a dataset
+identity under `all`, an internal authorization rung, a key-record count, or whether one
+request hit the snapshot or invoked authorize-on-miss beyond what that request's own wire
+outcome already disclosed (OB-1/12/13, INV-39).
+
+*Interaction with the envelope.* An auth refusal is emitted in the IB-5 envelope with the
+codes above. It must reach the client with the status IB-5 binds to its code — a refusal
+carrying no code is normalized onto `malformed_request` at 400 by the same rule that
+catches framework rejections, which would erase the distinction this rule exists to make
+(GAP-29).
 
 **IB-8 — Versioning rule.** Any change to this binding (route, code, header, schema,
 taxonomy) updates this file and the interface-conformance class CT-5 in the same

--- a/spec/15-parameters.md
+++ b/spec/15-parameters.md
@@ -70,7 +70,7 @@ assumes, not knobs it owns.
 | P-DRAIN-TIMEOUT | In-flight drain budget after intake stops (REQ-24, ADR-005) | 25 s | 25 s |
 | P-KILL-GRACE | *Environmental:* the orchestrator's grace between SIGTERM and SIGKILL — Kubernetes `terminationGracePeriodSeconds` (REQ-24, LIV-11, ADR-005) | deployment-set, unverified; the Kubernetes default of 30 s is **below** the 50 s budget | ≥ P-PRE-DRAIN-GRACE + P-DRAIN-TIMEOUT + slack (≥ 60 s) |
 | P-READY-CONNECTION-RATIO | Min fraction of known workers connected for readiness (REQ-23) | 3/4 *(fixed)* | 3/4 |
-| P-STARTUP-BOUND | ⚠ Start → ready bound, dominated by artifact fetch (LIV-5, S5) | unmeasured | ⚠ 10 min (proposed) |
+| P-STARTUP-BOUND | ⚠ Start → ready bound, including artifact fetch and enforcing-commercial key bootstrap (LIV-5, S5) | unmeasured | ⚠ 10 min (proposed) |
 | P-STALL-BUDGET | ⚠ Max zero-progress interval on a healthy stream; also the first-record bound (LIV-1, LIV-2, OB-2) | unmeasured | ⚠ 2 × P-TRANSPORT-TIMEOUT (proposed) |
 
 ## Accounting & reporting
@@ -82,6 +82,26 @@ assumes, not knobs it owns.
 | P-HEARTBEAT-INTERVAL | Stream progress heartbeat cadence (OB-2, harness quiescence) | 5 s *(fixed)* | 5 s |
 | P-MEMORY-BUDGET | ⚠ Per-replica memory budget REQ-27 must fit | 4–5 GB provisioned; **violated 2026-07-17 (OOM-kill restarts on 0.11.8)** | ⚠ ratify via OQ-4 and OQ-9 |
 | P-ASSIGNMENT-SIZE | *Environmental:* mainnet assignment artifact size (REQ-27, GAP-3) | docs disagree: ~300 MB vs ~0.5 GB | resolve via OQ-4 |
+
+## Commercial access control
+
+Bound only on a commercial deployment (REQ-56); unused elsewhere. "Observed" values are
+those of the phase-1 implementation under review (PR #143), which hard-codes all but the
+sync interval — making them operator-bindable is part of closing GAP-33.
+
+| Parameter | Role (where used) | Observed | Target |
+|---|---|---|---|
+| P-KEY-SYNC-INTERVAL | Key-feed poll interval; one term in the page-count-dependent revocation-convergence bound (DC-8, LIV-13) | 10 s | 10 s |
+| P-KEY-PAGE-LIMIT | Records requested per feed page; also defines what a "short page" is (DC-8) | 1000 *(fixed)* | 1000 |
+| P-KEY-FETCH-TIMEOUT | Per-page feed and single-key lookup deadline; sync ticks are serialized, and LIV-13 accounts for one such bound per page (DC-8) | 5 s *(fixed)* | 5 s |
+| P-KEY-MAX-PAGES-PER-TICK | Bound on pages read in one drain; larger delta backlogs continue next tick, while an atomic bootstrap must fit inside the bound (DC-8, LIV-5/13) | 10000 *(fixed)* | 10000 |
+| P-KEY-SNAPSHOT-MAX-AGE | ⚠ Max tolerated key-snapshot age before an enforcing Portal degrades (REQ-54, INV-31, OB-13) | **unbounded — GAP-31** | ⚠ ratify via OQ-12 |
+| P-KEY-NEGATIVE-TTL | How long a "control plane knows nothing about this key" answer suppresses repeat lookups (DC-8) | 15 s *(fixed)* | 15 s |
+| P-KEY-NEGATIVE-CAPACITY | Cap on remembered negative answers; ids are attacker-chosen, so the map is bounded rather than grown (DC-8, HZ-10) | 4096 *(fixed)* | 4096 |
+| P-KEY-RESOLVE-RATE | Token-bucket rate for authorize-on-miss lookups (DC-8, LIV-14, HZ-10) | 20 /s *(fixed)* | ⚠ one budget serves two opposed purposes — bounding attacker cost and admitting legitimate new keys (HZ-10); ratify via GAP-33 once CT-10 can measure the interference |
+| P-KEY-RESOLVE-INFLIGHT | Cap on concurrent authorize-on-miss lookups (DC-8, HZ-10) | 16 *(fixed)* | 16 |
+| P-KEY-ID-MAX-LEN | Max accepted key-id length; mirrors what the control plane can mint (IB-9, REQ-52) | 64 *(fixed)* | 64 |
+| P-KEY-SECRET-MAX-LEN | Max accepted secret length (IB-9, REQ-52) | 128 *(fixed)* | 128 |
 
 ## SLO targets
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -19,6 +19,12 @@ nothing durable survives a restart). Modules 06 (consistency/durability) and 10
 refreshed-snapshot lifecycle is folded into 05. Numbering gaps are canonical, never
 recycled.
 
+Commercial access control (REQ-50..REQ-56, DC-8, ADR-016/017) is **conditional**: every
+property in that area is vacuous on a Portal the operator has not configured
+commercially, which is the default and the only mode a self-hosted build has. It is
+spread through the existing documents rather than given one of its own, because it is a
+precondition on the surface those documents already describe, not a second system.
+
 ## Document map
 
 | Doc | Contents | Normative? | Mutable? |
@@ -58,6 +64,8 @@ not been ratified are explicitly `Proposed` and appear after the accepted log.
 | ADR-014 | 2026-07-17 | [Contract reconciliation: overload hints, conflict precedence, artifact regression, archival finalized head, EMPTY metadata, timestamp frontier, gated debug surface](decisions/ADR-014-contract-reconciliation.md) | Accepted |
 | ADR-015 | 2026-07-21 | [One connection-class replay on the real-time path](decisions/ADR-015-real-time-connection-replay.md) | Accepted |
 | ADR-013 | 2026-07-17 | [Assignment staleness must be bounded and observable](decisions/ADR-013-assignment-staleness-bound.md) | **Proposed** |
+| ADR-016 | 2026-08-05 | [The Portal authenticates requests itself](decisions/ADR-016-portal-side-authentication.md) | **Proposed** |
+| ADR-017 | 2026-08-05 | [Authentication and permission errors extend the ADR-011 taxonomy](decisions/ADR-017-auth-error-taxonomy.md) | **Proposed** |
 
 ## Conventions
 
@@ -86,8 +94,11 @@ not been ratified are explicitly `Proposed` and appear after the accepted log.
 1. **Extend the harness past Phase 0** (13 §build order): the Phase-0 skeleton —
    dependency stubs per IB-7, the structural validators, the reference model — has
    landed (GAP-14 closed 2026-07-17); build the `CT-2..CT-9` classes on it next.
-2. **Ratify or reject proposed ADR-013** and the ⚠ targets in [15-parameters.md](15-parameters.md)
-   and the SLO table (11); close the open questions in
-   [02-requirements.md](02-requirements.md).
+2. **Ratify or reject proposed ADR-013, ADR-016 and ADR-017** and the ⚠ targets in
+   [15-parameters.md](15-parameters.md) and the SLO table (11); close the open questions
+   in [02-requirements.md](02-requirements.md). ADR-016 and ADR-017 are a pair: the
+   first makes the Portal refuse requests on identity grounds, the second gives those
+   refusals somewhere to live in the error taxonomy — adopting the first without the
+   second is what GAP-29 records.
 3. **Burn down the gap register** in [13-conformance.md](13-conformance.md) in priority
    order — failing test first, fix second, matrices updated in the same change.

--- a/spec/decisions/ADR-016-portal-side-authentication.md
+++ b/spec/decisions/ADR-016-portal-side-authentication.md
@@ -1,0 +1,77 @@
+# ADR-016 — The Portal authenticates requests itself
+
+Status: Proposed (2026-08-05)
+
+## Context
+
+NG1 declared per-request authentication a non-goal on the reasoning that the Portal
+"runs behind a trusted perimeter". That perimeter is a single edge rule in front of the
+shared deployment. It has three properties the suite never wrote down and cannot keep:
+
+- It is not part of this system. Nothing in the Portal's own tests, metrics, or spec
+  says whether it is on, and a misconfigured edge silently opens the data API.
+- It cannot express what commercial access actually needs. The edge knows a request;
+  it does not know that *this* key is revoked, expired, bought only `ethereum-mainnet`,
+  or belongs on a different portal.
+- It does not exist for single-tenant deployments, where the dataset catalog itself
+  discloses what one customer bought.
+
+Meanwhile the control plane already mints keys and knows their state. The missing half
+is a data plane that can decide, per request, whether to serve.
+
+## Decision
+
+The Portal authenticates and coarsely authorizes each request itself, when — and only
+when — the operator configures it to.
+
+1. **Opt-in, and absent by default.** Without commercial configuration the Portal has no
+   gate, no control-plane dependency, and no authorization middleware: byte-for-byte the
+   behavior of a self-hosted build (REQ-56). Configuration present but empty is a
+   startup error, never an open portal.
+2. **Mirror, don't ask.** The Portal tails the control plane's key feed into an
+   in-memory snapshot (DC-8) and verifies presented secrets locally against the published
+   digest. The request path makes no control-plane call except the bounded
+   authorize-on-miss lookup that lets a key minted seconds ago work before the next sync.
+3. **Fail-closed on the key, fail-static on the feed.** An unknown key is refused. A
+   control-plane outage does not invalidate a snapshot hit: the last good snapshot keeps
+   answering (REQ-54). A miss that cannot be resolved is refused retryably as overload
+   when its local lookup budget is exhausted, or as upstream unavailability when the call
+   fails — never mislabeled as an invalid credential. The two paths differ because
+   refusing every snapshot hit during a control-plane blip is a worse outage than briefly
+   honoring a key that was just revoked.
+4. **Enforcement is a mode, not a deploy.** `log_only` attempts the whole ladder, records
+   the verdict it would have returned or an indeterminate lookup that prevented one, and
+   admits regardless (REQ-55) — the cutover is a config change with a measured blast
+   radius, not a leap.
+5. **Two gate scopes.** `data` gates streams, queries and block lookups and leaves
+   metadata public — correct for the shared portal, where the catalog is public knowledge.
+   `all` closes metadata too, for single-tenant portals where the catalog is the
+   disclosure (REQ-51). Readiness, metrics and the API schema are never gated in either
+   mode: a pod that cannot answer its own probe leaves rotation, and existing scrapers do
+   not need a customer key. The keyless metrics representation is correspondingly
+   constrained: no dataset identities under `all`, and no internal auth rung or lookup
+   detail beyond the public wire outcome under either scope (OB-1/12/13).
+
+**NG1 is retired** and replaced by a narrower non-goal: the Portal still performs no
+per-client quota, metering, or rate limiting (NG2 unchanged) — an admitted key streams
+unrestricted. Those are later phases and are deliberately out of this decision.
+
+## Consequences
+
+The Portal gains a dependency it can be down without (DC-8) and a readiness precondition
+it cannot serve without: an *enforcing* portal that has never mirrored the key set knows
+no keys, so it would answer 401 to every valid one, and must stay out of rotation until
+the first sync lands (INV-31). A shadow-mode portal has no such precondition, since it
+admits regardless.
+
+Rejection reasons become a public contract surface, which is what forces ADR-017: the
+ADR-011 vocabulary has no way to say "your credential is the problem" and no status
+outside the 400/404/409/5xx set.
+
+Two properties now need bounds the suite did not previously owe anyone: how long a
+revocation may take to reach a replica (LIV-13) and how stale a snapshot may get before
+the deployment should stop trusting it (P-KEY-SNAPSHOT-MAX-AGE ⚠, GAP-31). Both are
+the key-set analogue of the assignment-staleness question ADR-013 leaves open, and
+should be ratified together.
+
+Shapes REQ-50..REQ-56; adds DC-8; retires NG1.

--- a/spec/decisions/ADR-017-auth-error-taxonomy.md
+++ b/spec/decisions/ADR-017-auth-error-taxonomy.md
@@ -1,0 +1,82 @@
+# ADR-017 — Authentication and permission errors extend the ADR-011 taxonomy
+
+Status: Proposed (2026-08-05)
+
+## Context
+
+ADR-011 fixed a closed two-axis vocabulary: four `type` values, a generated `code` list,
+and a code→status binding that IB-5 calls exact. It was written for a Portal that could
+not refuse a request on grounds of *who was asking*, so it has no way to say so — and,
+because the binding is closed, no status outside the set it enumerates.
+
+ADR-016 makes the Portal refuse on exactly those grounds. Its rejections are 401 and
+403, statuses that appear nowhere in IB-5, carrying reasons — missing credential,
+unknown key, revoked, expired, wrong portal, wrong dataset — that map onto no existing
+code.
+
+This is not a theoretical gap. A refusal that names no code is normalized by the
+middleware every routed response passes through: an unmatched client error is rewritten
+onto `malformed_request` and its bound status, 400. An authentication failure emitted
+outside this vocabulary therefore does not merely carry a vague code — it *stops being a
+401*, and a client cannot distinguish "your key is invalid" from "your query is
+malformed". The observability cost matches: every auth refusal lands on the metric as
+`error_code="malformed_request"`, indistinguishable from client query errors, so the one
+signal an operator needs during a cutover — how much traffic is being turned away, and
+why — does not exist.
+
+Extending a closed vocabulary is a binding change under IB-8, so it is a decision, not
+an edit.
+
+## Decision
+
+Add two `type` values and six `code` values to the ADR-011 vocabulary.
+
+| Type | Retryable | Meaning |
+|---|---|---|
+| `authentication_error` | no | The credential is absent, unreadable, or does not authenticate |
+| `permission_error` | no | The credential authenticated but does not cover this request |
+
+| Code | Type | Status |
+|---|---|---|
+| `missing_credential` | `authentication_error` | 401 |
+| `invalid_credential` | `authentication_error` | 401 |
+| `revoked_credential` | `authentication_error` | 401 |
+| `expired_credential` | `authentication_error` | 401 |
+| `portal_not_allowed` | `permission_error` | 403 |
+| `dataset_not_allowed` | `permission_error` | 403 |
+
+Both new types are non-retryable: retrying with the same credential cannot succeed, and
+a client that treats an auth refusal as a transient failure produces exactly the refusal
+storm ADR-012 exists to prevent. Neither carries `Retry-After`; every 401 carries
+`WWW-Authenticate: Bearer`. A snapshot miss that could not be resolved is not an auth
+verdict: lookup saturation remains retryable overload, and lookup failure remains
+retryable upstream unavailability (DC-8).
+
+**`invalid_credential` deliberately covers four distinct internal reasons** — a token the
+Portal could not parse, a key id it does not know, a key id whose secret does not match,
+and a record carrying no digest with which to prove the secret. They are one wire code
+because distinguishing them turns the endpoint into an enumeration oracle: a client that
+learns "this key id exists, wrong secret" has been told which of its guesses to keep. The
+operator's need for the distinction is real and is met on the *internal* axis — protected
+structured logs (OB-12) — which no client can read. The keyless metrics surface
+deliberately keeps the same coarsening as the wire. The remaining codes are only reachable
+by someone already holding the right secret, so they can be specific without leaking
+anything (INV-39). A digestless revoked or malformed tombstone cannot establish that fact
+and therefore remains `invalid_credential`; the current #143 implementation differs
+(GAP-34).
+
+`api_error` keeps its meaning: an auth refusal is never an `api_error` and must never
+page. The Portal turning away an unauthenticated request is the system working.
+
+## Consequences
+
+IB-5's table gains six rows and the status set gains 401 and 403; CT-5 covers them like
+any other binding row. `ErrorType` grows the first values that are not about the
+Portal's own health, which is the point — the existing four all answer "is this
+retryable and does it page?", and both new ones answer no to both.
+
+The `code` vocabulary is public API twice over (wire field and metric label), so these
+names are frozen on first release, per ADR-011.
+
+Amends ADR-011; required by ADR-016. GAP-29 tracks the current implementation, which
+emits an envelope that predates this vocabulary and is consequently rewritten to 400.


### PR DESCRIPTION
Specifies the commercial access-control capability #143 implements, so that PR can rebase onto a master that already carries the contract. Spec only — no `src/` changes.

## Why this is a decision, not documentation

**NG1 declared per-request authentication a non-goal.** Its rationale was that the Portal "runs behind a trusted perimeter" — an edge rule this system cannot see, cannot test, and does not have at all on a single-tenant deployment. Retiring a non-goal changes intended behavior, so it needs an ADR.

**The error taxonomy has no room for auth refusals.** ADR-011 fixed four `type` values and a closed code→status binding; none of them can say the credential is the problem, and 401/403 appear nowhere in IB-5. This is not cosmetic: a refusal carrying no `ErrorCode` is rewritten by `logging::middleware` onto its bound status. Running #143's gate behind master's stack:

```
STATUS = 400 Bad Request
BODY   = {"error":{"type":"invalid_request_error","code":"malformed_request",
           "message":"{\"message\":\"API key required\"}"}}
```

No 401 or 403 reaches the wire, clients cannot tell an invalid key from a malformed query, and every auth refusal counts on the metric as `error_code="malformed_request"` — the one signal a Cloudflare cutover depends on. Recorded as **GAP-29 (P0)** with the failing test that proves it.

## Decisions (both `Proposed`)

- **ADR-016** — the Portal authenticates requests itself. Retires NG1; keeps NG2, so an admitted key still gets no quota or metering. Opt-in and absent by default; fail-closed on the key, fail-static on the feed.
- **ADR-017** — adds `authentication_error` and `permission_error` plus six codes. `invalid_credential` deliberately covers unparseable-token, unknown-key and wrong-secret as one wire value, so the endpoint is not a key-id enumeration oracle; the distinction survives on the metric's reason label, which no client can read.

## What landed

REQ-50..REQ-56 · DEF-16..DEF-20 and six DEF-10 rows · OP-11 · DC-8 · INV-6/14/15/38/39, with INV-31 and INV-37 amended · LIV-13/14 · a control-plane fault table · PF-7, HZ-10/11 · OB-12/13 · IB-9 and the IB-5 rows · eleven `P-KEY-*` parameters · CT-10 · GAP-29..GAP-33 · OQ-12/13.

Access control is spread through the existing documents rather than given one of its own, because it is a precondition on the surface they already describe. Every property in it is vacuous without commercial configuration, which stays the default.

## Gaps this registers against #143

Specced as intent with the deviation recorded, per the suite's rules — none of these block the implementation landing, but they should land dated rather than implied.

| GAP | Priority | Statement |
|---|---|---|
| GAP-29 | **P0** | Auth refusals are normalized to 400 `malformed_request`; no 401/403 on the wire |
| GAP-30 | P1 | No authorization metrics at all — shadow mode is readable only by grepping logs |
| GAP-31 | P1 | Key-snapshot staleness unbounded and unexported; revocations never land during a control-plane outage |
| GAP-33 | P1 | CT-10 has no harness: DC-8 has no stub, so every claim is unit-tested rather than driven black-box |
| GAP-32 | P2 | INV-39 holds on the response but not on the clock — a snapshot miss still discloses key-id existence by timing |

## Verification

```
spec-lint: 0 errors · 0 warnings · 2 info   (--strict exit 0)
```
Both infos are pre-existing canonical numbering gaps, identical to master's baseline.

## Open before ratifying

- **OQ-12** — `P-KEY-SNAPSHOT-MAX-AGE`: does an enforcing Portal decline readiness once its key set is stale, or keep serving and alarm? Revocation latency and control-plane availability pull in opposite directions.
- **OQ-13** — a dataset-scoped key currently cannot use the SQL surface at all, which is fail-closed but locks out exactly the customers most likely to be scoped.
- `P-KEY-RESOLVE-RATE` is one budget serving two opposed purposes: bounding attacker cost and admitting legitimate new keys (HZ-10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)