### PR TITLE
spec: access control as an on-demand credential exchange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 .env
 *.key
 db
+
+# Local libp2p identity keypairs.
+key-*
+!key-*.rs
+
+.idea/

--- a/spec/01-overview.md
+++ b/spec/01-overview.md
@@ -32,9 +32,10 @@ status**. Worker-health bookkeeping is in-memory only and resets on restart.
 | head / finalized head | Highest available block / highest finalized block of a dataset |
 | data frontier | Highest block servable for a request right now (archival head or real-time head) |
 | stream | One request/response pair; may end early at any time and be resumed by a follow-up request |
-| API key | A credential a client presents: a public key id plus a secret the Portal only ever sees as a digest (DEF-16) |
-| key snapshot | The Portal's in-memory mirror of the control plane's key set, refreshed by cursor-paged deltas (DEF-18) |
-| gated route | A route that requires a key on a commercial deployment; which routes are gated is the operator's gate scope (DEF-19) |
+| API key | A credential a client presents: a public key id plus a secret (DEF-16) |
+| grant | The control plane's short-lived authorization answer for one credential: explicit claims plus the lifetimes it chose for them (DEF-17) |
+| grant cache | The Portal's bounded in-memory map from credential fingerprint to grant; the only authorization state a replica holds (DEF-18) |
+| gated route | A route that requires a key on a commercial deployment: block delivery, queries and block lookups (DEF-19) |
 
 ## Actors
 
@@ -48,7 +49,7 @@ status**. Worker-health bookkeeping is in-memory only and resets on restart.
 | Real-time source | Serves head/stream requests for recent blocks; proxied per request | outbound |
 | Chain RPC + contracts | On-chain registry: epoch, stake, compute units, worker set | outbound |
 | Error-reporting sink | Receives sampled error/trace reports | outbound |
-| Control plane | Mints and revokes API keys; publishes the key feed the Portal mirrors (DC-8). Present only on a commercial deployment | outbound |
+| Control plane | Mints and revokes API keys; answers the Portal's per-credential exchange with a short-lived grant (DC-8). Present only on a commercial deployment | outbound |
 
 ## Design goals
 
@@ -73,17 +74,18 @@ status**. Worker-health bookkeeping is in-memory only and resets on restart.
 | NG5 — No durable local state | Restart amnesia is by design: everything is refetched or relearned. There is nothing to back up or recover. |
 | NG6 — SQL surface plans, never executes | The experimental SQL endpoints return a routing plan (which workers hold which chunks); execution happens elsewhere (REQ-15). |
 | NG7 — Deprecated endpoints are unspecified | Legacy routes (worker lookup, height, direct worker query) exist for migration only; their behavior must not be pinned by new clients or tests. |
+| NG8 — No catalog privacy | Which datasets a Portal serves is public on every deployment: the catalog, heads, heights and worker inventory answer without a credential whatever the commercial configuration says. Gating that surface as a second scope was considered and rejected: it makes every route's classification a decision, and the contract is simpler when the catalog is public everywhere. Revisit if a deployment ever needs the catalog closed. |
 
 ## Trust model
 
 | Actor | Verified | Trusted | Must never be able to cause |
 |---|---|---|---|
-| Data consumer | Query syntax, size caps, parameter ranges; on a commercial deployment, the presented credential against the mirrored key set (REQ-50) | Nothing | Crash/wedge the process, corrupt another stream, bypass operator caps (REQ-21); on a commercial deployment, reach a gated route without a key that covers it (INV-14), or learn from a completed credential verdict or keyless metrics which key ids exist (INV-39; authorize-on-miss residual: GAP-32) |
+| Data consumer | Query syntax, size caps, parameter ranges; on a commercial deployment, the presented credential against a grant the control plane issued for it (REQ-50) | Nothing | Crash/wedge the process, corrupt another stream, bypass operator caps (REQ-21); on a commercial deployment, reach a gated route without a key that covers it (INV-14), or learn from a completed credential verdict or keyless metrics which key ids exist (INV-39; accepted cache-membership residual: GAP-32) |
 | Archival worker | Response signature (when enabled, REQ-43); response size cap; result range plausibility | Data content within its signed response | Process crash, unbounded memory, permanently poisoning the worker pool (penalties decay, REQ-41) |
 | Assignment publisher | Transfer integrity only — structural validity is currently **trusted, not verified** (ADR-002, GAP-1) | Artifact correctness | *Intent:* crash or false readiness via a corrupt artifact (REQ-26) — presently not enforced |
 | Real-time source | Streamed success data and public headers; errors normalized by ADR-011 | Data content, conflict responses | Stalling a client past bounded deadlines (REQ-22) |
 | Chain RPC | Nothing beyond transport | Status values | Any effect on data serving — status only (REQ-25) |
-| Control plane | Transport integrity and feed-envelope well-formedness; an unparseable key record is fail-closed, never dropped (INV-6) | The key set it publishes: status, scopes, expiry, and the secret digest | Admit a request the published key set does not cover; open the data API by going silent — an outage freezes the snapshot, it never empties it (REQ-54, FM table) |
+| Control plane | Transport integrity and answer well-formedness; the Portal authenticates *itself* by signature (ADR-018) but authenticates the control plane only by the transport; an unreadable answer is fail-closed, never guessed at (INV-6) | Every authorization answer it gives: the grant's claims and the lifetimes it set for them | Admit a credential it denied; hold a grant past P-GRANT-MAX-LIFETIME however long a lifetime it asked for. It *can* close the data API by going silent, for uncached credentials at once and for cached ones at `expires_at` — the direction an outage fails is availability, deliberately (REQ-54, FM table) |
 | Operator | Config validity at startup | Fully | Configure a commercial block that silently serves everything (REQ-56) |
 
 ## Lifecycle at a glance
@@ -103,6 +105,7 @@ status**. Worker-health bookkeeping is in-memory only and resets on restart.
 - **Request lifecycle:** *authorize, where the route is gated (REQ-50)* → validate →
   clamp to operator bounds → route by range → serve from one source → end (complete,
   empty, or truncated) → client resumes (REQ-2).
-- **Process lifecycle:** start → fetch catalog + first assignment *(+ mirror the key set,
-  where commercial)* → ready → serve ⟲ refresh world view → SIGTERM → advertise
-  not-ready, drain two-phase (REQ-24) → exit.
+- **Process lifecycle:** start → fetch catalog + first assignment → ready → serve ⟲
+  refresh world view → SIGTERM → advertise not-ready, drain two-phase (REQ-24) → exit.
+  Commercial configuration adds nothing here: authorization state is learned from the
+  requests that need it, so there is no key bootstrap between start and ready (LIV-5).

--- a/spec/02-requirements.md
+++ b/spec/02-requirements.md
@@ -357,100 +357,130 @@ delaying or failing data serving.
 ## Commercial access control (50–56)
 
 This band applies only to a Portal the operator has configured commercially (REQ-56).
-On any other deployment every requirement here is vacuous: there is no gate, no key set,
-and no control-plane dependency. Admission decided here is binary — it never shapes how
-much capacity an admitted request may consume (NG2).
+On any other deployment every requirement here is vacuous: there is no gate, no grant
+cache, and no control-plane dependency. Admission decided here is binary — it never shapes
+how much capacity an admitted request may consume (NG2).
 
 **REQ-50 — Gated routes require a valid key.** [MUST]
 On a commercial deployment, every request to a gated route (DEF-19) is authorized before
-any other work: the presented credential (DEF-16) must resolve to a key record (DEF-17)
-that authenticates, is active, is unexpired, and covers this portal and the requested
-dataset. A request that fails any of these is refused in the DEF-10 taxonomy and reaches
-no handler or serving dependency. OP-11 may make its one declared control-plane lookup on
-a snapshot miss, and may canonicalize a dataset only after the credential has
+any other work: the presented credential (DEF-16) must be covered by a usable grant
+(DEF-17) — one the control plane issued for that exact credential, that has not passed
+its hard expiry, and whose claims cover this portal and the requested dataset. A request
+that fails any of these is refused in the DEF-10 taxonomy and reaches no handler or serving
+dependency. OP-11 may make its one declared control-plane exchange when the grant cache
+holds no usable grant, and may canonicalize a dataset only after the credential has
 authenticated and only when its dataset scope requires that name (INV-14).
 *Acceptance:* against a gated route, a request with no credential, an unparseable token,
-an unknown key id, a wrong secret, a revoked key retaining its digest, a digestless
-tombstone, an expired key, a key scoped to another portal, and a key scoped to another
-dataset each receive the refusal ADR-017 binds to it; no serving-dependency stub records a
-call for any of them; only a snapshot miss may call the DC-8 lookup, and only an
-authenticated dataset-scoped case may canonicalize the dataset. A valid unscoped key is
-served exactly as the same request is served on a non-commercial deployment.
+an unknown key id, a wrong secret, a revoked key, an expired key, a key scoped to another
+portal, and a key scoped to another dataset each receive the refusal ADR-017 binds to it;
+no serving-dependency stub records a call for any of them; the control-plane stub records
+at most one exchange per request and none at all for a cache hit or a token outside the
+grammar; only an authenticated dataset-scoped case may canonicalize the dataset. A valid
+unscoped key is served exactly as the same request is served on a non-commercial
+deployment.
 
-**REQ-51 — Gate scope is an operator choice with a closed set of modes.** [MUST]
-The operator selects which surface requires a key: `data` gates block delivery, queries,
-and block lookups while leaving metadata public; `all` additionally gates every route
-that describes the Portal or its datasets. Readiness, metrics, and the served API schema
-are never gated under either mode. Because metrics are client-readable, their public
-families never expose dataset identities under `all`, nor any internal authorization
-reason or lookup detail beyond the client-visible wire outcome under either mode
-(OB-12/13). An unrecognized mode is a startup error, never a fallback to the more
-permissive one.
-*Acceptance:* under `data`, a keyless metadata read succeeds and a keyless stream is
-refused; under `all`, both are refused; under both, `/ready`, `/metrics` and the API
-schema answer without a credential. A route added to the surface without being
-classified fails the build rather than defaulting to ungated. A keyless scrape under
-`all` names no dataset of the served catalog in any series or label; and under either
-mode, two keyless scrapes bracketing each case of REQ-50's corpus differ only in ways
-that case's own response already disclosed — no series distinguishes the four
-`invalid_credential` reasons from each other, nor a snapshot hit from an
-authorize-on-miss.
+**REQ-51 — The gated surface is fixed, and every route states whether it is in it.** [MUST]
+Block delivery, queries and block lookups require a credential. Everything else — the
+catalog, per-dataset metadata and state, heads and heights, the worker and debug lookups,
+readiness, metrics and the served API schema — answers without one, on every deployment
+(NG8). A route is in one set or the other because it says so at the point it is declared;
+there is no default, so a route that says nothing does not compile. Because metrics are
+client-readable, their public families never expose an internal authorization reason or
+exchange detail beyond the client-visible wire outcome (OB-12/13).
+*Acceptance:* a keyless metadata read succeeds and a keyless stream is refused;
+`/ready`, `/metrics` and the API schema answer without a credential. A route added
+without stating which set it is in fails to compile. Two keyless scrapes bracketing each
+case of REQ-50's acceptance corpus differ only in ways that case's own response already
+disclosed — no series distinguishes the reasons sharing `invalid_credential` from each
+other, and none separates an unknown key id from a known one presented with a wrong
+secret.
 
 **REQ-52 — Credential presentation.** [MUST]
-A credential is presented either as an HTTP bearer token or as a query parameter, the
-latter because some browser transports cannot set headers. Only tokens in a form the
-control plane can actually mint are accepted; anything else is refused as an invalid
-credential without being looked up (INV-39). The secret itself is never logged, stored,
-echoed, or compared other than as a digest, in constant time (INV-38).
-*Acceptance:* a valid key is accepted through either channel and refused when its token
-is truncated, over-long, carries an unknown prefix, or contains bytes outside the minted
-alphabet; no log record, metric label, error body, or stored value produced by any of
-these contains the secret.
+A credential is presented as an HTTP bearer token, and by no other channel. In particular
+it is never read from the query string: that puts the secret in a URL, and a URL is
+recorded by browser history, by `Referer` on every outbound request from a page, and by
+the access log of every intermediary in front of the Portal — none of which this system
+can see, reach, or clear. Only tokens in a form the control plane can actually mint are
+accepted; anything else is refused as an invalid credential without being exchanged
+(INV-39). The secret leaves the process in exactly one direction — the DC-8 exchange that
+asks the authority about it — and nowhere else. Before that decision it may exist only in
+the request-local exchange input DEF-16 bounds; it is never logged, placed in shared state,
+echoed, or held past that call, and is matched against the grant cache only as a
+fingerprint, in constant time (INV-38).
+*Acceptance:* a valid key is accepted through the header and refused when its token is
+truncated, over-long, carries an unknown prefix, or contains bytes outside the minted
+alphabet; the same token in a query parameter is not a credential at all and the request
+is refused as though none were presented; no log record, metric label, error body, shared
+or persisted value, or outbound request other than the exchange itself, produced by any
+of these, contains the secret.
 
 **REQ-53 — The ladder has a fixed precedence.** [MUST]
-Authorization evaluates in one order — credential present → key known → secret matches →
-not revoked → not expired → portal allowed → dataset allowed — and reports the first rung
-that fails. A record carrying no secret digest — including a tombstone — cannot establish
-that the caller holds the secret, so it fails at `secret matches` as BAD-CREDENTIAL rather
-than disclosing the later revoked rung. Absent scope means unrestricted (a key with no
-portal list is valid on any portal; a key with no dataset list covers every dataset); an
-empty scope list means nothing, not everything. A dataset-scoped key may not use a route
-that names no dataset.
-*Acceptance:* a key failing several rungs at once reports the earliest — a digestless
-tombstone that is also revoked reports the secret rung, not the revoked one; a null scope
-list admits where an empty list refuses; a dataset-scoped key is refused on a route with
-no dataset; scope matching is exact, with aliases resolved to canonical names first, and
-never by prefix or wildcard. The no-dataset case makes the SQL surface unusable for every
-dataset-scoped key, which is fail-closed but may not be the intent — OQ-13.
+Authorization evaluates in one order — credential present → credential well-formed → key
+authenticates → not revoked → not expired → portal allowed → dataset allowed — and reports
+the first rung that fails. The Portal owns the first two rungs and the last; the four in
+between are the control plane's answer to the exchange, and a denial names the earliest of
+them that failed. The split does not loosen the order: a well-formed credential is
+exchanged before anything else is decided about it, and dataset scope is read from the
+grant the exchange returned, so a key that is both revoked and scoped elsewhere reports
+revoked. Absent scope means unrestricted (a key with no portal list is valid on any portal;
+a key with no dataset list covers every dataset); an empty scope list means nothing, not
+everything. A dataset-scoped key may not use a route that names no dataset. Claim semantics
+are versioned: a grant whose claim vocabulary this build does not fully understand admits
+nothing rather than being read for the parts it recognizes (REQ-54).
+*Acceptance:* a key failing several rungs at once reports the earliest — a revoked key
+scoped to another dataset reports revoked, and one that is both revoked and expired reports
+revoked; a null scope list admits where an empty list refuses; a dataset-scoped key is
+refused on a route with no dataset; scope matching is exact, with aliases resolved to
+canonical names first, and never by prefix or wildcard. The no-dataset case makes the SQL
+surface unusable for every dataset-scoped key, which is fail-closed but may not be the
+intent — OQ-13.
 
-**REQ-54 — Fail closed on the key, fail static on the feed.** [MUST]
-A key the Portal cannot positively establish as valid is refused. A control-plane outage
-does not invalidate any snapshot hit: the last good snapshot keeps answering. A snapshot
-miss that cannot be resolved because the lookup budget is exhausted is refused as
-OVERLOADED; one that cannot be resolved because the lookup failed is refused as
-UPSTREAM-FAILURE. Neither is mislabeled as a non-retryable bad credential. A malformed or
-unrecognized feed record becomes a non-authenticating tombstone rather than being skipped.
-Where a snapshot has never been established, an enforcing Portal declines readiness
-instead of serving refusals (INV-31).
-*Acceptance:* with the control plane stopped, previously valid keys keep being served and
-previously revoked keys keep being refused; a fresh valid key absent from the snapshot
-receives retryable UPSTREAM-FAILURE rather than BAD-CREDENTIAL; a snapshot miss denied by
-the local lookup budget receives OVERLOADED with `Retry-After`; a record carrying a status
-this build does not recognize is refused; a Portal started with the control plane already
-unreachable never reports ready while enforcing.
+**REQ-54 — Fail closed on the credential; bounded, explicit grace on the dependency.** [MUST]
+A credential the Portal cannot positively establish as authorized is refused. Positive
+establishment is a grant (DEF-17) the control plane issued for that exact credential, still
+inside its hard expiry, whose claims this build understands and which covers this portal
+and the requested dataset. Around that, four rules:
+
+- **Soft staleness costs nothing.** Past a grant's `refresh_after` the Portal re-exchanges,
+  and a request arriving while that runs is still served on the grant in hand.
+- **A denial lands at once.** An authoritative denial replaces the cached grant the moment
+  it arrives, whatever the grant's remaining lifetime.
+- **A dependency failure buys time, and only to `expires_at`.** If the re-exchange cannot
+  run or cannot answer, the existing grant keeps serving until its hard expiry and no
+  further. That window is the entire outage grace; the control plane sizes it and the Portal
+  caps what it will accept at P-GRANT-MAX-LIFETIME. Two deadlines rather than one is what
+  buys the grace at all — OQ-14 records what collapsing them would cost.
+- **A missing answer is never a verdict.** With no usable grant, an exchange the local budget
+  refuses is OVERLOADED and one that failed, timed out, or returned something unusable is
+  UPSTREAM-FAILURE. Neither is BAD-CREDENTIAL: the same credential may succeed a second later.
+
+Readiness is conditioned on none of this. A Portal that has never reached the control plane
+is ready and refuses retryably (INV-31): every replica shares one authority, so withholding
+readiness on its account empties the fleet in exactly the situation nobody can recover from.
+*Acceptance:* with the control plane stopped, a credential whose grant is inside its hard
+expiry keeps being served and one whose grant has passed it is refused as UPSTREAM-FAILURE,
+never as BAD-CREDENTIAL; a key revoked while the control plane is healthy stops being served
+no later than LIV-13's bound; with no usable grant, an exchange denied by the local budget
+receives OVERLOADED with `Retry-After`, while the same denial during renewal leaves a usable
+grant serving and increments the grace signal; a grant offering a lifetime beyond
+P-GRANT-MAX-LIFETIME is honored only to the cap; a grant carrying a claims version this
+build does not recognize admits nothing; a Portal started with the control plane already
+unreachable reports ready and refuses retryably.
 
 **REQ-55 — Shadow enforcement.** [MUST]
 The operator may attempt the full ladder without acting on it: every available verdict is
-recorded in protected structured observability, and a snapshot miss whose lookup cannot
-produce a verdict is recorded there as indeterminate. Every request is admitted regardless
-— including requests presenting no credential at all. Shadow mode never refuses, never
-withholds readiness for a reason only enforcement would care about, and never projects
-the would-be verdict onto the keyless metrics surface (OB-12).
+recorded in protected structured observability, and an exchange that cannot produce a
+verdict is recorded there as indeterminate. Every request is admitted regardless —
+including requests presenting no credential at all, which are not exchanged, there being
+nothing to exchange. Shadow mode never refuses and never projects the would-be verdict
+onto the keyless metrics surface (OB-12). It is not free: shadow traffic drives real
+exchanges against the same budgets enforcement would use, which is the point — the load a
+cutover will produce is measured before it decides anything.
 *Acceptance:* in shadow mode every request of REQ-50's acceptance corpus is served, each
-having recorded the verdict enforcement would have returned or the lookup outcome that
+having recorded the verdict enforcement would have returned or the exchange outcome that
 prevented one; valid, invalid, and indeterminate cases all increment the same neutral
-public shadow counter; a shadow-mode Portal whose key set has never synced still reports
-ready.
+public shadow counter; the control-plane stub's ledger shows shadow mode exchanging on
+the same cache-miss rule as enforcement.
 
 **REQ-56 — Open by default, never open by accident.** [MUST]
 Absent commercial configuration the Portal authorizes nothing, opens no control-plane
@@ -477,10 +507,14 @@ Deliberately left open — tests and clients must not pin these:
 - Worker identity, ranking internals, and how throughput is measured (REQ-41 pins
   outcomes, not scores).
 - The shape of a key id or secret beyond the acceptance grammar (REQ-52), and the
-  control plane's own issuance, rotation, and organization model — the Portal mirrors a
-  key set, it does not define one.
-- Which internal rejection reason underlies a given `invalid_credential` response: the
-  three are deliberately indistinguishable to a client (INV-39, ADR-017).
+  control plane's own issuance, rotation, and organization model — the Portal asks about
+  one credential at a time and defines none of them.
+- The wire form of a grant. The Portal reads its claims and lifetimes; whether it arrives
+  as a signed capability or a typed answer is free while it never leaves the process. The
+  request signature that fetches it is *not* free: ADR-018 fixes its headers, canonical
+  bytes, algorithm, and encodings for the independently implemented verifier.
+- Which internal rejection reason underlies a given `invalid_credential` response: they
+  are deliberately indistinguishable to a client (INV-39, ADR-017).
 
 ## Open questions
 
@@ -494,11 +528,16 @@ Deliberately left open — tests and clients must not pin these:
 | OQ-7 | A stream body without a first block silently defaults to block 0, while the API description marks it required — reject instead? | REQ-7 | portal team |
 | OQ-9 | Ratify a global P-BUFFERED-BYTES-BUDGET and its accounting/admission semantics. | REQ-27, GAP-17 | portal team |
 | OQ-10 | Ratify the draft SLO target parameters and their benchmark gating policy. | 11 SLO table | portal team |
-| OQ-12 | Ratify P-KEY-SNAPSHOT-MAX-AGE and what an enforcing Portal does once its key set is older than it — decline readiness (the ADR-013 answer for assignments) or keep serving and alarm only? Revocation latency and a control-plane outage pull in opposite directions. | REQ-54, GAP-31, ADR-016 | portal team |
 | OQ-13 | Should a dataset-scoped key be able to use the SQL surface, which names its datasets in the body rather than the path? Today such a key is refused there outright (REQ-53), which is fail-closed but makes the surface unusable for exactly the customers most likely to be scoped. | REQ-53, OP-10 | portal team |
 | OQ-11 | REQ-40's fleet-cutover premise assumes workers also honor `effective_from`; workers currently apply assignments immediately (recorded in the worker suite's open questions, `worker-rs/spec/02`), so each publication opens a window of routing to reshuffling workers (transient `no_workers`/`retries_exhausted` churn). Size the window for worker convergence, or have workers delay too? | REQ-40, REQ-41 | network team |
+| OQ-14 | Should a grant carry two deadlines or one? REQ-54 takes `refresh_after` + `expires_at` because one value cannot both keep refreshes off the latency path and bound how long a stale answer is acted on. Collapsing them is simpler and makes convergence exact, at the cost of a synchronous exchange every period and no outage grace at all. | REQ-54, DC-8, LIV-13 | portal + control-plane teams |
+| OQ-15 | Ratify P-GRANT-MAX-LIFETIME and the exchange budget (P-GRANT-EXCHANGE-RATE, P-GRANT-EXCHANGE-INFLIGHT, P-GRANT-CACHE-CAPACITY). The lifetime cap is the fleet's worst-case stale-authorization window and the budget decides whose new key gets turned away under a flood (HZ-10); neither has an observed value to reason from yet. | REQ-54, DC-8, HZ-10, HZ-13 | portal team |
+| OQ-16 | Does anything need revocation faster than LIV-13's bound? If so it is a push invalidation channel, not a shorter refresh interval — shortening the interval multiplies exchange traffic across the whole working set to shorten one key's window. Adding the channel is a second distributed mechanism and should follow a stated freshness requirement, not precede it. | LIV-13, DC-8 | portal + control-plane teams |
 
 Closed: **OQ-6** (should the clamp-bypassing debug stream variant be exposed unconditionally,
 or gated behind an operator flag?) — resolved by ADR-014: the variant is gated behind an
-operator flag and disabled by default (GAP-21 until implemented). OQ numbers are never
-recycled.
+operator flag and disabled by default (GAP-21 until implemented). **OQ-12** (what does an
+enforcing Portal do once its key set is older than its staleness bound?) — moot since
+ADR-016's 2026-08-07 revision: there is no mirrored key set to age. Its answer survives as
+the reasoning REQ-54 and INV-31 still rest on — readiness never turns on the control plane's
+availability, because every replica shares one authority. OQ numbers are never recycled.

--- a/spec/03-data-model.md
+++ b/spec/03-data-model.md
@@ -104,6 +104,8 @@ additional public values.
 | `authentication_error` | no | The credential is absent, unreadable, or does not authenticate (ADR-017) |
 | `permission_error` | no | The credential authenticated but does not cover this request (ADR-017) |
 
+Both credential types answer 403, so the status never distinguishes them (ADR-017).
+
 | Spec outcome | Wire `type` / `code` | Meaning |
 |---|---|---|
 | BAD-REQUEST | `invalid_request_error` / `malformed_request` or `method_not_allowed` | DEF-7 violation, bad parameter, or a verb the surface does not serve |
@@ -117,7 +119,7 @@ additional public values.
 | WORKER-FAILURE | `api_error` / `worker_failure` | Worker results violated an owned integrity invariant and rerouting was exhausted (DC-1) |
 | INTERNAL | `api_error` / `internal_error` or `unclassified` | Portal invariant failed or a failure escaped classification |
 | NO-CREDENTIAL | `authentication_error` / `missing_credential` | A gated route was reached with no credential (REQ-50) |
-| BAD-CREDENTIAL | `authentication_error` / `invalid_credential` | The token is unparseable, names no known key, its secret does not match, or the held record has no digest — one code for all four, by design (INV-39) |
+| BAD-CREDENTIAL | `authentication_error` / `invalid_credential` | The token is unparseable, names no known key, or its secret does not match — one code for all three, by design (INV-39) |
 | REVOKED | `authentication_error` / `revoked_credential` | The key authenticated but the control plane has withdrawn it |
 | EXPIRED | `authentication_error` / `expired_credential` | The key authenticated but its expiry has passed |
 | WRONG-PORTAL | `permission_error` / `portal_not_allowed` | The key is scoped to portals not including this one |
@@ -141,52 +143,63 @@ Every definition in this section is vacuous on a Portal with no commercial
 configuration: nothing constructs these objects and no route consults them (REQ-56).
 
 **DEF-16 — Credential.** What a client presents: the pair (**key id**, **secret**). The
-key id is public and identifies a key record; the secret is proof of holding it. The
-Portal handles the secret only as a digest — it is reduced to one at the moment the
-request is parsed and the original is discarded, so no later stage can log, store, or
-echo what it never received (INV-38). A credential is *well-formed* iff it is presented
-through a channel IB-9 names and both segments fall within the grammar the control plane
-can mint; anything else is an invalid credential and is refused as BAD-CREDENTIAL without
-a lookup. NO-CREDENTIAL is reserved for a gated request that presents neither channel.
+key id is public and identifies a key; the secret is proof of holding it. The Portal
+reduces the presented token to a **fingerprint** — a digest over the *whole* credential,
+id and secret together — at the moment the request is parsed. The raw credential remains
+only as request-local exchange input: a cache or negative-answer hit destroys it
+immediately; on a miss, one request moves it into the single in-flight DC-8 exchange and
+every coalesced waiter destroys its copy. The exchange owner destroys it on completion,
+timeout, or cancellation. It is never shared or cached; only the fingerprint is. A
+credential is *well-formed* iff it is presented through the channel IB-9 names and both
+segments fall within the
+grammar the control plane can mint; anything else is an invalid credential and is refused
+as BAD-CREDENTIAL without being exchanged. NO-CREDENTIAL is reserved for a gated request
+that presents no credential at all.
 
-**DEF-17 — Key record.** The control plane's statement about one key: (key id; **status**
-∈ {active, revoked}; **sequence**, a feed position that only ever moves forward; an
-optional secret digest; **portal scope**; **dataset scope**; optional expiry). A usable
-active record carries a digest. A record without one cannot prove which caller holds its
-secret and therefore authenticates nobody; on the request path it maps to BAD-CREDENTIAL,
-not the more specific REVOKED outcome (REQ-53, INV-39). A scope is either
-*absent*, meaning unrestricted, or a list matched exactly — an empty list therefore
-matches nothing, and the two are never conflated (REQ-53). A record whose status this
-build does not recognize, or which fails to parse while still naming its key, is not
-dropped: it becomes a **tombstone** — a record with no usable digest that authenticates
-nobody — because dropping it would leave an older, possibly usable version of that key
-in service (REQ-54).
+**DEF-17 — Grant.** The control plane's answer to one exchange: a short-lived
+authorization for one credential, carrying (**claims version**; the **subject** key id;
+**dataset scope**; **`refresh_after`**; **`expires_at`**). Portal scope is not a claim the
+Portal evaluates — the exchange knows which portal is asking (ADR-018) and a key that does
+not cover it is denied rather than granted. A scope is either *absent*, meaning
+unrestricted, or a list matched exactly — an empty list therefore matches nothing, and the
+two are never conflated (REQ-53). The two lifetimes are the control plane's to choose and
+the Portal's only to cap (P-GRANT-MAX-LIFETIME): `refresh_after` is when the answer should
+be renewed, `expires_at` when it may no longer be acted on. A grant whose claims version
+this build does not fully understand is unusable rather than partly usable — reading a
+newer vocabulary for the parts it recognizes is how an added restriction becomes an
+accidental permission (REQ-54).
 
-**DEF-18 — Key snapshot.** The Portal's in-memory mirror of the control plane's key set:
-(records by key id; a **cursor**, the feed position read so far; an **epoch**, the
-identity of the feed's history; a **generation**, incremented by every wholesale
-replacement). The snapshot is established by reading the feed from its start and kept
-current by cursor-paged deltas (DC-8). A delta applies a record only if its sequence
-exceeds the held one. An epoch change, or a feed head below the held cursor, means the
-history the cursor refers to no longer exists, and the snapshot is rebuilt from the start
-rather than advanced. Nothing about the snapshot survives restart (NG5).
+A **denial** is the exchange's other authoritative answer: the earliest ladder rung that
+failed (REQ-53), which the Portal maps to its DEF-10 row. A denial is not a grant and is
+never cached as one; it is remembered only as a negative answer, briefly and under a bound
+(DC-8).
 
-**DEF-19 — Route class and gate scope.** Every route carries exactly one class: **data**
-(delivers blocks, query results, or block lookups), **metadata** (describes the Portal or
-its datasets), or **always-open** (readiness, metrics, the served API schema). The
-operator's **gate scope** — `data` or `all` — selects which classes require a credential:
-`data` gates the data class, `all` gates data and metadata. Always-open is gated under
-neither (REQ-51). The classification is a property of the route, not of the request.
+**DEF-18 — Grant cache.** The Portal's bounded in-memory map from credential fingerprint
+(DEF-16) to grant, holding at most P-GRANT-CACHE-CAPACITY entries. It is keyed on the whole
+credential and never on the key id: an entry reached by id alone would admit the next caller
+to name that id without proving it holds the secret. Nothing populates it but exchanges the
+requests themselves triggered — there is no bootstrap, no background fill, and no
+authorization state a replica holds that some request did not put there. Nothing survives
+restart (NG5), and a cold replica is not a degraded one: it is one whose first request per
+credential costs an exchange.
 
-**DEF-20 — Authorization verdict.** The outcome of evaluating DEF-16 against DEF-17 for
-one request: **admit**, or **reject** carrying the first failed rung of REQ-53's ladder.
-The verdict is a pure function of (credential, key record, portal identity, requested
+**DEF-19 — Gated route.** A route that requires a credential on a commercial deployment:
+those delivering blocks, query results, or block lookups. Every other route answers
+without one (NG8). Which it is, is a property of the route rather than of the request or
+of the configuration, and is stated where the route is declared — a route that states
+neither does not compile (REQ-51).
+
+**DEF-20 — Authorization verdict.** The outcome of evaluating DEF-16 against a grant or
+denial (DEF-17) for one request: **admit**, or **reject** carrying the first failed rung of
+REQ-53's ladder. The verdict is a pure function of (credential, grant or denial, requested
 dataset, current time) — it consults no capacity, no load, and no prior request (INV-15).
-A snapshot miss may fail before a verdict exists: lookup-budget exhaustion is OVERLOADED
-and lookup failure is UPSTREAM-FAILURE (DC-8), both retryable system outcomes rather than
-claims about the credential. A verdict is separately *acted on* or not, per the
+An exchange required because no usable grant exists may fail before a verdict: budget
+exhaustion is OVERLOADED and a failed, timed-out, or unreadable exchange is
+UPSTREAM-FAILURE (DC-8), both retryable system outcomes rather than claims about the
+credential. A renewal suppressed while its old grant remains usable does not replace that
+grant's verdict. A verdict is separately *acted on* or not, per the
 enforcement mode (REQ-55): shadow mode discards a verdict when one exists, and records an
-indeterminate lookup when one does not. The rung is the internal reason; what reaches the
+indeterminate exchange when one does not. The rung is the internal reason; what reaches the
 client is the DEF-10 row it maps to, which is deliberately coarser (INV-39).
 
 ## Shared state (the frame of the stateless shape)
@@ -202,9 +215,9 @@ in-memory and reset by restart: (a) the applied artifact (DEF-4) and catalog sna
 (b) the **worker health map** — per worker: open-lease count, error/timeout cooldown
 marks, backoff-until, throughput estimate; (c) the **congestion window** (DEF-13);
 (d) the **stream census** (count of active streams, monotone stream sequence); and, on a
-commercial deployment, (e) the key snapshot, negative-answer cache, and lookup limiters
-(DEF-18, DC-8). Shared adaptive state may influence *admission, worker choice, coverage
-extent, and timing* — never record content (INV-28).
+commercial deployment, (e) the grant cache, the negative-answer cache, and the exchange
+limiters (DEF-18, DC-8). Shared adaptive state may influence *admission, worker choice,
+coverage extent, and timing* — never record content (INV-28).
 
 **DEF-13 — Congestion window.** An adaptive bound on concurrent chunk-body downloads,
 within [P-CONGESTION-MIN-WINDOW, P-CONGESTION-MAX-WINDOW]; grows additively on success,
@@ -217,7 +230,9 @@ snapshots (staleness: 05 §caches).
 
 **DEF-15 — Configuration.** The operator-supplied object binding every `P-*` parameter
 ([15-parameters.md](15-parameters.md)) plus identity (peer key), upstream endpoints,
-and the dataset map. Static per process lifetime.
+and the dataset map; on a commercial deployment it also binds the control-plane endpoint,
+the enforcement mode, and the signing identity DC-8 authenticates with (ADR-018). Static
+per process lifetime.
 
 ## Input events (background, not client-driven)
 
@@ -226,7 +241,10 @@ and the dataset map. Static per process lifetime.
 | Artifact publication | New assignment artifact (DEF-4) | Routing world changed | Polled every P-ASSIGNMENT-REFRESH; at-least-once; deduplicated by identifier |
 | Catalog update | Dataset catalog/metadata | Served-dataset set changed | Polled every P-DATASETS-REFRESH; last-write-wins |
 | Chain status update | Epoch, stake, compute units, worker registry | Accounting/status only | Polled every P-CHAIN-REFRESH; never affects serving (REQ-25) |
-| Key-set delta | Key records past the held cursor (DEF-17) | The served key set changed | Polled every P-KEY-SYNC-INTERVAL; ordered by sequence; applied only forward; epoch change forces a rebuild (DC-8) |
+
+Authorization is deliberately absent from this table. Nothing pushes key state at the
+Portal and no loop polls for it: a grant exists because a request asked for one (DC-8),
+which is what keeps a replica's authorization state the size of its own traffic.
 
 ## Operation summary
 
@@ -263,7 +281,7 @@ Semantics in [04-operations.md](04-operations.md).
 | hotblocks | Real-time source (DC-4) |
 | `x-sqd-data-source` | Serving source marker (DEF-6) |
 | commercial block / gate | Commercial configuration, authorization gate (REQ-56, DEF-19) |
-| snapshot store, feed cursor/epoch | Key snapshot (DEF-18) |
 | ladder, rung | REQ-53's ordered precedence; the rung is DEF-20's internal reason |
 | `log_only` / `enforce` | Shadow and enforcing modes (REQ-55) |
-| authorize-on-miss | Bounded direct lookup for a key absent from the snapshot (DC-8) |
+| exchange | The one control-plane call: credential in, grant or denial out (DC-8) |
+| fingerprint | The digest of a whole credential that keys the grant cache (DEF-16, DEF-18) |

--- a/spec/04-operations.md
+++ b/spec/04-operations.md
@@ -39,8 +39,8 @@ are new requests).
 *Pre.* In order: (1) resolve alias → dataset, else NOT-FOUND; (2) parse tuning
 parameters, reject zero/unparsable as BAD-REQUEST; (3) decode and validate the query
 per DEF-7, else BAD-REQUEST — **no serving-dependency call happens before validation
-completes**; OP-11's bounded authentication lookup may already have occurred on a
-snapshot miss (INV-10/14); (4) clamp tuning to operator caps (INV-11); (5) admission: if
+completes**; OP-11's bounded credential exchange may already have occurred for a
+credential with no usable grant (INV-10/14); (4) clamp tuning to operator caps (INV-11); (5) admission: if
 the stream census is at P-MAX-STREAMS or congestion utilization exceeds
 P-HEADROOM-THRESHOLD, refuse OVERLOADED with a retry hint (INV-12) — admission is checked
 before any upstream work.
@@ -123,12 +123,11 @@ of the conformance surface beyond existence and freshness.
 
 *Effect.* Pure read of local state — never calls a dependency. *Post.* Ready iff:
 an artifact is applied ∧ worker connectivity ≥ P-READY-CONNECTION-RATIO ∧ not shutting
-down ∧ (on a commercial deployment that is *enforcing*, a key snapshot has been
-established — REQ-54) (INV-31). Shadow enforcement adds no such condition: it admits
-regardless of what the snapshot knows, so withholding readiness for it would cause the
-outage shadow mode exists to avoid (REQ-55). Intent (ADR-013 ⚠): also degrade when
-artifact age > P-ASSIGNMENT-MAX-AGE; the key-set analogue,
-P-KEY-SNAPSHOT-MAX-AGE ⚠, is open on OQ-12.
+down (INV-31). Commercial configuration adds no conjunct in either enforcement mode: there
+is nothing to load before serving, and a control plane that is unreachable is answered with
+retryable refusals, not by leaving rotation — every replica shares one authority, so a
+readiness rule on its account would empty the fleet at the worst possible moment (REQ-54).
+Intent (ADR-013 ⚠): also degrade when artifact age > P-ASSIGNMENT-MAX-AGE.
 
 ## OP-9 — Metrics read
 
@@ -148,30 +147,36 @@ gated route (DEF-19) of a commercial deployment, and does not exist at all on an
 (REQ-56). It is listed as an operation because it has a contract, a failure mapping, and
 tests of its own.
 
-*Pre.* The route's class is gated under the operator's gate scope. An ungated route skips
-this operation entirely and costs exactly what it costs on a non-commercial deployment —
-the credential is not read and the dataset is not resolved.
+*Pre.* The route is a gated one (DEF-19). An ungated route skips this operation entirely
+and costs exactly what it costs on a non-commercial deployment — the credential is not
+read and the dataset is not resolved.
 
-*Effect.* Reads the key snapshot (DEF-18). On a snapshot miss, and only then, it may
-consult the control plane directly (DC-8), under that contract's rate and concurrency
-bounds; a lookup it is not allowed to make is an immediate OVERLOADED outcome, not a
-delay or a BAD-CREDENTIAL claim, and a failed lookup is UPSTREAM-FAILURE. It resolves the
-requested dataset to a canonical name **only** for a key that is dataset-scoped and has
-already authenticated — the one rung that needs it — so an unauthenticated request cannot
-buy that work (INV-14). No serving dependency is consulted, and no shared state is
-mutated beyond the snapshot's own caches and authorization observability.
+*Effect.* Checks the presented credential's grammar, then looks up its fingerprint in the
+grant cache (DEF-18). A grant that has not passed `refresh_after` answers locally and
+consults nothing. Otherwise, and only then, it exchanges at the control plane (DC-8) under
+that contract's rate, concurrency and single-flight bounds. With no usable grant, an
+exchange it is not allowed to make is an immediate OVERLOADED outcome, not a delay and not
+a BAD-CREDENTIAL claim, and a failed one is UPSTREAM-FAILURE. Past `refresh_after` but
+inside `expires_at`, the existing grant answers whether the renewal runs or its local
+budget is exhausted; past `expires_at` the request waits only for an exchange already
+admitted by the limiter, and is refused immediately rather than queued when no permit is
+available. It resolves the requested dataset to a canonical name **only** for a key that
+is dataset-scoped and has already authenticated — the one rung that needs it — so an
+unauthenticated request cannot buy that work (INV-14). No serving dependency is consulted,
+and no shared state is mutated beyond the grant cache, its negative answers, and
+authorization observability.
 
 *Post.* Admit, and the request proceeds to its operation unchanged; reject with the first
 failed rung of REQ-53's ladder, mapped to its DEF-10 row; or fail before a verdict with
-OVERLOADED/UPSTREAM-FAILURE when a required lookup could not run or answer. Any such
+OVERLOADED/UPSTREAM-FAILURE when a required exchange could not run or answer. Any such
 outcome is terminal while enforcing: no handler runs, no stream slot is taken, and no
 serving dependency is called. Under shadow enforcement the verdict or indeterminate
-lookup outcome is recorded and the request proceeds regardless (REQ-55).
+exchange outcome is recorded and the request proceeds regardless (REQ-55).
 
 *Timing.* The rejection path is O(1) in request size and consults no dependency in the
-snapshot-hit and syntactically-invalid cases (PF-7). The evaluation itself is a pure
-function (INV-15); only snapshot-miss resolution may wait on its DC-8 deadline, and local
-lookup saturation refuses immediately as OVERLOADED rather than queuing.
+cache-hit and syntactically-invalid cases (PF-7). The evaluation itself is a pure
+function (INV-15); only a request with no usable grant waits on the DC-8 deadline, and
+local exchange saturation refuses immediately as OVERLOADED rather than queuing.
 
 ## Concurrency
 

--- a/spec/05-dependencies.md
+++ b/spec/05-dependencies.md
@@ -114,58 +114,72 @@ never delays or fails serving.
 *Role.* Sampled error/trace reports (P-ERROR-SAMPLE-RATE).
 *Contract.* Fire-and-forget; failure has no client-visible effect.
 
-## DC-8 — Control plane (key feed)
+## DC-8 — Control plane (credential exchange)
 
 Exists only on a commercial deployment (REQ-56); on any other the Portal opens no
 connection to it and this contract is vacuous.
 
-*Role.* Publishes the key set the Portal mirrors (DEF-17, DEF-18) and answers direct
-lookups for a single key; the source of every authorization decision (OP-11).
-*Call contract.* Two interactions, both authenticated with a portal-held service
-credential and neither following redirects — a redirected request carries that credential
-somewhere the operator did not configure, and a redirected key set is not the control
-plane's answer.
+*Role.* Answers one question — is *this* credential authorized here, and under what claims
+— and is the source of every authorization decision (OP-11). It publishes nothing and the
+Portal mirrors nothing.
 
-1. *Feed read* — a background loop only, never on a request path. Polls every
-   P-KEY-SYNC-INTERVAL, reading pages of at most P-KEY-PAGE-LIMIT records forward from
-   the held cursor with a per-page deadline P-KEY-FETCH-TIMEOUT. Ticks are serialized; a
-   slow drain never overlaps the next poll. One tick drains up to
-   P-KEY-MAX-PAGES-PER-TICK rather than applying exactly one page; a larger backlog
-   continues on the next tick, and the resulting convergence bound is LIV-13's function
-   of page count. A page that carries records without advancing the cursor, or a short
-   page whose cursor remains below the head the feed reports, is a broken answer, not an
-   empty one — it fails the tick.
-2. *Direct lookup (authorize-on-miss)* — on the request path, and only for a key the
-   snapshot does not hold, so a key minted seconds ago works before the next tick
-   (LIV-14). Bounded by P-KEY-RESOLVE-RATE and at most P-KEY-RESOLVE-INFLIGHT concurrent
-   calls; a negative answer is remembered for P-KEY-NEGATIVE-TTL across at most
-   P-KEY-NEGATIVE-CAPACITY entries. Every bound is a fail-*closed* bound: exceeding one
-   produces an immediate OVERLOADED response with a retry hint, never a delay or an
-   admission (HZ-10).
+*Call contract.* One interaction, the **exchange**: the presented credential (DEF-16) in,
+a grant or a denial (DEF-17) out. It runs on the request path, and only when the cache holds
+no *fresh* grant for that credential's fingerprint — after a token outside the grammar has
+already been refused, that means an unseen credential or one whose grant has passed
+`refresh_after`. Freshness governs when an exchange happens; usability — not past
+`expires_at` — governs whether the grant in hand may still answer while it does.
+
+- *Authenticated by signature.* Every request carries exactly one `X-Portal-Id`,
+  `X-Signature-Timestamp`, and `X-Signature`; the last covers ADR-018's canonical binding
+  under the Portal's configured Ed25519 identity. The control plane rejects absent,
+  repeated, or malformed signing headers, a portal with no matching active registered key,
+  and a timestamp whose absolute skew exceeds P-SIGNATURE-MAX-SKEW.
+- *No redirects.* A redirected exchange carries a client's credential somewhere the
+  operator did not configure, and its answer is not the control plane's.
+- *Deadline.* P-GRANT-EXCHANGE-TIMEOUT per call, strictly below P-CLIENT-TIMEOUT (ADR-010)
+  — a caller must never still be waiting on an exchange the Portal has stopped waiting for.
+- *Bounded, without shortening a live grant.* At most P-GRANT-EXCHANGE-RATE exchanges per
+  second and P-GRANT-EXCHANGE-INFLIGHT concurrent, with one *logically active* call per
+  fingerprint, so a burst on the same credential costs one exchange rather than one per
+  request. Each attempt owns a locally monotone generation in that fingerprint's
+  coordination state. Timing out or replacing an attempt retires its generation before a
+  successor starts; a late transport completion from a retired generation cannot mutate
+  either cache. The generation is local coordination metadata, not a grant field. A
+  denial is remembered for P-GRANT-NEGATIVE-TTL across at most P-GRANT-NEGATIVE-CAPACITY
+  entries. If no usable grant exists, a rate or in-flight bound produces an immediate
+  OVERLOADED response with a retry hint — never a queue or an admission (HZ-10). If a grant
+  remains inside `expires_at`, the same bound merely suppresses that renewal attempt: the
+  request is served on the grant and the skipped renewal is observed as grace-serving.
+- *Renewal is off the latency path.* A request arriving past `refresh_after` is served on
+  the grant in hand while the exchange runs; only a request with no usable grant waits for
+  one. Renewals are spread by up to P-GRANT-REFRESH-JITTER, so a cohort of grants issued
+  together does not come back together (HZ-12).
 
 *Error mapping.* No control-plane fault ever reaches a client as itself.
 
 | Fault | Own class / action |
 |---|---|
-| Feed unreachable, timeout, or non-success status | keep serving the established snapshot; alarm on age (OB-13). Never fails a request by itself (REQ-54) |
-| Feed envelope missing a required field | treat as a broken answer, not an empty page — fail the tick, keep the snapshot. A 200 from a wrong route or a half-deployed replica must not read as "the key set is now empty", which would quietly stop delivering revocations |
-| Record malformed but identifiable | tombstone that key (DEF-17): it stops authenticating, and the older version it replaces does not survive |
-| Record unidentifiable | fail the page; keep the snapshot |
-| Record status this build predates | tombstone — an unknown status is fail-closed by the same path as any other unusable record |
-| Epoch change, or reported head below the held cursor | the cursor's history is gone: rebuild the snapshot from the start rather than advance (DEF-18) |
-| Epoch change *mid-drain* | fail the tick; pages from two epochs compose into a snapshot of neither |
-| Lookup: key unknown | refuse the request (BAD-CREDENTIAL); remember the answer for P-KEY-NEGATIVE-TTL |
-| Lookup: rate/concurrency bound reached | refuse immediately as OVERLOADED with `Retry-After` ≥ P-RETRY-AFTER-MIN; never queue or claim the credential is bad |
-| Lookup: call fails, times out, or returns an unusable answer | refuse as UPSTREAM-FAILURE; the same credential may succeed after recovery, so this is never BAD-CREDENTIAL |
-| Lookup: answer names a different key than was asked about | discard the answer and refuse as UPSTREAM-FAILURE |
+| Exchange denies the credential | refuse on the rung it names (REQ-53), mapped to its DEF-10 row; evict any cached grant for that fingerprint at once; remember the denial for P-GRANT-NEGATIVE-TTL |
+| Exchange unreachable, times out, or returns a non-success status | serve on a cached grant that has not passed `expires_at`, if one exists; otherwise refuse as UPSTREAM-FAILURE. Never BAD-CREDENTIAL — the credential was never judged (REQ-54) |
+| Answer missing a required field, or carrying a claims version this build does not understand | unusable, not permissive: handled as a failed exchange. Reading a newer vocabulary for the parts it recognizes is how an added restriction becomes an accidental permission (DEF-17) |
+| Answer about a credential other than the one asked about | discard and refuse as UPSTREAM-FAILURE |
+| Answer offering a lifetime beyond P-GRANT-MAX-LIFETIME | accept the grant, capped at the bound, and count it — a control plane drifting past the cap is a misconfiguration an operator should see before it becomes an incident |
+| Signing headers absent, repeated, malformed, unattributable, or outside P-SIGNATURE-MAX-SKEW in either direction | UPSTREAM-FAILURE like any other failed exchange, and alarm. The cause is the Portal's own clock, identity, or request construction, not the client's key, and it fails every exchange at once (ADR-018) |
+| Rate or in-flight bound reached | with no usable grant, refuse immediately as OVERLOADED with `Retry-After` ≥ P-RETRY-AFTER-MIN; with a grant still inside `expires_at`, skip the renewal and serve on that grant. Never queue, and never claim the credential is bad |
+| Cache at P-GRANT-CACHE-CAPACITY | evict by least-recent use; the evicted credential's next request is an ordinary miss. Sustained eviction of live grants is the HZ-13 capacity signal, not a correctness event |
 
-*Degradation.* Fail-static and unbounded today: the established snapshot serves for as
-long as the outage lasts, so a revocation issued during it does not land until the feed
-returns (GAP-31). Intent bounds this at P-KEY-SNAPSHOT-MAX-AGE ⚠ (OQ-12). Before the
-*first* complete bootstrap there is no snapshot to be static about, and an enforcing
-Portal declines readiness instead of refusing every key (INV-31). Nothing survives
-restart (NG5): every replica re-reads the feed from the start on boot, which puts the
-whole key set on the startup path and in every replica's memory (HZ-11).
+*Degradation.* Fail-static, and bounded by construction: a cached grant rides an outage out
+to its `expires_at` and no further, so the worst-case stale-authorization window is one the
+control plane chose and the Portal capped. Past it, and for every credential this replica
+has not cached, an outage means refusals — retryable, attributed to the dependency, and
+never converted into a claim about anyone's key. That is the deliberate direction of failure
+(ADR-016): a quiet control plane closes the gate rather than freezing it open, at the price
+of being a dependency the deployment must run like a production service. Readiness never
+turns on it (INV-31): every replica shares the same authority, so withholding readiness
+fleet-wide would answer an outage with an outage. Nothing survives restart (NG5), and
+nothing needs to — a cold replica has no bootstrap to do, only a first exchange for each
+credential it serves.
 
 ## Caches & refreshed snapshots (lifecycle)
 
@@ -176,8 +190,8 @@ whole key set on the startup path and in every replica's memory (HZ-11).
 | Chain status | DC-5 poll | none (status only) | loading state before first fetch |
 | Worker health map (DEF-12) | per-query outcomes | rolling windows (P-WORKER-ERROR-COOLDOWN / P-WORKER-TIMEOUT-COOLDOWN) | operator debug view |
 | Heads | artifact (archival) / per-request (real-time) | one successful P-ASSIGNMENT-REFRESH cycle / live; archival outage unbounded | response metadata (INV-24) |
-| Key snapshot (DEF-18) | DC-8 feed poll, plus authorize-on-miss for absent keys | LIV-13's page-count-dependent bound while healthy; none during outage today; ⚠ P-KEY-SNAPSHOT-MAX-AGE (OQ-12) | intent: age gauge + alarm (OB-13, GAP-31) |
-| Negative key answers | DC-8 lookup | P-KEY-NEGATIVE-TTL; cleared wholesale by a snapshot rebuild | protected lookup events (OB-13) |
+| Grant cache (DEF-18) | DC-8 exchange, on the request that needs it | each grant's own `refresh_after` while healthy, `expires_at` absolutely — the only snapshot here with a hard bound during an outage | enforcing mode: grace count + minimum remaining expiry and exchange-outcome counters; shadow mode: protected events only (OB-13), alarmed on sustained grace (OB-9) |
+| Negative answers (denials) | DC-8 exchange | P-GRANT-NEGATIVE-TTL | protected exchange events (OB-13) |
 
 There is no response cache: no client-visible value is ever served from a cache other
 than these declared snapshots.

--- a/spec/07-invariants.md
+++ b/spec/07-invariants.md
@@ -48,30 +48,37 @@ admitted stream decrements exactly once at its end.
 *Why:* census drift silently shrinks (or unbounds) global capacity.
 *Check:* CT-3 — concurrent admit/finish/disconnect storm; compare census to truth.
 
-**INV-6 — Key snapshot coherence.** [transition]
-Every read of the key snapshot (DEF-18) sees exactly one generation: a rebuild replaces
-the record set wholesale and is never partially observable, and a direct lookup that
-began under an earlier generation never inserts its answer into a later one. Within a
-generation a key only moves forward — a delta applies a record only if its sequence
-exceeds the held one, so a replayed or reordered page cannot resurrect a revoked key.
-A record that cannot be used is held as a tombstone, never dropped (DEF-17).
-*Why:* the two ways a mirror silently un-revokes a key are applying a stale record over a
-newer one, and letting an in-flight lookup write into a snapshot that has since been
-rebuilt beneath it.
-*Check:* CT-10 — feed stub replays and reorders pages, and flips epoch while a lookup is
-in flight; assert no key regresses and no answer lands in the wrong generation.
+**INV-6 — Grant cache coherence.** [transition]
+Every entry of the grant cache (DEF-18) is reachable only by the fingerprint of the whole
+credential that earned it, and only until it passes `expires_at`; past that it admits
+nothing, whatever the state of the control plane. "Newer" means the result of a
+later-started local exchange generation for that fingerprint, never a comparison of grant
+deadlines. Starting a successor retires the earlier generation, so a late completion from
+the retired attempt cannot write. An authoritative denial evicts on arrival and is never
+overwritten by an exchange generation that started before it. An answer the Portal cannot
+fully read — a
+missing field, an unrecognized claims version, a subject other than the one asked about —
+is never stored (DEF-17).
+*Why:* the ways a cache silently un-revokes a key are writing a stale answer over a fresh
+one, letting an entry outlive the deadline it was issued under, and admitting on the part
+of an answer that parsed.
+*Check:* CT-10 — time out one exchange without suppressing the stub's late completion,
+start its successor, and deliver the two answers in reverse generation order; also return a
+denial from the successor while the retired call can still complete. Assert the retired
+completion writes nothing, the denial survives, and an entry stops admitting at
+`expires_at` with the stub unreachable.
 
 ## Operation legality (10–19)
 
 **INV-10 — Validation precedes serving work.** [response]
 A request failing DEF-7 validation triggers no serving-dependency call and no shared-state
 mutation beyond authorization caches and observability. Because OP-11 precedes operation
-validation, a syntactically valid credential naming a snapshot-miss key may already have
-made the one bounded DC-8 lookup INV-14 permits; no other dependency exception exists.
+validation, a well-formed credential with no usable grant may already have made the one
+bounded DC-8 exchange INV-14 permits; no other dependency exception exists.
 *Why:* invalid input must be cheap to reject and must never buy the work that serves it;
 the earlier authorization exception has its own explicit bounds.
 *Check:* CT-4/CT-10 — invalid-request corpus against dependency stubs; assert zero
-serving-dependency calls and at most the one DC-8 lookup for a snapshot miss.
+serving-dependency calls and at most the one DC-8 exchange.
 
 **INV-11 — Clamping.** [response]
 Effective tuning = min(requested, operator cap) with defaults for absent values; no
@@ -99,30 +106,37 @@ Pre-routing validation, alias, and admission failures have no source marker.
 **INV-14 — Authorization precedes work.** [response]
 On a gated route (DEF-19), a request that does not pass OP-11 causes no serving-dependency
 call, no handler execution, no stream-census admission, and no shared-state mutation
-beyond the snapshot's own caches and authorization observability. A snapshot miss may
-make the one bounded DC-8 lookup OP-11 declares. Dataset canonicalization is itself work:
-it happens only for a credential that has already authenticated and only where the key's
-scope requires it (REQ-53). On an ungated route, or a Portal with no commercial
-configuration, no part of this runs.
+beyond the grant cache, its negative answers, and authorization observability. A credential
+with no usable grant may make the one bounded DC-8 exchange OP-11 declares — one, whatever
+the request rate, because concurrent requests on a fingerprint share a single call. A token
+outside the grammar makes none. Dataset canonicalization is itself work: it happens only
+for a credential that has already authenticated and only where the key's scope requires it
+(REQ-53). On an ungated route, or a Portal with no commercial configuration, no part of
+this runs.
 *Why:* an unauthenticated request must not be able to buy unbounded or serving-path work.
-The one attacker-reachable exception — authorize-on-miss — has explicit rate,
-concurrency, cache, and deadline bounds so the gate does not become an open cost amplifier.
+The one attacker-reachable exception is now the ordinary path rather than a rare miss, so
+its rate, concurrency, single-flight, negative-cache and deadline bounds are what stop the
+gate from being an open cost amplifier pointed at the control plane (HZ-10).
 *Check:* CT-10 — keyless and bad-key corpus against every gated route with dependency
-stubs and a counting catalog; assert zero serving-dependency calls, a DC-8 call only for
-a snapshot miss, and canonicalization only after authentication on the dataset rung.
+stubs and a counting catalog; assert zero serving-dependency calls, at most one DC-8
+exchange per fingerprint under a concurrent burst, none at all for a malformed token or a
+cached grant, and canonicalization only after authentication on the dataset rung.
 
 **INV-15 — Verdict determinism.** [response]
-The authorization verdict (DEF-20) is a pure function of (credential, key record, portal
-identity, requested dataset, current time). It never depends on load, capacity, prior
-requests, or which replica served, and the ladder's precedence (REQ-53) is total: a
-request failing several rungs always reports the earliest. Two replicas holding the same
-record state and evaluating at the same time return the same verdict for the same request;
-a local generation counter alone does not establish equivalent state.
+The authorization verdict (DEF-20) is a pure function of (credential, grant or denial,
+requested dataset, current time). It never depends on load, capacity, prior requests, or
+which replica served, and the ladder's precedence (REQ-53) is total: a request failing
+several rungs always reports the earliest. Two replicas holding the same grant and
+evaluating at the same time return the same verdict for the same request. They need not
+hold the same grant — each exchanges on its own traffic, so one replica may be a refresh
+ahead of another, and that divergence is bounded by `expires_at` rather than eliminated.
 *Why:* a verdict that varies with load is an availability bug wearing an authorization
 costume, and a precedence that varies makes the refusal reason — the operator's only
-diagnostic — untrustworthy.
-*Check:* CT-10 — the multi-failure corpus of REQ-53 against a fixed snapshot, replayed
-under saturation and on a second replica; assert identical verdicts.
+diagnostic — untrustworthy. Per-replica grant divergence is the honest cost of asking on
+demand, and stating its bound is what keeps it from being mistaken for this defect.
+*Check:* CT-10 — the multi-failure corpus of REQ-53 against a fixed set of grants, replayed
+under saturation and on a second replica; assert identical verdicts, and that two replicas
+given the same denial converge within their grants' `expires_at`.
 
 ## Response semantics (20–29)
 
@@ -227,11 +241,13 @@ through them).
 
 **INV-31 — Readiness honesty.** [state]
 Ready ⇒ (an artifact is applied ∧ connectivity ≥ P-READY-CONNECTION-RATIO ∧ not
-shutting down ∧ (enforcing commercial ⇒ a key snapshot has been established)). A Portal
-that would refuse every valid key is not ready (REQ-54); a shadow-mode one has no such
-conjunct, since it refuses nobody (REQ-55). Shutdown flips readiness before intake stops
-(ADR-005). Intent ⚠: ready also ⇒ artifact age ≤ P-ASSIGNMENT-MAX-AGE (ADR-013, GAP-2),
-and the key-set analogue P-KEY-SNAPSHOT-MAX-AGE ⚠ if OQ-12 ratifies it.
+shutting down). Shutdown flips readiness before intake stops (ADR-005). Intent ⚠: ready
+also ⇒ artifact age ≤ P-ASSIGNMENT-MAX-AGE (ADR-013, GAP-2). Commercial configuration adds
+no conjunct in either enforcement mode and will not get one: there is nothing to load
+before serving, and every replica shares one authority, so a readiness rule keyed on the
+control plane would empty the fleet during exactly the outage that triggered it (REQ-54).
+An unreachable control plane is answered with retryable refusals and an alarm (OB-9), which
+keeps the failure attributable to the thing that failed.
 *Why:* orchestrators route by this; a lying probe turns deploys into outages.
 *Check:* CT-2 — drive each conjunct false via stubs; probe.
 
@@ -257,37 +273,51 @@ where the operator configured it — REQ-56).
 *Check:* CT-2 — harness observes all egress; anything not stub-addressed fails.
 
 **INV-38 — Credential confidentiality.** [state]
-A presented secret exists only as the digest the request parser reduces it to. No log
-record, metric label, span field, error body, stored value, or outbound request ever
-carries the secret, and comparison against the published digest completes in time
-independent of how many leading bytes matched.
+Past the request parser a presented secret exists only in the bounded request-local
+exchange input DEF-16 describes and as the fingerprint the parser reduced it to. The raw
+input is destroyed immediately on a cache or negative-answer hit; on a miss, one owner
+moves it into the single DC-8 exchange and destroys it on completion, timeout, or
+cancellation. It leaves the process in that direction and by no other: no log record,
+metric label, span field, error body, shared or persisted value, or any other outbound
+request carries it, the grant cache holds fingerprints rather than credentials, and
+fingerprint comparison completes in time independent of how many leading bytes matched.
 *Why:* an API key that reaches a log line has been disclosed to everyone with log access,
 and a comparison that exits early lets a wrong secret be refined byte by byte from
-response timing — the digest would then be no better than the secret itself.
+response timing — the fingerprint would then be no better than the secret itself. The one
+egress is not a loophole but the point of naming it: an exception that is written down is
+one a test can bound, and INV-37 already forbids every other destination.
 *Check:* CT-10 — drive the full corpus with a marked secret; grep every emitted log,
-metric, span, and body for it; assert the comparison is the constant-time one by
-construction.
+metric, span, body, and shared-state dump for it; assert it appears in the control-plane
+stub's ledger only on a miss and in no other stub's; force hit, timeout, cancellation, and
+coalesced-waiter paths and assert no raw input outlives them; assert the comparison is the
+constant-time one by construction.
 
 **INV-39 — No enumeration oracle.** [response]
 On every completed credential verdict, an unparseable token, an authoritatively unknown
-key id, a known key id with a wrong secret, and a digestless tombstone are
-indistinguishable to the client: same status, same code, same body (ADR-017). The reasons
-that *are* distinguishable — revoked, expired, wrong portal, wrong dataset — are reachable
-only by a client already holding the correct secret. The distinction survives on the
-internal axis only, in protected structured logs — never as a label or
-request-synchronous counter on the keyless metrics surface (OB-12/13).
+key id, and a known key id presented with a wrong secret are indistinguishable to the
+client: same status, same code, same body (ADR-017). The reasons that *are* distinguishable
+— revoked, expired, wrong portal, wrong dataset — are reachable only by a client already
+holding the correct secret. The distinction survives on the internal axis only, in
+protected structured logs — never as a label or request-synchronous counter on the keyless
+metrics surface (OB-12/13).
 *Why:* telling a caller that a key id exists turns the endpoint into a key-id oracle, and
 the whole point of a public key id plus a secret is that the id alone is worthless.
-*Check:* CT-10 — assert the four responses are byte-identical apart from the request id;
+*Check:* CT-10 — assert the three responses are byte-identical apart from the request id;
 assert the specific reasons appear only for correct-secret requests; bracket every case
 under both enforcement modes with metrics scrapes and assert no public series reveals the
-internal reason or lookup path beyond the response that case received. In shadow mode,
-where every case is admitted, their authorization projections are identical.
-*Known deviation:* a snapshot miss may consult the control plane while a hit answers
-locally, so timing differs; if that lookup cannot run or answer, its retryable
-OVERLOADED/UPSTREAM-FAILURE response also differs from a hit's BAD-CREDENTIAL. The
-residual reveals snapshot membership under lookup pressure, but public metrics must not
-amplify it beyond the response the caller already received (GAP-32).
+internal reason or the exchange path beyond the response that case received. In shadow
+mode, where every case is admitted, their authorization projections are identical.
+*Accepted deviation:* a credential with no usable grant costs an exchange while a cached
+one answers locally, so timing differs in either enforcement mode. In enforcing mode, if
+that exchange cannot run or answer, its retryable OVERLOADED/UPSTREAM-FAILURE response also
+differs from a cached BAD-CREDENTIAL. Shadow mode still admits both cases and exposes the
+same neutral public authorization projection; only protected telemetry records the
+exchange result. The residual reveals *cache membership* under exchange pressure, and is
+accepted because the alternative — collapsing both enforcing responses onto one outcome —
+means answering a dependency failure with a claim about the key, which REQ-54 forbids. It
+is not a key-id oracle: the cache is keyed on the whole credential, so an unknown id and a
+known id with a wrong secret miss identically, and neither timing nor public counters
+separate them.
 
 ## Recovery (40–44)
 

--- a/spec/08-liveness.md
+++ b/spec/08-liveness.md
@@ -8,8 +8,11 @@ Liveness claims hold only under a declared environment:
   correct responses within P-TRANSPORT-TIMEOUT and is not rate-limiting.
 - **Healthy publisher/registry:** DC-2/DC-3 fetches succeed within their deadlines.
 - **Healthy real-time source:** DC-4 answers within its deadlines.
-- **Healthy control plane:** DC-8 feed reads and lookups succeed within their deadlines.
-  Vacuous on a Portal with no commercial configuration.
+- **Healthy control plane:** DC-8 exchanges succeed within their deadline, and the absolute
+  skew between the Portal's clock and the control plane's is at most
+  P-SIGNATURE-MAX-SKEW — a skew past it in either direction fails every exchange, not a
+  share of them (ADR-018). Vacuous on a Portal with no commercial
+  configuration.
 - **Adequate resources:** census below P-MAX-STREAMS, congestion utilization below
   P-HEADROOM-THRESHOLD, memory within P-MEMORY-BUDGET.
 - **Patient supervisor:** the orchestrator's kill grace P-KILL-GRACE exceeds
@@ -48,14 +51,14 @@ P-NO-DATA-DELAY + slack — bounded above as well as below (the throttle must no
 connections indefinitely). Witness: OB-3. Check: CT-1 timing.
 
 **LIV-5 — Startup bound, accept/ready decoupled.** From process start with a healthy
-publisher — and, for an enforcing commercial deployment, a healthy control plane whose
-initial snapshot is `K ≤ P-KEY-MAX-PAGES-PER-TICK` pages — the listener accepts
-connections early (probes answerable while loading). Readiness is achieved within the
-artifact fetch time + `K × P-KEY-FETCH-TIMEOUT` + snapshot-apply time + scheduling slack;
-a supported deployment sizes the feed so that sum is ≤ P-STARTUP-BOUND ⚠. Neither
-startup input is assumed to dominate the other. Startup never blocks on the real-time
-source or chain RPC. Witness: OB-8 lifecycle timestamps. Check: CT-2/CT-10 cold-start
-scenario (S5), including a multi-page key set and an unavailable control plane.
+publisher the listener accepts connections early (probes answerable while loading).
+Readiness is achieved within the artifact fetch and apply time plus scheduling slack, which
+a supported deployment sizes to ≤ P-STARTUP-BOUND ⚠. Commercial configuration adds no term:
+there is no key bootstrap, and a Portal whose control plane is unreachable reaches
+readiness on the same schedule as one whose control plane is healthy (REQ-54). Startup
+never blocks on the real-time source, the control plane, or chain RPC. Witness: OB-8
+lifecycle timestamps. Check: CT-2/CT-10 cold-start scenario (S5), including a cold start
+against an unavailable control plane.
 
 **LIV-6 — Artifact convergence.** A newly published artifact (effective time passed)
 is applied within P-ASSIGNMENT-REFRESH + fetch time; routing reflects it for all new
@@ -89,29 +92,34 @@ INV-30 audit.
 within P-PRE-DRAIN-GRACE + P-DRAIN-TIMEOUT + slack, regardless of client behavior
 (ADR-005). Witness: OB-8/OB-5. Check: CT-2 — shutdown under load with stalled readers.
 
-**LIV-13 — Revocation convergence.** Healthy control plane, commercial deployment ⇒ a
-key revoked at the control plane stops being served by every replica after the pending
-pages through that record have been read. For `N` such pages and
-`M = P-KEY-MAX-PAGES-PER-TICK`, a conservative time bound is
-`ceil(N / M) × P-KEY-SYNC-INTERVAL + N × P-KEY-FETCH-TIMEOUT` plus snapshot-apply and
-scheduling slack; when `N ≤ M`, one tick drains the backlog. Convergence is therefore
-bounded but not independent of backlog size. It is per replica and needs no coordination
-— each mirrors the same feed independently. Witness: OB-13 snapshot age/cursor against
-the feed's head; per-request lookup details remain off the keyless metrics surface. Check:
-CT-10 — with a test-small `M ≥ 2`, revoke one key, a bulk of P-KEY-PAGE-LIMIT + 1, and
-a backlog of `M + 1` pages; assert one-, one-, and two-cycle convergence respectively.
+**LIV-13 — Revocation convergence.** Commercial deployment ⇒ a key revoked at the control
+plane stops being served by a replica within its grant's `refresh_after` + one exchange +
+P-GRANT-REFRESH-JITTER, and unconditionally at that grant's `expires_at`. The same bound
+covers every narrowing of a live key — a withdrawn dataset, a reduced scope — since all of
+them reach the Portal only as the next grant. The first bound
+needs a healthy control plane and a request to arrive — an idle credential converges
+trivially, since nothing is being served on it. The second needs nothing at all: it holds
+through an outage, which is what makes the stale-authorization window a number rather than
+a hope, and it is capped for the fleet at P-GRANT-MAX-LIFETIME (REQ-54). Convergence is per
+replica and needs no coordination; two replicas may sit a refresh apart, bounded by the same
+expiry (INV-15). Nothing here converges faster than the control plane asked for; if a
+product requirement needs it to, that is an invalidation channel rather than a shorter
+interval (OQ-16). Witness: enforcing-mode OB-13 grace count, minimum remaining expiry, and
+exchange outcomes; shadow-mode and per-request details remain protected. Check: CT-10 —
+revoke a key while the stub is healthy and assert the first request past `refresh_after`
+converges; repeat with the stub unreachable and assert convergence exactly at `expires_at`.
 
-**LIV-14 — New-key admission.** Healthy control plane ⇒ a key minted after the last
-successful tick is served without waiting for the next one: a snapshot miss resolves
-directly against the control plane (DC-8), so admission latency for a fresh key is one
-lookup, not up to P-KEY-SYNC-INTERVAL. The bound holds only within the lookup budget —
-P-KEY-RESOLVE-RATE and P-KEY-RESOLVE-INFLIGHT — and outside it the key is refused as
-OVERLOADED with a retry hint until the next tick rather than delayed or mislabeled as an
-invalid credential (HZ-10). A failed lookup is UPSTREAM-FAILURE and likewise retryable.
-Witness: protected OB-13 lookup events plus the control-plane stub ledger. Check: CT-10 —
-mint a key between ticks; assert it is served, that saturation returns OVERLOADED, and
-that a control-plane failure returns UPSTREAM-FAILURE before the same credential succeeds
-after recovery.
+**LIV-14 — New-key admission.** Healthy control plane ⇒ a key minted a moment ago is served
+on its first request: there is no set to be absent from, only an exchange to make, so
+admission latency for a fresh key is one exchange (DC-8) and never a sync interval. The
+bound holds only within the exchange budget — P-GRANT-EXCHANGE-RATE and
+P-GRANT-EXCHANGE-INFLIGHT — and outside it the key is refused as OVERLOADED with a retry
+hint rather than delayed or mislabeled as an invalid credential (HZ-10). A failed exchange
+is UPSTREAM-FAILURE and likewise retryable. Witness: protected OB-13 exchange events plus
+the control-plane stub ledger. Check: CT-10 — present a key the stub minted after the
+replica started; assert it is served, that budget saturation returns OVERLOADED, and that a
+control-plane failure returns UPSTREAM-FAILURE before the same credential succeeds after
+recovery.
 
 **LIV-12 — No silent infinite retry.** Any divergence converges or alarms: chunk
 attempts are bounded by 1 + retries, then surface RETRIES-EXHAUSTED (WORKER-FAILURE

--- a/spec/09-failure-model.md
+++ b/spec/09-failure-model.md
@@ -69,24 +69,23 @@ requests only; the publisher ⇒ freshness only; chain RPC ⇒ status only (REQ-
 
 ## Control-plane faults (DC-8)
 
-Commercial deployments only. The governing asymmetry: a fault in the *key* fails closed,
-a fault in the *feed* fails static. Refusing every request because the control plane is
-unreachable would convert its outage into the Portal's (REQ-54).
+Commercial deployments only. The governing asymmetry: a fault in the *credential* fails
+closed, a fault in the *exchange* degrades — onto a cached grant while one is live, and
+into retryable refusals once it is not. The window between those two is the whole outage
+policy, and it is the control plane's `expires_at` under the Portal's cap (REQ-54).
 
 | Fault | Required response |
 |---|---|
-| Feed unreachable / timeout / error status | degrade serve-static on the established snapshot + alarm on age (OB-13); no request fails for this reason. ⚠ Unbounded today — GAP-31 |
-| Feed answers 200 with a malformed envelope | integrity: fail the tick, keep the snapshot, alarm. Never read as "the key set is empty" — that would silently stop delivering revocations |
-| Record malformed but identifiable | integrity: tombstone the key (fail-closed), count, keep serving everything else |
-| Record unidentifiable | integrity: fail the page; snapshot unchanged |
-| Record with an unrecognized status | fail-closed tombstone — a status this build predates must never admit traffic |
-| Feed epoch change / head below cursor | mask: rebuild the snapshot from the start (DEF-18); mid-drain, fail the tick and rebuild on the next |
-| No snapshot ever established, enforcing | fail-safe: decline readiness (INV-31) — leave rotation rather than 401 every valid key |
-| No snapshot ever established, shadow mode | mask: admit everything, stay ready (REQ-55) |
-| Lookup rate-limited or over the in-flight cap | fail-safe: refuse immediately as OVERLOADED with a retry hint; never admit, queue, or claim the credential is invalid (HZ-10) |
-| Lookup unavailable, times out, or returns an unusable answer | fail-safe: refuse as UPSTREAM-FAILURE; the unchanged credential may succeed after recovery |
-| Lookup answers about a different key | integrity: discard and refuse as UPSTREAM-FAILURE |
-| Service credential missing or empty at startup | fail-safe at startup: refuse to run (REQ-33) |
+| Exchange unreachable / timeout / error status, cached grant inside `expires_at` | degrade: serve on the cached grant; count the grace-serving and alarm on it (OB-9/13). No request fails for this reason while the grant lives |
+| Exchange unreachable, no usable grant (never cached, or past `expires_at`) | fail-safe: refuse as UPSTREAM-FAILURE, retryable, attributed to the dependency. This is the accepted cost of asking on demand, not a defect (ADR-016) |
+| Answer malformed, missing a field, or carrying an unrecognized claims version | integrity: treat as a failed exchange, store nothing, alarm. Never read for the parts that parsed — an unread restriction is a granted permission |
+| Answer about a different credential than was asked about | integrity: discard and refuse as UPSTREAM-FAILURE |
+| Answer offers a lifetime beyond P-GRANT-MAX-LIFETIME | mask: accept, capped at the bound; count it as a control-plane misconfiguration |
+| Authoritative denial arriving against a live cached grant | fail-closed: evict and refuse from that moment; a denial is never outranked by remaining lifetime (INV-6) |
+| Exchange rate-limited or over the in-flight cap | with no usable grant, fail-safe immediately as OVERLOADED with a retry hint; with a grant inside `expires_at`, suppress this renewal and serve on the grant. Never queue or claim the credential is invalid (REQ-54, HZ-10) |
+| Signing headers malformed or unattributable, or timestamp skew past P-SIGNATURE-MAX-SKEW in either direction | fail-safe as UPSTREAM-FAILURE, and alarm: it fails every exchange at once and the cause is local clock, identity, or request construction, not any client's key (ADR-018) |
+| Control plane never reached at all, either mode | mask for readiness — stay ready and refuse retryably (INV-31); leaving rotation would answer one outage with a larger one |
+| Signing identity missing or empty at startup | fail-safe at startup: refuse to run (REQ-33) |
 | Commercial block present but empty | fail-safe at startup: refuse to run — the open portal is the one outcome nobody configuring it intended (REQ-56) |
 
 ## Other dependencies
@@ -120,4 +119,4 @@ unreachable would convert its outage into the Portal's (REQ-54).
 | Publisher | INV-1, INV-2, INV-31, LIV-6, REQ-26 | CT-2 |
 | Real-time source | INV-25, INV-26, LIV-2, REQ-22, REQ-25 | CT-2 |
 | Process/operator | FM-1, INV-30, LIV-11, REQ-33 | CT-2, CT-7 |
-| Control plane | INV-6, INV-31, REQ-54, REQ-55, LIV-13, LIV-14 | CT-10 |
+| Control plane | INV-6, INV-15, INV-31, REQ-54, REQ-55, LIV-13, LIV-14 | CT-10 |

--- a/spec/11-performance.md
+++ b/spec/11-performance.md
@@ -13,6 +13,7 @@ Parameters (symbolic; scenarios bind them):
 | W-DATASETS | distinct datasets in play |
 | W-CHURN | worker-set / artifact change rate |
 | W-POLL | share of beyond-frontier (head-polling) requests |
+| W-CREDENTIALS | distinct credentials in play, commercial deployments only — the grant cache is sized by this and not by the key set (HZ-13) |
 
 Reference scenarios:
 
@@ -53,7 +54,7 @@ register ([13-conformance.md](13-conformance.md)), and seed the regression gates
 | SLI-4 | any | ≥ P-SLO-AVAILABILITY monthly ⚠ |
 | SLI-5 | S1/S4 | ≤ P-SLO-MEMORY-HEADROOM ⚠ |
 | SLI-6 | S1 | ≥ P-SLO-COMPLETION-INTEGRITY ⚠ |
-| readiness time | S5 | ≤ P-STARTUP-BOUND ⚠ (artifact fetch + enforcing-commercial key bootstrap, LIV-5) |
+| readiness time | S5 | ≤ P-STARTUP-BOUND ⚠ (artifact fetch and apply; commercial configuration adds no term, LIV-5) |
 | shutdown time | any | ≤ P-PRE-DRAIN-GRACE + P-DRAIN-TIMEOUT + slack (hard, LIV-11) |
 
 ## Resource-bound requirements
@@ -74,31 +75,35 @@ consumption within its buffer bound; it never grows unbounded queues anywhere
 new work (INV-12), never by degrading admitted work past its liveness bounds or by
 process death (FM: memory row).
 
-**PF-4 — Refresh budget, two-sided.** Background refreshes (artifact, catalog, chain,
-key feed where commercial) must complete within their declared convergence bounds
-(keep-up) **and** must not consume more than a bounded share of serving resources while
-doing so — an artifact or key-snapshot apply must not stall request routing beyond a
-scheduling pause (HZ-5/HZ-11).
+**PF-4 — Refresh budget, two-sided.** Background refreshes (artifact, catalog, chain) must
+complete within their declared convergence bounds (keep-up) **and** must not consume more
+than a bounded share of serving resources while doing so — an artifact apply must not stall
+request routing beyond a scheduling pause (HZ-5). Authorization has no background refresh
+by construction: grants are renewed by the traffic that uses them, which moves this budget
+onto PF-7 and the exchange bounds rather than removing it.
 
-**PF-5 — Startup work scheduling.** Startup-critical work (artifact fetch and, on an
-enforcing commercial deployment, complete key bootstrap) is prioritized; nothing else on
-the startup path may push readiness past P-STARTUP-BOUND (LIV-5).
+**PF-5 — Startup work scheduling.** Startup-critical work — the artifact fetch — is
+prioritized; nothing else on the startup path may push readiness past P-STARTUP-BOUND
+(LIV-5). Commercial configuration puts nothing on that path.
 
 **PF-6 — Refusal cheapness.** Every refusal allocates O(1) work and memory per request.
 Locally decidable refusals are at least an order of magnitude cheaper than serving an
-admission. A snapshot-miss refusal may spend PF-7's one deadline-bounded DC-8 lookup; it
-is benchmarked separately and never waits in an unbounded queue.
+admission. A refusal awaiting an exchange may spend PF-7's one deadline-bounded DC-8 call;
+it is benchmarked separately and never waits in an unbounded queue.
 
 **PF-7 — Authorization cheapness.** On a commercial deployment, an authorization refusal
-costs O(1) in request size and performs no dependency call on a snapshot hit or
-syntactically invalid token. A snapshot miss may spend one deadline-bounded DC-8 lookup;
-an authenticated dataset-scoped key may spend one canonicalization at the dataset rung.
-Neither cost is reachable by a keyless, malformed-token, or wrong-secret hit request
-(INV-14). An ungated route costs exactly what it costs on a non-commercial deployment:
-the gate returns before reading the credential. The common admitted path adds one snapshot
-hash lookup under a read lock; miss and scoped-key benchmarks are measured separately.
+costs O(1) in request size and performs no dependency call on a cache hit, a token outside
+the grammar, or a fingerprint under an unexpired negative answer. A credential with no
+usable grant may spend one deadline-bounded DC-8 exchange, shared with every concurrent
+request on the same fingerprint; an authenticated dataset-scoped key may spend one
+canonicalization at the dataset rung. An ungated route costs exactly what it costs on a
+non-commercial deployment: the gate returns before reading the credential. The common
+admitted path is one fingerprint digest, one cache read under a briefly held lock, and two
+time comparisons; the exchange and scoped-key paths are measured separately.
 Rationale: the gate is the first thing every request meets and the only thing an
-unauthenticated flood reaches, so each attacker-reachable cost needs its own bound.
+unauthenticated flood reaches. Under ADR-016's revision that flood now points at a
+dependency rather than at local memory, so the ordering of these checks is itself the
+bound — grammar and negative cache before anything that can leave the process (HZ-10).
 
 ## Hazard register
 
@@ -116,8 +121,10 @@ defects live in the gap register (13).
 | HZ-7 | Usage-log queue drops silently at P-LOGS-QUEUE | accounting fidelity (REQ-44) | drop counter vs stub-sink ledger |
 | HZ-8 | Chain RPC calls carry no explicit deadline | LIV-3 for the status loop | stalled-RPC stub; loop aliveness (GAP-18) |
 | HZ-9 | Congestion waiter queue is unbounded | PF-1 under S3 | waiter census at saturation |
-| HZ-10 | Authorize-on-miss is keyed on attacker-chosen ids: a flood of distinct unknown keys drains P-KEY-RESOLVE-RATE and fills the P-KEY-NEGATIVE-CAPACITY map, and every bound is fail-closed — so the traffic that exhausts the budget also denies *newly minted legitimate keys* with retryable OVERLOADED until the next sync tick lands them in the snapshot | LIV-14, REQ-50 | CT-10: saturate with distinct unknown ids, then present a key minted since the last tick; assert OVERLOADED + hint and measure admission delay against P-KEY-SYNC-INTERVAL |
-| HZ-11 | The snapshot is a per-replica in-memory map of the entire key set, rebuilt from the feed on every start and on every epoch change; nothing bounds how large the control plane may let it grow | PF-1, LIV-5 (startup) | RSS and time-to-ready against a feed stub serving a key set at the projected ceiling |
+| HZ-10 | The exchange is on the request path and keyed on attacker-chosen credentials: a flood of distinct well-formed tokens drains P-GRANT-EXCHANGE-RATE and fills the P-GRANT-NEGATIVE-CAPACITY map, and every miss bound is fail-closed — so the traffic that exhausts the budget also denies *every uncached legitimate credential* with retryable OVERLOADED. Sharper than under the retired mirror, which could fall back on a local key set: here there is no local fallback for a credential this replica has not seen | LIV-14, REQ-50, PF-7 | CT-10: saturate with distinct unknown tokens, then present a valid uncached credential; assert OVERLOADED + hint and measure admission delay |
+| HZ-11 | **Retired** by ADR-016's 2026-08-07 revision. The mechanism it described — a per-replica in-memory copy of the entire key set, rebuilt on every start, bounded by nothing the Portal owned — no longer exists. Its capacity question survives, in the smaller form HZ-13 states | — | — |
+| HZ-12 | Grants issued in a burst — a deploy, a fleet restart, a cohort of clients starting together — share a `refresh_after` and an `expires_at`, so they stampede the exchange in step and, during an outage, stop serving in step. P-GRANT-REFRESH-JITTER spreads the first; nothing spreads the second, because `expires_at` is a safety bound and moving it is the one thing grace must not do | LIV-13, LIV-14, DC-8 capacity | CT-6/CT-10: issue a cohort of same-lifetime grants, then measure exchange rate at renewal and the refusal edge with the stub stopped |
+| HZ-13 | The grant cache is bounded at P-GRANT-CACHE-CAPACITY — the working-set-sized successor to HZ-11's copy of everything. A working set larger than the bound thrashes: every request evicts a live grant and buys an exchange, converting steady-state serving traffic into control-plane traffic at request rate and putting the DC-8 deadline on the latency path of every request | PF-7, LIV-14, DC-8 capacity | CT-6: drive a distinct-credential working set past the bound; watch exchange rate against request rate and TTFB against the cached baseline |
 
 ## Benchmarking requirements
 

--- a/spec/12-observability.md
+++ b/spec/12-observability.md
@@ -5,18 +5,14 @@ as a failure (INV-30): **lying metrics are failures**. Cardinality of every labe
 family is bounded (intent — GAP-6): labels come from closed sets (endpoint, class,
 outcome, dataset) — per-worker labels must be bounded or evicted. `/metrics` is a
 keyless, client-readable surface (IB-9), so commercial deployments apply an additional
-confidentiality rule: under gate scope `all`, no public series carries a dataset identity;
-under either scope, no public series exposes an internal authorization rung or lookup
+confidentiality rule: no public series exposes an internal authorization rung or exchange
 detail beyond the client-visible wire outcome (INV-39).
 
 **OB-1 — State gauges.** Active streams (census), in-flight congestion permits and
 window size, open leases (or an equivalent worker-busy gauge), known workers, known
-chunks and highest block per dataset. At quiescence each equals modeled truth. On an
-`all`-scope commercial deployment, the public scrape aggregates additive dataset gauges
-and omits the dataset label; a per-dataset value with no truthful aggregate, such as
-highest block, is omitted. Per-dataset state remains available only through authenticated
-metadata/operator routes and protected logs. A keyless metrics scrape must not reconstruct
-the catalog that `all` exists to hide (REQ-51).
+chunks and highest block per dataset. At quiescence each equals modeled truth. Dataset
+identities are public on every deployment (NG8), so the scrape carries them as it always
+has.
 
 **OB-2 — Progress heartbeat.** Per active stream: periodic progress (coverage cursor,
 bytes) at P-HEARTBEAT-INTERVAL, plus time-to-first-byte per response. Distinguishes
@@ -50,9 +46,11 @@ connection fault whose shape the replay classifier stopped recognising. A wedged
 dependency must be visible from the Portal's own metrics alone (REQ-22).
 
 **OB-5 — Readiness reason.** The readiness state as a gauge with a reason code
-(loading / insufficient-connectivity / shutting-down / no-key-snapshot on an enforcing
-commercial deployment / ⚠ stale-artifact — ADR-013, GAP-2), and logged transitions. A
-probe flip is attributable without log archaeology.
+(loading / insufficient-connectivity / shutting-down / ⚠ stale-artifact — ADR-013,
+GAP-2), and logged transitions. A probe flip is attributable without log archaeology.
+Authorization contributes no reason code, in either enforcement mode: it cannot flip this
+probe (INV-31), and a code for a state that cannot occur reads as a promise the gauge
+does not keep.
 
 **OB-6 — Artifact provenance.** Applied artifact identifier and ⚠ age
 (ADR-013/GAP-2), application timestamps, skipped/unchanged fetch counts. A wedged
@@ -67,8 +65,17 @@ ready, SIGTERM, drain start, exit — the LIV-5/LIV-11 witnesses.
 
 **OB-9 — Alarm states.** Edge events + level reads, reason-coded, for: artifact
 fetch/validation failures (⚠ GAP-1/2), background-loop deaths, usage-log drops,
-signature-verification failures. Alarms are the LIV-12 witness: persistent failure is
-never log-only. (Sampled error reporting to DC-7 complements, never replaces, these.)
+signature-verification failures, and — on a commercial deployment — requests being served
+on renewal grace (a grant past `refresh_after` whose renewal is failing or locally
+suppressed), sustained exchange failure, and refused signing headers. The first is the one
+that has to page before the others matter: it is the leading edge of the `expires_at` cliff,
+and the minimum remaining lifetime among affected grants is the whole window an operator
+has to act in (REQ-54, DC-8). The last is a Portal-local misconfiguration — clock, identity,
+or request construction — that fails every exchange at once, and it must not be diagnosed
+as a client-key problem (ADR-018). Alarms are the LIV-12
+witness: persistent failure is never log-only. None of the three commercial ones is emitted
+or configured today (GAP-30). (Sampled error reporting to DC-7 complements, never replaces,
+these.)
 
 **OB-10 — Congestion window trace.** Window size, grow/shrink counters — the LIV-8
 witness.
@@ -90,28 +97,44 @@ the operator's is not.
 
 **OB-12 — Authorization decisions.** Commercial deployments only. In enforcing mode,
 every completed verdict (DEF-20) is counted on the public scrape by decision × actual
-**wire code** (or success) × route class × enforcement mode; a lookup that produced no
+**wire code** (or success) × enforcement mode; an exchange that produced no
 verdict is counted only by the OVERLOADED or UPSTREAM-FAILURE code actually returned. The
-four internal reasons sharing `invalid_credential` are deliberately one public label
+internal reasons sharing `invalid_credential` are deliberately one public label
 value. In `log_only`, every request increments the same neutral `shadow_evaluated` public
-outcome: the would-be verdict and an indeterminate lookup are distinguishable only in
+outcome: the would-be verdict and an indeterminate exchange are distinguishable only in
 protected structured logs. No metric label or request-synchronous counter may let a
 client bracket two keyless scrapes and learn more than its response revealed (INV-39,
 ADR-017). Auth refusals in enforcing mode must still be distinguishable from every other
-refusal on the OB-3 error-code axis — an auth 401 counted as `malformed_request` is a lying
-metric (INV-30, GAP-29). None of this exists yet (GAP-30).
+refusal on the OB-3 error-code axis — an auth refusal counted as `malformed_request` is a lying
+metric (INV-30).
 
-**OB-13 — Key snapshot freshness and provenance.** Commercial deployments only.
-Snapshot age since the last successful feed read (a gauge — the LIV-13 and GAP-31
-witness), the held cursor, last reported head and epoch, applied-delta and rebuild
-counters, and sync failures by cause. These public values change on background feed
-activity, not synchronously with one presented key. Record count and authorize-on-miss
-outcomes are omitted from the keyless scrape: either can reveal whether an
-attacker-chosen id caused a lookup or inserted a record. Lookup outcomes instead emit
-protected structured events (resolved, unknown, rate-limited, over the in-flight cap,
-failed), and CT-10 uses those events plus the control-plane stub ledger as the
-LIV-14/HZ-10 witness. A control plane that has stopped answering remains visible publicly
-as monotone age growth without exposing a key id or request path.
+**OB-13 — Grant cache and exchange health.** Commercial deployments only. In enforcing
+mode, the public scrape carries cache occupancy against P-GRANT-CACHE-CAPACITY and the
+eviction rate (the HZ-13 witness); exchange attempts and outcomes by operational class —
+answered, refused by budget, failed — with latency (the LIV-13/LIV-14 and DC-8 capacity
+witnesses); and a count of grants whose offered lifetime was capped. For the cliff it also
+carries a counter of admissions served on renewal grace, the number of grants currently in
+that state, and the minimum time remaining to `expires_at` among them (zero when none are in
+grace). The count says the condition exists and the minimum names the first hard refusal,
+without a key- or dataset-labeled series. None of these carries a key id, a fingerprint, a
+dataset, or a refusal reason finer than the enforcing caller's wire response.
+
+Shadow mode is deliberately different. Its keyless scrape exposes none of the cache,
+exchange-outcome, latency, capping, or grace signals above: `issued` versus `denied`, or a
+grant-cache occupancy change, would reveal the verdict of a request whose response admits
+either way. OB-12's single `shadow_evaluated` outcome is its entire public authorization
+projection. The load and cutover evidence shadow mode exists to gather remains in protected
+per-exchange events and in the control plane's own telemetry.
+
+The enforcing-mode `answered` class deliberately combines grants and denials. The cache is
+keyed on the whole credential (DEF-18), so an unknown key id and a known one presented with
+a wrong secret miss identically and increment the same operational counter. Bracketing two
+scrapes around one's own enforcing request can therefore reveal the accepted
+cache-membership residual that timing already exposes, but never the control plane's
+verdict or either invalid case. Everything finer stays protected: per-exchange events
+(resolved, denied with its rung, rate-limited, over the in-flight cap, failed) go to
+structured logs, and CT-10 uses those plus the control-plane stub ledger as the
+LIV-14/HZ-10 witness.
 
 ## Property → observable mapping
 
@@ -126,8 +149,8 @@ as monotone age growth without exposing a key id or request path.
 | LIV-9 | OB-3 refusal counters, OB-11 saturation integral |
 | LIV-10 | OB-1 gauges at quiescence |
 | LIV-12 | OB-9 |
-| LIV-13, LIV-14 | OB-13 age/cursor; protected lookup events + stub ledger |
-| INV-6, INV-15, INV-39 | protected OB-12 reason logs + public non-disclosure; OB-13 epoch/rebuild counters |
+| LIV-13, LIV-14 | enforcing-mode OB-13 grace deadline and exchange outcomes; protected exchange events + stub ledger in both modes |
+| INV-6, INV-15, INV-39 | protected OB-12 reason logs + public non-disclosure; neutral shadow projection and enforcing-only OB-13 classes |
 | INV-30/31 | OB-1, OB-5 (they are the invariant's subject) |
 | SLI-1..6 | OB-2, OB-3, OB-1 + process RSS |
 

--- a/spec/13-conformance.md
+++ b/spec/13-conformance.md
@@ -1,8 +1,14 @@
 # 13 — Conformance & TDD plan
 
-**Mutable doc.** Statuses as of **2026-08-05** (0.11.9,
-`master@15fcaeeea803b39e4985a7c91dada20203f411ef`). Statuses: **C** covered · **P** partial · **U**
-unchecked; *known-violated* / *known-suspect* where reality contradicts the property.
+**Mutable doc.** Statuses as of **2026-08-07** (0.12.1,
+`master@e9a1878f863c4d87615bcf21ba1ef79fdf649385`). Statuses: **C** covered · **P** partial ·
+**U** unchecked; *known-violated* / *known-suspect* where reality contradicts the property.
+**The commercial band (REQ-50..56, DC-8, OP-11 and the invariants scoped to them) is
+specified and unimplemented at this baseline** — the binary carries no authorization code at
+all, so every row in that band is `U` and no deployment is affected by any of it. One entry,
+GAP-35, tracks the whole band; the per-row notes say what each will need rather than what
+covers it. Splitting the specification from its implementation is deliberate: the wire
+contract binds another team, and it is cheaper to argue with before code exists than after.
 The **Phase-0 harness exists** (`harness/` crate: IB-7 stubs with ledgers — including
 a real p2p worker stub on the pinned transport rev — toy world, reference model, the six
 validators, client driver, quiescence-gated gauge audit; CT-1 smoke green — GAP-14
@@ -115,7 +121,7 @@ chunk-boundary records FV-6 licenses.
 | CT-7 | Soak/endurance: S4 churn for hours; leak & cardinality audits | HZ-1/5/6, INV-30, SLI-5 |
 | CT-8 | Isolation/noisy-neighbor: S6 | INV-35 |
 | CT-9 | Fuzz, both surfaces: client inputs and stub responses (payloads, artifacts) | INV-36, FM-1, GAP-1 |
-| CT-10 | Authorization: credential corpus × gate scope × enforcement mode against a control-plane stub; feed-fault/convergence cases; bracketed metrics scrapes proving no catalog or key-id side channel, including neutral shadow-mode projection | INV-6/10/14/15/38/39, INV-31, LIV-13/14, REQ-50..REQ-56, DC-8, IB-9, HZ-10 |
+| CT-10 | Authorization: credential corpus × enforcement mode against a control-plane stub; exchange-fault, lifetime and convergence cases (denial mid-grant, a retired timed-out generation completing after its successor, over-cap lifetime, unreadable claims version, outage across `refresh_after` and `expires_at`); bracketed metrics scrapes proving no key-id side channel, including neutral shadow-mode projection | INV-6/10/14/15/38/39, INV-31, LIV-13/14, REQ-50..REQ-56, DC-8, IB-9, HZ-10/12/13 |
 
 ## Structural validators (kind-agnostic, applied to every response)
 
@@ -130,10 +136,10 @@ chunk-boundary records FV-6 licenses.
    selected (retention-gap case). Pre-routing failures have no source marker.
 6. Errors: type/code ∈ DEF-10; a hint on every OVERLOADED — on proxied ones too,
    preserved or injected at the floor — never on DATA-UNAVAILABLE, and on no other class
-   unless the upstream sent one (ADR-014); `WWW-Authenticate: Bearer` on every 401; no
+   unless the upstream sent one (ADR-014); one status across every credential refusal; no
    data alongside errors (INV-26, IB-5).
 
-## Traceability matrix — properties (2026-08-05)
+## Traceability matrix — properties (2026-08-07)
 
 | Property | CT | Status | Note |
 |---|---|---|---|
@@ -156,13 +162,13 @@ chunk-boundary records FV-6 licenses.
 | INV-28 | CT-3 | U | — |
 | INV-29 | CT-1 | P | boundary emission asserted by the CT-1 selective-tail resume on both sources; the network multi-chunk case exercises the per-chunk granularity FV-6 licenses. Interior boundary records are not audited, and the EMPTY case (no block evaluated) is untested. Boundary pinning is a worker-engine behavior — re-prove before adopting new engine/format fields on a dependency bump |
 | INV-30 | CT-3/7 | U | gauge accounting was a past defect class |
-| INV-31 | CT-2 | P | shutdown flip e2e-tested; other conjuncts not; *known-violated* on staleness intent (GAP-2) |
+| INV-31 | CT-2 | P | shutdown flip e2e-tested; other conjuncts not; *known-violated* on staleness intent (GAP-2). The spec states that commercial configuration adds no conjunct, which at this baseline is vacuously true |
 | INV-35 | CT-8 | U | — |
 | INV-36 | CT-4/9 | P | three crash regressions covered — the third, a worker reporting a last block past the queried range, panicked the stream task via an inverted continuation range; latent panic (GAP-5) |
 | INV-37 | CT-2 | U | — |
 | INV-40 | CT-2 | U | — |
 | LIV-1..LIV-4 | CT-1/2/6 | U | stall budget unmeasured |
-| LIV-5, LIV-6 | CT-2 | U | startup bound unmeasured (S5), including enforcing-commercial key bootstrap |
+| LIV-5, LIV-6 | CT-2 | U | startup bound unmeasured (S5); no commercial term to measure at this baseline |
 | LIV-7 | CT-2 | P | CT-2 waits for the pool to serve again between fault cases and after exhaustion; a latched penalty fails the run. Cooldown *durations* are unmeasured |
 | LIV-8 | CT-6 | P | regrowth unit-tested at scheduler level |
 | LIV-9 | CT-6 | U | — |
@@ -173,16 +179,16 @@ chunk-boundary records FV-6 licenses.
 | FM-2 | CT-2 | P | the DC-4 replay classifier is unit-tested on both sides of the transient/integrity line (clean close, reset, the two non-replay exclusions — ADR-015). Worker-side classification now exists and is CT-2-tested: wrong-range and bad-signature responses are integrity — discarded, rerouted, never delivered — and all-integrity exhaustion is a distinguishable outcome from transient exhaustion. Corrupt artifact (GAP-1) is still untested; the *taxonomy* of both exhaustion outcomes is inside GAP-16 |
 | FM-3 | CT-2/3 | U | per-dependency confinement never exercised: no outage tests (REQ-25), no isolation swarm (INV-35) |
 | SLI-1..SLI-6 | CT-6 | U | no benchmarks; baselines from incidents only |
-| INV-6 | CT-10 | P | PR #143 unit-tests forward-only sequence application, generation-guarded lookup insertion, wholesale rebuild on epoch change and head rollback, and tombstoning of malformed and unknown-status records. No harness stub exists, so nothing exercises a *concurrent* rebuild against an in-flight lookup — the race the generation counter is there for |
-| INV-14 | CT-10 | P | a counting catalog proves canonicalization happens only on the dataset rung of an authenticated request, and the ungated path is asserted to read neither credential nor dataset. Zero serving-dependency calls and the one-DC-8-call-on-miss bound are not asserted against stubs, because CT-10 has no harness (GAP-33) |
-| INV-15 | CT-10 | P | ladder precedence and the multi-failure corpus are unit-tested at the evaluate layer; determinism under saturation and across replicas is untested |
-| INV-38 | CT-10 | P | constant-time comparison is used and unit-tested for equality semantics; the credential's debug rendering redacts the secret. No test greps emitted logs, metrics, or spans for a marked secret, and the query-parameter channel puts the secret in a URL that intermediaries may record (IB-9) |
-| INV-39 | CT-10 | P | unknown key and wrong secret are asserted to return the same reason; the *response* identity and metrics non-disclosure are not asserted end-to-end, the timing channel is a known deviation (GAP-32), and digestless tombstones currently expose `revoked` (GAP-34) |
-| LIV-13 | CT-10 | P | one tick is unit-tested to drain a multi-page backlog; convergence itself is not measured against a clock, and the `M + 1`-page two-cycle boundary is untested |
-| LIV-14 | CT-10 | P | authorize-on-miss is unit-tested including the rate-limited and in-flight-capped refusals, but both currently collapse onto BAD-CREDENTIAL rather than the retryable outcomes DC-8 requires; the admission bound and HZ-10 interference case are untested (GAP-34) |
-| DC-8 | CT-10 | P | feed faults are well covered at unit level — non-success status, malformed envelope, missing envelope fields, non-advancing cursor, short-of-head bootstrap, mid-bootstrap epoch flip, redirect refusal. Nothing runs against a stub in the harness, so none of it is CT-2-style fault injection (GAP-33) |
+| INV-6 | CT-10 | U | needs grant-cache coherence: fingerprint-only reach, the hard-expiry stop, no stale answer overwriting a fresh one, a denial surviving an in-flight exchange (GAP-35) |
+| INV-14 | CT-10 | U | needs zero serving-dependency calls, one exchange per fingerprint under a burst, none for a malformed token or a cached grant, canonicalization only on the dataset rung of an authenticated request (GAP-35) |
+| INV-15 | CT-10 | U | needs ladder precedence, determinism under saturation, and the bound on per-replica grant divergence (GAP-35) |
+| INV-38 | CT-10 | U | needs the secret's single egress — the exchange and nothing else — and constant-time fingerprint comparison, proved by grepping every emitted signal for a marked secret (GAP-35) |
+| INV-39 | CT-10 | U | needs the unauthenticated rungs answering one wire code with one public metric projection, and shadow mode projecting every verdict onto one neutral series (GAP-35) |
+| LIV-13 | CT-10 | U | needs convergence at `refresh_after` + one exchange with the control plane healthy, and at `expires_at` with it stopped — the second is the one carrying the security claim (GAP-35) |
+| LIV-14 | CT-10 | U | needs a freshly minted key served on its first request, and budget saturation answering retryable overload rather than a verdict (GAP-35) |
+| DC-8 | CT-10 | U | needs the exchange contract entire: signature, deadline, single-flight, lifetime cap, denial-evicts, outage grace, and every unusable answer failing rather than denying (GAP-35) |
 
-## Acceptance matrix — requirements (2026-08-05)
+## Acceptance matrix — requirements (2026-08-07)
 
 | REQ | Status | Note |
 |---|---|---|
@@ -217,15 +223,15 @@ chunk-boundary records FV-6 licenses.
 | REQ-42 | P | Scheduler units; headroom refusal untested (INV-4, LIV-8), and its observable — shrink cause, download utilization, headroom-refusal counter (OB-7) — is unasserted |
 | REQ-43 | P | Positive path exercised by the smoke (signed stub responses verified and delivered); CT-2 now drives the rejection path — a wrongly-signed response is not delivered and the attempt is retried elsewhere, meeting the acceptance criterion. Integrity failures are counted per worker but raise no OB-9 alarm state (GAP-24) |
 | REQ-44 | U | — |
-| REQ-50 | P | The ladder and every rung are unit-tested, and a source-scanning test forces each route in the table to be classified or fail the build. **Known-violated on the wire**: the refusal carries no taxonomy code, so the middleware rewrites it to 400 `malformed_request` and the client never sees a 401 or 403 (GAP-29). The zero-serving-call and bounded-DC-8-call claims lack a harness (GAP-33) |
-| REQ-51 | P | Both gate scopes are tested at the route-classification level, and the always-open set is pinned. Whether an `all`-scope deployment actually refuses each metadata route end-to-end, and whether keyless metrics omit every dataset identity and unsafe auth projection, are untested (GAP-30/33) |
-| REQ-52 | P | Token grammar, both presentation channels, length caps and the alphabet are unit-tested; digest-only handling is structural. Log/metric non-disclosure is unasserted (INV-38) |
-| REQ-53 | P | Precedence, absent-vs-empty scope, exact matching, alias resolution, and the no-dataset route case are unit-tested, including the earliest-rung-wins corpus. **Known-violated for digestless tombstones:** #143 returns `revoked` before a secret can match (GAP-34) |
-| REQ-54 | P | Fail-closed on unknown keys and fail-static across feed faults are unit-tested, as is readiness withholding before the first snapshot. Lookup budget/failure currently collapses onto non-retryable BAD-CREDENTIAL instead of OVERLOADED/UPSTREAM-FAILURE (GAP-34); staleness is unbounded and invisible (GAP-31) |
-| REQ-55 | P | Shadow mode is asserted to admit the whole rejection corpus, record ordinary verdicts, and not withhold readiness. An indeterminate lookup outcome and the identical neutral public projection of valid, invalid, and indeterminate cases are unimplemented or untested (GAP-30/33) |
-| REQ-56 | C | Absent configuration is asserted to install no middleware on either route class, an empty block fails startup naming the missing field through both deserializer paths, and the mode is logged once at startup |
+| REQ-50 | U | Specified, not implemented (GAP-35) |
+| REQ-51 | U | Specified, not implemented (GAP-35) |
+| REQ-52 | U | Specified, not implemented (GAP-35) |
+| REQ-53 | U | Specified, not implemented (GAP-35) |
+| REQ-54 | U | Specified, not implemented (GAP-35) |
+| REQ-55 | U | Specified, not implemented (GAP-35) |
+| REQ-56 | U | Specified, not implemented (GAP-35) |
 
-## Gap register — 2026-08-05
+## Gap register — 2026-08-07
 
 Priorities: P0 blocks the program · P1 active production risk · P2 correctness hole
 with plausible trigger · P3 polish. "Next" = cheapest failing-test-first entry.
@@ -258,14 +264,39 @@ with plausible trigger · P3 polish. "Next" = cheapest failing-test-first entry.
 | GAP-26 | No aggregate deadline bounds a worker attempt: connect is a 10 s crate default (P-WORKER-CONNECT-TIMEOUT, not operator-bound), first byte 60 s, and the body is read in 1 s-stall-bounded reads with no total bound — DC-1's single "request deadline P-TRANSPORT-TIMEOUT" is not what runs, and the transport's `request_timeout` is set but unused on this path | DC-1, REQ-22, HZ-2 | P2 | stub worker trickles a body at just under the per-read stall bound indefinitely; assert the attempt is bounded |
 | GAP-27 | Penalty classification diverges from ADR-004's cost rationale: an instant stream reset (the worker's documented flood-shed posture) draws the 300 s timeout-class cooldown plus a congestion signal, and integrity penalties are split (bad signature 300 s vs undecodable/wrong-range 30 s) though DC-1 treats them as one class — a brief worker-side flood can push the whole pool to AllUnavailable | REQ-41, DC-1, LIV-7 | P2 | CT-2: instant-reset injector; assert the cooldown class matches observed cost and the pool recovers within the error-cooldown window |
 
-| GAP-29 | Authorization refusals are emitted outside the ADR-011 envelope, so they carry no `ErrorCode` and the routed middleware normalizes them: a 401 reaches the client as **400 `malformed_request`** with the auth message nested as a JSON string, and a 403 likewise. No 401 or 403 is observable on the wire, clients cannot distinguish an invalid key from a malformed query, every auth refusal lands on the metric as `error_code="malformed_request"`, and no Bearer challenge is emitted — the signals and recovery surface a cutover depends on do not exist. Demonstrated by running the PR #143 gate behind the master middleware stack | REQ-50, IB-5, IB-9, DEF-10, INV-30, OB-12 (ADR-017) | **P0** | CT-5: assert an unauthenticated request to a gated route answers 401 with `authentication_error`/`missing_credential` and `WWW-Authenticate: Bearer`; it fails today at the status line |
-| GAP-30 | Authorization emits no metrics at all: verdicts, snapshot age and sync failures exist only as log lines. OB-12 and OB-13 are unimplemented, so shadow-mode analysis requires protected-log aggregation and a control plane that stopped answering is invisible on a dashboard. The implementation may expose actual enforcement wire codes and a neutral shadow total only: internal rungs, hypothetical shadow verdicts, record count and request-path resolve outcomes stay in protected logs because `/metrics` is keyless | OB-12, OB-13, REQ-55, INV-30, INV-39 | P1 | add the safe decision counter, then bracket scrapes: enforcing unknown-key/wrong-secret cases share a series, while shadow valid/invalid/indeterminate cases all share the neutral series |
-| GAP-31 | Key-snapshot staleness is unbounded and unexported. A control-plane outage freezes the key set indefinitely — revocations issued during it never land — and nothing degrades, alarms, or reports age. Exactly the assignment-staleness hole of GAP-2, on a surface where the stale data is an access-control decision | REQ-54, DC-8, INV-31 ⚠, OB-13 (ADR-016, OQ-12) | P1 | age gauge first; then ratify P-KEY-SNAPSHOT-MAX-AGE via OQ-12 and test the degradation |
-| GAP-32 | INV-39's wire identity holds only while authorize-on-miss can answer authoritatively. A key id absent from the snapshot may take longer than a hit; if its lookup budget is exhausted or the control plane fails, it receives retryable OVERLOADED/UPSTREAM-FAILURE while a present id with a wrong secret receives BAD-CREDENTIAL. The accurate retry contract therefore reveals snapshot membership under lookup pressure. Public metrics must not amplify that accepted residual beyond the outcome the caller already received (OB-12/13) | INV-39 | P2 | decide whether the residual is accepted, or close it by making hits and misses share the lookup-failure outcome; bracketed scrapes must expose no internal detail either way |
-| GAP-33 | CT-10 has no harness: DC-8 has no stub in `harness/`, so every claim in the CT-10 row set is unit-tested inside the crate rather than driven black-box. Nothing exercises a concurrent rebuild against an in-flight lookup (INV-6's race), zero serving-dependency calls and one bounded DC-8 call under refusal (INV-14), verdict determinism across replicas (INV-15), secret/non-oracle disclosure in emitted signals (INV-38/39), or HZ-10's interference with legitimate new keys. All the phase-1 constants are hard-coded rather than operator-bound (15 §commercial) | CT-10, DC-8, INV-6/14/15/38/39, HZ-10 | P1 | build the DC-8 stub per IB-7; the cheapest first case is INV-14's call-ledger assertion, which needs only the stub's ledger |
-| GAP-34 | Snapshot-miss failures and digestless tombstones violate the authorization contract in #143. Rate/in-flight exhaustion and control-plane errors all return `None`, so a valid fresh key receives non-retryable BAD-CREDENTIAL instead of OVERLOADED/UPSTREAM-FAILURE. A revoked or malformed tombstone carries no digest, yet the evaluator returns `revoked` before comparing the presented secret, exposing that the guessed key id exists and violating INV-39's secret-first rule | REQ-53/54, DC-8, INV-39, ADR-017 | P1 | split `get_or_resolve` into authoritative unknown vs overloaded vs unavailable; map the latter two to retryable taxonomy outcomes, and map every digestless record to BAD-CREDENTIAL; CT-10 pins all four paths |
+| GAP-30 | Nothing consumes the authorization signals OB-12/13 require, and none of OB-9's three commercial alarms exists: no dashboard shows refusal rate by code against admitted traffic, and grace admissions — the only warning before the `expires_at` cliff, and the whole window an operator has to act in — has no alarm rule. Lives in the monitoring stack, not the binary, so it does not block GAP-35 but must not trail it into production either | OB-9, OB-12, OB-13 (presentation only) | P2 | alarm on the grace counter first, then build the cutover dashboard |
+| GAP-32 | **Accepted residual.** A credential with no cached grant costs an exchange and so answers more slowly than a cached one. In enforcing mode, under exchange pressure it receives retryable OVERLOADED/UPSTREAM-FAILURE where a cached credential receives BAD-CREDENTIAL, so the accurate retry contract also reveals cache membership in the response; shadow mode admits both and keeps the same neutral public projection. Accepted rather than closed: collapsing the enforcing outcomes means answering a dependency failure with a claim about the key, which REQ-54 forbids. It is not a key-id oracle — the cache is keyed on the whole credential, so an unknown id and a wrong secret miss identically — and public metrics do not amplify it | INV-39 | P3 | revisit only if the channel is shown to be exploitable at scale |
+| GAP-33 | CT-10 has no harness: DC-8 has no stub in `harness/` and none of the CT-10 row set is driven black-box. Distinct from GAP-35 — that one is the implementation, this one is the means of proving it. A ledger is what the claims need: zero serving-dependency calls under refusal (INV-14) and the secret's single egress (INV-38) are otherwise structural rather than asserted, and verdict determinism across replicas (INV-15), a retired generation completing after its successor (INV-6), LIV-13's clock and HZ-10's interference with legitimate uncached keys have nothing to run against | CT-10, DC-8, INV-6/14/15/38, HZ-10 | P1 | build the DC-8 exchange stub per IB-7; the cheapest first case is INV-14's call-ledger assertion, which needs only the stub's ledger |
+| GAP-35 | The commercial band is specification only at this baseline: the binary contains no authorization code, so REQ-50..56, DC-8, OP-11, INV-6/14/15/38/39 and LIV-13/14 are all unmet by absence rather than by defect. A deployment without commercial configuration is unaffected, but the wire contract binds another component, so the specification is deliberately ahead of the code | REQ-50..56, DC-8, OP-11, INV-6/14/15/38/39, LIV-13/14, OB-12/13 | P1 | ratify ADR-016/018, then land the exchange path failing-test-first against the GAP-33 stub. LIV-13's `expires_at` convergence with the control plane stopped is the case to write first — it carries the security claim the retired mirror could not make |
 
 ### Closed findings
+
+- **GAP-31** (closed 2026-08-06; superseded 2026-08-07): key-snapshot staleness was
+  unbounded and unexported, and was closed by exporting an age gauge and alarming on it.
+  ADR-016's revision removed the snapshot, and with it both the defect and its fix: the
+  stale-authorization window is now a deadline the control plane sets on each grant rather
+  than an age a dashboard watches. What the closure argued still holds and is why INV-31
+  reads as it does — a staleness rule in the binary would pull the whole fleet from
+  rotation at once, since every replica shares one authority.
+
+- **GAP-29** (closed 2026-08-05): authorization refusals were built outside the ADR-011
+  envelope, so they carried no `ErrorCode` and the middleware every routed response passes
+  through rewrote them to 400 `malformed_request`. No 403 reached the wire and every refusal
+  counted as a client query error. ADR-017's two types and six codes are implemented and
+  CT-5 pins an unauthenticated request behind
+  the *real* middleware stack — the only place the defect was visible, since the gate and
+  the normalizer were each correct alone.
+- **GAP-34** (closed 2026-08-05): rate and in-flight exhaustion and control-plane errors
+  all collapsed onto one "no such key" answer, so a key minted seconds earlier was told
+  non-retryably that it was invalid. `Lookup` now separates the authoritative unknown from
+  saturation and from failure, and the latter two answer OVERLOADED and UPSTREAM-FAILURE
+  per REQ-54. The digestless tombstone half is closed too: it answers `invalid_credential`
+  and keeps `revoked_tombstone` on the protected axis, where naming it discloses nothing.
+  Writing the test store's control plane is what exposed the first half — until then the
+  suite's "unknown key" case was really its unreachable-control-plane case. (The tombstone
+  half was made moot by ADR-016's revision, which leaves the Portal holding no records to
+  tombstone; the separation of saturation from failure from denial carries over intact and
+  is the part worth keeping.)
 
 - **Wrong-range worker responses** (closed 2026-07-25): a worker reporting a last block
   past the queried range end produced an inverted continuation range and panicked the
@@ -292,9 +323,11 @@ with plausible trigger · P3 polish. "Next" = cheapest failing-test-first entry.
 
 ## Build order
 
-- **Phase 1 — P1 gaps, failing tests first:** GAP-1/2/4/16/17/23/29/30/31/33/34 tests
+- **Phase 1 — P1 gaps, failing tests first:** GAP-1/2/4/16/17/23/33/35 tests
   red → fixes; GAP-3 probe + heap profile → refresh-copy fix. GAP-23 already has its
-  failing case parked in `ct2_worker_faults`'s known-violated list.
+  failing case parked in `ct2_worker_faults`'s known-violated list. GAP-35 waits on the
+  ratification it names, and GAP-33's stub is worth building first either way — an
+  implementation landing without it is one whose properties nothing can check.
 - **Phase 2 — correctness core:** full CT-1 oracle diffing; the rest of the CT-2 fault
   matrix (DC-2/DC-3/DC-4 injectors, kill/restart) on the `Fixture` + worker-injector
   scaffolding; CT-4 corpus; burn down P2 gaps.

--- a/spec/14-interface-binding.md
+++ b/spec/14-interface-binding.md
@@ -5,7 +5,7 @@ encodings — as *observable contract*, still no internals. **Anything not speci
 here is unspecified: clients and tests must not pin it** (IB-8).
 
 **IB-1 — Transport generalities.** HTTP/1.1+; permissive CORS (any origin/method/
-header), exposing `Retry-After`, `WWW-Authenticate`, `x-request-id` and the `x-sqd-*`
+header), exposing `Retry-After`, `x-request-id` and the `x-sqd-*`
 stream metadata —
 allowing an origin does not make a response header readable, and the CORS-safelisted set
 contains none of ours, so a browser client would otherwise see the status and nothing
@@ -88,20 +88,22 @@ closed mapping is:
 | `api_error` / `worker_failure` | 500 | envelope |
 | `api_error` / `internal_error` | 500 | envelope |
 | `api_error` / `unclassified` | contextual 5xx | envelope; must be counted and investigated |
-| `authentication_error` / `missing_credential` | 401 | envelope; `WWW-Authenticate: Bearer`; no `Retry-After` |
-| `authentication_error` / `invalid_credential` | 401 | envelope; `WWW-Authenticate: Bearer`; identical byte-for-byte apart from the request id whether the token was unparseable, named an unknown key, carried a wrong secret, or named a digestless tombstone (INV-39) |
-| `authentication_error` / `revoked_credential` | 401 | envelope; `WWW-Authenticate: Bearer` |
-| `authentication_error` / `expired_credential` | 401 | envelope; `WWW-Authenticate: Bearer` |
+| `authentication_error` / `missing_credential` | 403 | envelope; no `Retry-After`, no challenge |
+| `authentication_error` / `invalid_credential` | 403 | envelope; identical byte-for-byte apart from the request id whether the token was unparseable, named an unknown key, or carried a wrong secret (INV-39) |
+| `authentication_error` / `revoked_credential` | 403 | envelope |
+| `authentication_error` / `expired_credential` | 403 | envelope |
 | `permission_error` / `portal_not_allowed` | 403 | envelope |
 | `permission_error` / `dataset_not_allowed` | 403 | envelope |
 
 The last six rows appear only on a commercial deployment (REQ-56) and only on a gated
 route (IB-9). None is retryable and none carries a retry hint: retrying with the same
 credential cannot succeed, and treating an auth refusal as transient reproduces the
-ADR-012 refusal storm. Every 401 carries the Bearer challenge HTTP requires. None is an
-`api_error`, so none pages. A snapshot miss that could not be resolved is not one of these
-six rows: lookup-budget exhaustion maps to retryable `overloaded`, and lookup failure to
-retryable `upstream_unavailable` (DC-8).
+ADR-012 refusal storm. All six share one status, so the status line never reveals that a
+presented secret was the right one (ADR-017); none carries a challenge. None is an
+`api_error`, so none pages. When no usable grant exists, an exchange that could not be made
+is not one of these six rows: budget exhaustion maps to retryable `overloaded`, and a failed
+exchange to retryable `upstream_unavailable`. A suppressed renewal keeps serving on its
+still-usable grant instead (DC-8).
 
 EMPTY (204) is not in this table: it is a success, not a refusal, and carries no
 `type`/`code`. It is bound by IB-4 — no body, head-marker headers, emitted after
@@ -116,8 +118,7 @@ resolve (OP-5) uses the same envelope and code vocabulary.
 `not_ready` envelope (OB-5). `/metrics`: OpenMetrics; families under the `portal_` prefix
 with a constant portal-identity label. On commercial deployments the keyless scrape obeys
 12's confidentiality rule: no internal auth rung or lookup detail beyond the public wire
-outcome under either gate scope, and no dataset identity under `all`. `/status`, `/state`,
-`/debug/*`: bodies explicitly unstable (REQ-14).
+outcome. `/status`, `/state`, `/debug/*`: bodies explicitly unstable (REQ-14).
 
 **IB-7 — Input-side binding (what harness stubs implement).** Worker stub (DC-1): the
 peer-to-peer query protocol — signed query in, sized/compressed result or typed error
@@ -127,10 +128,15 @@ and metadata documents. Real-time stub (DC-4): `/head`, `/finalized-head`, `/sta
 `/stream`, `/finalized-stream` under `datasets/{name}`, honoring the portal-supplied
 client-identity header, emitting head headers and `x-internal-*` noise for
 strip-testing, plus every 4xx/5xx/409 shape needed to assert error normalization. RPC
-stub (DC-5): the contract read set. Control-plane stub (DC-8): the cursor-paged key feed
-with its four-field envelope, plus the single-key lookup — and, as a fault injector, the
-epoch flip, head rollback, non-advancing cursor, short-of-head page, malformed record and
-unrecognized status the DC-8 error table names (⚠ unbuilt — GAP-33). Log-sink stub (DC-6) and error-report stub (DC-7):
+stub (DC-5): the contract read set. Control-plane stub (DC-8): the credential exchange —
+credential in, grant or denial out — verifying the exact `X-Portal-Id`,
+`X-Signature-Timestamp`, and `X-Signature` contract of ADR-018 and refusing malformed,
+unattributable, past-skewed, or future-skewed requests, with a ledger of every credential it
+was asked about; and, as a fault
+injector, the denial, the unreadable answer, the unrecognized claims version, the
+wrong-subject answer, the over-cap lifetime, the late completion of a retired exchange
+generation after its successor, and the outage the DC-8 error table names (⚠ unbuilt —
+GAP-33). Log-sink stub (DC-6) and error-report stub (DC-7):
 fire-and-forget receivers with ledgers, so egress audits (INV-37) and drop accounting
 (HZ-7) have ground truth. Stubs double as fault
 injectors for the CT-2 matrix.
@@ -138,38 +144,41 @@ injectors for the CT-2 matrix.
 **IB-9 — Authorization binding.** Commercial deployments only (REQ-56); on any other
 deployment nothing in this rule is observable.
 
-*Presentation.* A credential is accepted as `Authorization: Bearer <token>` or as the
-`api_key` query parameter, in that precedence. The query channel exists because some
-browser transports cannot set headers on every request; operators should assume a token
-presented that way is recorded by intermediaries and access logs, which is a property of
-URLs, not of this binding.
+*Presentation.* A credential is accepted as `Authorization: Bearer <token>` and nowhere
+else. A query-string channel is deliberately not offered: it would exist to serve
+transports that cannot set headers, and this binding has none — every gated route is POST
+but the timestamp lookup, and `fetch` sets headers on both. What it would have is a secret
+in a URL, which browser history, `Referer` and every intermediary's access log record
+outside this system's reach.
 
 *Token grammar.* `<prefix><key_id>_<secret>`, where the prefix is one the control plane
 mints, the two segments draw from `[A-Za-z0-9~-]`, and their lengths are at most
 P-KEY-ID-MAX-LEN and P-KEY-SECRET-MAX-LEN. A token outside this grammar is refused as
-`invalid_credential` without a lookup — it is not something the control plane could have
-issued (REQ-52).
+`invalid_credential` without an exchange — it is not something the control plane could have
+issued (REQ-52). This check is the cheapest rung and runs first for that reason: it is what
+keeps arbitrary client bytes from reaching a control-plane call (PF-7).
 
-*Gated surface.* Every route in IB-2 carries exactly one class (DEF-19). Under gate scope
-`data`, the gated set is the stream routes, the timestamp-to-block lookup, the direct
-worker query, and the SQL query plan. Under `all`, it additionally includes every
-metadata route: the catalog, per-dataset metadata and state, all head and height
-variants, `/status`, the worker lookup and the debug surfaces. `/ready`, `/metrics` and
-`/api-docs/openapi.json` are gated under neither, and the docs UI is deliberately open
-because it serves the same schema on every deployment and names no dataset. A route whose
-class is unstated is a build failure, not an ungated route (REQ-51).
+*Gated surface.* The gated set is the stream routes, the timestamp-to-block lookup, the
+direct worker query, and the SQL query plan (DEF-19). Every other route in IB-2 answers
+without a credential on every deployment (NG8): the catalog, per-dataset metadata and
+state, all head and height variants, `/status`, the worker lookup, the debug surfaces,
+`/ready`, `/metrics`, `/api-docs/openapi.json` and the docs UI. A route that states
+neither does not compile (REQ-51).
 
 Because `/metrics` is deliberately keyless, its commercial representation is part of the
-authorization boundary rather than an exemption from it: it must not reveal a dataset
-identity under `all`, an internal authorization rung, a key-record count, or whether one
-request hit the snapshot or invoked authorize-on-miss beyond what that request's own wire
-outcome already disclosed (OB-1/12/13, INV-39).
+authorization boundary rather than an exemption from it: it must not reveal an internal
+authorization rung, or which key ids exist, beyond what a request's own wire outcome already
+disclosed. Enforcing-mode aggregate exchange counters are publishable because the grant
+cache is keyed on the whole credential, so they cannot separate an unknown key id from a
+wrong secret; what they do reveal — cache membership — is the residual INV-39 already
+accepts. Shadow mode publishes only the neutral authorization projection (OB-12/13).
 
 *Interaction with the envelope.* An auth refusal is emitted in the IB-5 envelope with the
 codes above. It must reach the client with the status IB-5 binds to its code — a refusal
 carrying no code is normalized onto `malformed_request` at 400 by the same rule that
-catches framework rejections, which would erase the distinction this rule exists to make
-(GAP-29).
+catches framework rejections, which would erase the distinction this rule exists to make.
+Emitting through the envelope is what prevents that, and CT-5 pins it behind the real
+middleware stack rather than at the gate alone.
 
 **IB-8 — Versioning rule.** Any change to this binding (route, code, header, schema,
 taxonomy) updates this file and the interface-conformance class CT-5 in the same

--- a/spec/15-parameters.md
+++ b/spec/15-parameters.md
@@ -2,7 +2,7 @@
 
 **Mutable doc.** Every `P-*` symbol used anywhere in the suite has a row here; the
 operator binds them through the configuration object (DEF-15).
-"Observed" is the current default/behavior at version 0.11.9 (operator-overridable
+"Observed" is the current default/behavior at version 0.12.1 (operator-overridable
 unless marked *fixed*); "Target" is the ratified intent. ⚠ = proposed, awaiting
 ratification via the linked ADR. Environmental rows describe the world the Portal
 assumes, not knobs it owns.
@@ -70,7 +70,7 @@ assumes, not knobs it owns.
 | P-DRAIN-TIMEOUT | In-flight drain budget after intake stops (REQ-24, ADR-005) | 25 s | 25 s |
 | P-KILL-GRACE | *Environmental:* the orchestrator's grace between SIGTERM and SIGKILL — Kubernetes `terminationGracePeriodSeconds` (REQ-24, LIV-11, ADR-005) | deployment-set, unverified; the Kubernetes default of 30 s is **below** the 50 s budget | ≥ P-PRE-DRAIN-GRACE + P-DRAIN-TIMEOUT + slack (≥ 60 s) |
 | P-READY-CONNECTION-RATIO | Min fraction of known workers connected for readiness (REQ-23) | 3/4 *(fixed)* | 3/4 |
-| P-STARTUP-BOUND | ⚠ Start → ready bound, including artifact fetch and enforcing-commercial key bootstrap (LIV-5, S5) | unmeasured | ⚠ 10 min (proposed) |
+| P-STARTUP-BOUND | ⚠ Start → ready bound; artifact fetch and apply only, commercial configuration adding no term (LIV-5, S5) | unmeasured | ⚠ 10 min (proposed) |
 | P-STALL-BUDGET | ⚠ Max zero-progress interval on a healthy stream; also the first-record bound (LIV-1, LIV-2, OB-2) | unmeasured | ⚠ 2 × P-TRANSPORT-TIMEOUT (proposed) |
 
 ## Accounting & reporting
@@ -85,21 +85,22 @@ assumes, not knobs it owns.
 
 ## Commercial access control
 
-Bound only on a commercial deployment (REQ-56); unused elsewhere. "Observed" values are
-those of the phase-1 implementation under review (PR #143), which hard-codes all but the
-sync interval — making them operator-bindable is part of closing GAP-33.
+Bound only on a commercial deployment (REQ-56); unused elsewhere. Every row is
+operator-bindable in the `commercial:` block and defaults to its observed value; the
+targets stay proposals until OQ-15 ratifies them against a measured credential working
+set, which is the only thing that can size them honestly.
 
 | Parameter | Role (where used) | Observed | Target |
 |---|---|---|---|
-| P-KEY-SYNC-INTERVAL | Key-feed poll interval; one term in the page-count-dependent revocation-convergence bound (DC-8, LIV-13) | 10 s | 10 s |
-| P-KEY-PAGE-LIMIT | Records requested per feed page; also defines what a "short page" is (DC-8) | 1000 *(fixed)* | 1000 |
-| P-KEY-FETCH-TIMEOUT | Per-page feed and single-key lookup deadline; sync ticks are serialized, and LIV-13 accounts for one such bound per page (DC-8) | 5 s *(fixed)* | 5 s |
-| P-KEY-MAX-PAGES-PER-TICK | Bound on pages read in one drain; larger delta backlogs continue next tick, while an atomic bootstrap must fit inside the bound (DC-8, LIV-5/13) | 10000 *(fixed)* | 10000 |
-| P-KEY-SNAPSHOT-MAX-AGE | ⚠ Max tolerated key-snapshot age before an enforcing Portal degrades (REQ-54, INV-31, OB-13) | **unbounded — GAP-31** | ⚠ ratify via OQ-12 |
-| P-KEY-NEGATIVE-TTL | How long a "control plane knows nothing about this key" answer suppresses repeat lookups (DC-8) | 15 s *(fixed)* | 15 s |
-| P-KEY-NEGATIVE-CAPACITY | Cap on remembered negative answers; ids are attacker-chosen, so the map is bounded rather than grown (DC-8, HZ-10) | 4096 *(fixed)* | 4096 |
-| P-KEY-RESOLVE-RATE | Token-bucket rate for authorize-on-miss lookups (DC-8, LIV-14, HZ-10) | 20 /s *(fixed)* | ⚠ one budget serves two opposed purposes — bounding attacker cost and admitting legitimate new keys (HZ-10); ratify via GAP-33 once CT-10 can measure the interference |
-| P-KEY-RESOLVE-INFLIGHT | Cap on concurrent authorize-on-miss lookups (DC-8, HZ-10) | 16 *(fixed)* | 16 |
+| P-GRANT-MAX-LIFETIME | Cap on the `expires_at` the Portal will honour, however long a one the control plane offers. The fleet's worst-case stale-authorization window, and the only lifetime term the Portal owns (REQ-54, DC-8, LIV-13) | 900 s | ⚠ 15 min (draft; ratify via OQ-15) |
+| P-GRANT-EXCHANGE-TIMEOUT | Per-exchange deadline; must stay < P-CLIENT-TIMEOUT (DC-8, ADR-010, PF-7) | 2 s | ⚠ 2 s (draft; ratify via OQ-15) |
+| P-GRANT-EXCHANGE-RATE | Token-bucket rate for exchanges (DC-8, LIV-14, HZ-10) | 20 /s | ⚠ one budget serves two opposed purposes — bounding attacker cost and admitting legitimate uncached keys (HZ-10); ratify via OQ-15 once CT-10 can measure the interference |
+| P-GRANT-EXCHANGE-INFLIGHT | Cap on concurrent exchanges (DC-8, HZ-10) | 32 | ⚠ 32 (draft; ratify via OQ-15) |
+| P-GRANT-CACHE-CAPACITY | Cap on cached grants; sized by the replica's credential working set, not by the key set (DEF-18, DC-8, HZ-13) | 65536 | ⚠ 65536 (draft; ratify via OQ-15) |
+| P-GRANT-NEGATIVE-TTL | How long an authoritative denial suppresses repeat exchanges for the same fingerprint (DC-8) | 15 s | ⚠ 15 s (draft; ratify via OQ-15) |
+| P-GRANT-NEGATIVE-CAPACITY | Cap on remembered denials; fingerprints are attacker-chosen, so the map is bounded rather than grown (DC-8, HZ-10) | 4096 | ⚠ 4096 (draft; ratify via OQ-15) |
+| P-GRANT-REFRESH-JITTER | Spread applied to `refresh_after` so a cohort of grants issued together does not renew together (DC-8, HZ-12, LIV-13) | 10% | ⚠ 10% of the refresh interval (draft; ratify via OQ-15) |
+| P-SIGNATURE-MAX-SKEW | *Environmental:* maximum absolute clock skew accepted on a signed request; a timestamp farther in the past or future fails every exchange at once (DC-8, ADR-018, 08 §0) | n/a — the control plane's bound, not the Portal's | control-plane-set; ⚠ 30 s assumed (ratify via OQ-15) |
 | P-KEY-ID-MAX-LEN | Max accepted key-id length; mirrors what the control plane can mint (IB-9, REQ-52) | 64 *(fixed)* | 64 |
 | P-KEY-SECRET-MAX-LEN | Max accepted secret length (IB-9, REQ-52) | 128 *(fixed)* | 128 |
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -19,7 +19,7 @@ nothing durable survives a restart). Modules 06 (consistency/durability) and 10
 refreshed-snapshot lifecycle is folded into 05. Numbering gaps are canonical, never
 recycled.
 
-Commercial access control (REQ-50..REQ-56, DC-8, ADR-016/017) is **conditional**: every
+Commercial access control (REQ-50..REQ-56, DC-8, ADR-016/017/018) is **conditional**: every
 property in that area is vacuous on a Portal the operator has not configured
 commercially, which is the default and the only mode a self-hosted build has. It is
 spread through the existing documents rather than given one of its own, because it is a
@@ -64,8 +64,9 @@ not been ratified are explicitly `Proposed` and appear after the accepted log.
 | ADR-014 | 2026-07-17 | [Contract reconciliation: overload hints, conflict precedence, artifact regression, archival finalized head, EMPTY metadata, timestamp frontier, gated debug surface](decisions/ADR-014-contract-reconciliation.md) | Accepted |
 | ADR-015 | 2026-07-21 | [One connection-class replay on the real-time path](decisions/ADR-015-real-time-connection-replay.md) | Accepted |
 | ADR-013 | 2026-07-17 | [Assignment staleness must be bounded and observable](decisions/ADR-013-assignment-staleness-bound.md) | **Proposed** |
-| ADR-016 | 2026-08-05 | [The Portal authenticates requests itself](decisions/ADR-016-portal-side-authentication.md) | **Proposed** |
-| ADR-017 | 2026-08-05 | [Authentication and permission errors extend the ADR-011 taxonomy](decisions/ADR-017-auth-error-taxonomy.md) | **Proposed** |
+| ADR-016 | 2026-08-05 | [The Portal authenticates requests itself](decisions/ADR-016-portal-side-authentication.md) | **Proposed** (revised 2026-08-07) |
+| ADR-017 | 2026-08-05 | [Authentication and permission errors extend the ADR-011 taxonomy](decisions/ADR-017-auth-error-taxonomy.md) | **Proposed** (wording aligned 2026-08-07) |
+| ADR-018 | 2026-08-07 | [The Portal signs its control-plane requests](decisions/ADR-018-signed-control-plane-requests.md) | **Proposed** |
 
 ## Conventions
 
@@ -94,11 +95,14 @@ not been ratified are explicitly `Proposed` and appear after the accepted log.
 1. **Extend the harness past Phase 0** (13 §build order): the Phase-0 skeleton —
    dependency stubs per IB-7, the structural validators, the reference model — has
    landed (GAP-14 closed 2026-07-17); build the `CT-2..CT-9` classes on it next.
-2. **Ratify or reject proposed ADR-013, ADR-016 and ADR-017** and the ⚠ targets in
-   [15-parameters.md](15-parameters.md) and the SLO table (11); close the open questions
-   in [02-requirements.md](02-requirements.md). ADR-016 and ADR-017 are a pair: the
-   first makes the Portal refuse requests on identity grounds, the second gives those
-   refusals somewhere to live in the error taxonomy — adopting the first without the
-   second is what GAP-29 records.
+2. **Ratify or reject proposed ADR-013 and the ADR-016/017/018 group** and the ⚠ targets
+   in [15-parameters.md](15-parameters.md) and the SLO table (11); close the open
+   questions in [02-requirements.md](02-requirements.md). The three commercial ADRs stand
+   or fall together: ADR-016 makes the Portal refuse requests on identity grounds, ADR-017
+   gives those refusals somewhere to live in the error taxonomy, ADR-018 says how the
+   Portal proves its own identity to the authority it asks. ADR-017's taxonomy is
+   implemented. ADR-016 was revised on 2026-08-07 from a mirrored key set to an on-demand
+   exchange; that exchange and ADR-018's signed channel remain specification-only at this
+   baseline (GAP-35). They need both ratification and implementation.
 3. **Burn down the gap register** in [13-conformance.md](13-conformance.md) in priority
    order — failing test first, fix second, matrices updated in the same change.

--- a/spec/decisions/ADR-016-portal-side-authentication.md
+++ b/spec/decisions/ADR-016-portal-side-authentication.md
@@ -1,6 +1,6 @@
 # ADR-016 — The Portal authenticates requests itself
 
-Status: Proposed (2026-08-05)
+Status: Proposed (2026-08-05, revised 2026-08-07)
 
 ## Context
 
@@ -17,6 +17,13 @@ access decision, for two reasons the suite never wrote down:
 Meanwhile the control plane already mints keys and knows their state. The missing half
 is a data plane that can decide, per request, whether to serve.
 
+**Revised 2026-08-07.** The first draft had the Portal mirror the control plane's entire
+key set into memory — bootstrap from a cursor-paged feed, tail ordered deltas, rebuild on
+epoch change — and answer every request from that mirror. The mechanism below replaces it
+with an on-demand exchange. The position is unchanged: the Portal still decides, still
+only where an operator asked for it, still fail-closed on the credential. Only the way it
+learns the answer changed. §Why not the mirror records what that trade bought and cost.
+
 ## Decision
 
 The Portal authenticates and coarsely authorizes each request itself, when — and only
@@ -26,50 +33,104 @@ when — the operator configures it to.
    gate, no control-plane dependency, and no authorization middleware: byte-for-byte the
    behavior of a self-hosted build (REQ-56). Configuration present but empty is a
    startup error, never an open portal.
-2. **Mirror, don't ask.** The Portal tails the control plane's key feed into an
-   in-memory snapshot (DC-8) and verifies presented secrets locally against the published
-   digest. The request path makes no control-plane call except the bounded
-   authorize-on-miss lookup that lets a key minted seconds ago work before the next sync.
-3. **Fail-closed on the key, fail-static on the feed.** An unknown key is refused. A
-   control-plane outage does not invalidate a snapshot hit: the last good snapshot keeps
-   answering (REQ-54). A miss that cannot be resolved is refused retryably as overload
-   when its local lookup budget is exhausted, or as upstream unavailability when the call
-   fails — never mislabeled as an invalid credential. The two paths differ because
-   refusing every snapshot hit during a control-plane blip is a worse outage than briefly
-   honoring a key that was just revoked.
-4. **Enforcement is a mode, not a deploy.** `log_only` attempts the whole ladder, records
-   the verdict it would have returned or an indeterminate lookup that prevented one, and
+2. **Ask, then cache.** The Portal holds no key set. The first request presenting a given
+   credential exchanges it at the control plane (DC-8) for a short-lived **grant**: an
+   authorization answer carrying explicit claims and the lifetimes the control plane chose
+   for them. The grant is cached under a fingerprint of the *whole* credential — never
+   under the key id, or the next caller to name that id would be admitted without proving
+   it holds the secret — and answers every later request locally until it needs refreshing.
+3. **Two deadlines, both the control plane's.** A grant carries a soft `refresh_after` and
+   a hard `expires_at`. Past the soft one the Portal re-exchanges while still serving on
+   the grant it has; past the hard one it must not serve on that grant at all. An
+   authoritative denial replaces a cached grant the moment it arrives, at any point in the
+   grant's life. The split is what keeps a refresh off the request's latency path while
+   still bounding how long a stale answer can be acted on — one deadline can do one or the
+   other, not both.
+4. **Fail closed on the credential, retryable on the dependency.** A credential the Portal
+   cannot positively establish as authorized is refused. But an exchange that could not run
+   or could not answer is not a claim about the credential: without a usable grant, budget
+   exhaustion is refused as overload and a failed call as upstream unavailability, both
+   retryable, and neither is mislabeled as a bad credential. A renewal denied by the local
+   budget does not shorten a grant that is still usable; that request remains inside the
+   explicit grace the control plane issued. The Portal never invents a lifetime; it only
+   caps one (P-GRANT-MAX-LIFETIME), so a control-plane misconfiguration cannot hand the
+   fleet a month-long authorization.
+5. **Enforcement is a mode, not a deploy.** `log_only` attempts the whole ladder, records
+   the verdict it would have returned or the exchange outcome that prevented one, and
    admits regardless (REQ-55) — the cutover is a config change with a measured blast
    radius, not a leap.
-5. **Two gate scopes.** `data` gates streams, queries and block lookups and leaves
-   metadata public — correct for the shared portal, where the catalog is public knowledge.
-   `all` closes metadata too, for single-tenant portals where the catalog is the
-   disclosure (REQ-51). Readiness, metrics and the API schema are never gated in either
-   mode: a pod that cannot answer its own probe leaves rotation, and existing scrapers do
-   not need a customer key. The keyless metrics representation is correspondingly
-   constrained: no dataset identities under `all`, and no internal auth rung or lookup
-   detail beyond the public wire outcome under either scope (OB-1/12/13).
+6. **One gated surface.** Streams, queries and block lookups need a key; the catalog,
+   heads, heights, probes and the API schema do not, on every deployment (REQ-51).
+   Gating the catalog as a second scope was considered and rejected: it makes every
+   route's classification a decision (NG8). Each route states which set it is in
+   where it is declared, so there is no default to forget. The keyless metrics
+   representation stays constrained regardless: no internal auth rung or exchange detail
+   beyond the public wire outcome (OB-12/13).
 
 **NG1 is retired** and replaced by a narrower non-goal: the Portal still performs no
 per-client quota, metering, or rate limiting (NG2 unchanged) — an admitted key streams
 unrestricted. Those are later phases and are deliberately out of this decision.
 
+## Why not the mirror
+
+Both designs put the decision in the Portal. They differ in what each replica has to hold
+and what it does when the control plane is gone.
+
+The mirror's one real advantage is warm-outage availability: a replica that finished
+bootstrapping needs nobody to serve a key it already has. That is not free, and the price
+is not the one it looks like. Holding the last key set through an outage also holds every
+revocation and entitlement reduction issued during it, for as long as the outage lasts.
+"Keep the last snapshot" is an availability policy and an *unbounded stale-authorization*
+policy in the same sentence, and exporting the age (which the first draft did) reveals the
+condition without bounding it. The exchange makes that window a number the control plane
+sets and the Portal caps.
+
+The rest of the comparison follows the working set. A mirror is sized by the key set;
+an exchange cache is sized by the keys actually presenting themselves at that replica. The
+mirror multiplies the whole authorization corpus — verifier material included — by the
+replica count, puts a full scan on every cold start and every epoch rebuild, and grows
+without a bound the Portal owns. It also carries a distributed-state protocol the Portal
+would have to keep correct forever: cursors, page ordering, forward-only application,
+tombstones, epoch changes, and the bootstrap-capacity question underneath all of it.
+
+What the exchange gives up is precisely the warm-outage guarantee. It is a harder
+availability dependency: a control plane that is down cannot mint a grant, so a credential
+this replica has not seen recently is refused — retryably, and visibly as a dependency
+failure rather than as a bad key, but refused. Cached traffic rides the outage out to
+`expires_at` and then stops. That is the trade, taken deliberately: a bounded, explicit
+stale-authorization window and a working-set-sized replica, against a dependency the
+deployment must run like a production service. There is no third option — no offline
+authorization design gives immediate revocation and unlimited operation without its
+authority at the same time.
+
+The mechanism this rejects would remain a reasonable fallback if the total key set were
+predictably small and capped, nearly all of it active, and serving every known key through
+a prolonged control-plane outage were a hard requirement. None of those hold today.
+
 ## Consequences
 
-The Portal gains a dependency it can be down without (DC-8) and a readiness precondition
-it cannot serve without: an *enforcing* portal that has never mirrored the key set knows
-no keys, so it would answer 401 to every valid one, and must stay out of rotation until
-the first sync lands (INV-31). A shadow-mode portal has no such precondition, since it
-admits regardless.
+The Portal gains a dependency it can be down without only for as long as the grants it
+already holds live (DC-8). Two things the first draft owed the reader disappear with the
+mirror: there is no bootstrap, so an enforcing Portal is ready without ever having reached
+the control plane (INV-31 loses its key conjunct and LIV-5 its bootstrap term), and there
+is no fleet-wide snapshot age to alarm on. Startup gets simpler and strictly faster.
+
+Revocation convergence becomes a bound rather than a hope: `refresh_after` plus one
+exchange while the control plane is healthy, and `expires_at` regardless of its health
+(LIV-13). Nothing needs a kill-list.
+
+The cost lands on the request path, and it is the thing to watch. Every credential this
+replica has not cached costs a control-plane call, and the credentials an attacker
+controls are exactly the uncached ones — so the exchange budget is both the Portal's
+protection and, when a flood drains it, the reason a legitimate new key is turned away
+(HZ-10). The first draft could fall back on a mirror; this one cannot. Bounded caches,
+single-flight per fingerprint, negative caching and fail-closed miss budgets are therefore
+not hardening to add later — they are what makes the gate safe to expose at all.
 
 Rejection reasons become a public contract surface, which is what forces ADR-017: the
 ADR-011 vocabulary has no way to say "your credential is the problem" and no status
 outside the 400/404/409/5xx set.
 
-Two properties now need bounds the suite did not previously owe anyone: how long a
-revocation may take to reach a replica (LIV-13) and how stale a snapshot may get before
-the deployment should stop trusting it (P-KEY-SNAPSHOT-MAX-AGE ⚠, GAP-31). Both are
-the key-set analogue of the assignment-staleness question ADR-013 leaves open, and
-should be ratified together.
+How the Portal proves its own identity to the control plane is ADR-018.
 
 Shapes REQ-50..REQ-56; adds DC-8; retires NG1.

--- a/spec/decisions/ADR-017-auth-error-taxonomy.md
+++ b/spec/decisions/ADR-017-auth-error-taxonomy.md
@@ -1,6 +1,7 @@
 # ADR-017 — Authentication and permission errors extend the ADR-011 taxonomy
 
-Status: Proposed (2026-08-05)
+Status: Proposed (2026-08-05, wording aligned 2026-08-07 with ADR-016's revision; the
+decision itself is unchanged)
 
 ## Context
 
@@ -9,16 +10,15 @@ and a code→status binding that IB-5 calls exact. It was written for a Portal t
 not refuse a request on grounds of *who was asking*, so it has no way to say so — and,
 because the binding is closed, no status outside the set it enumerates.
 
-ADR-016 makes the Portal refuse on exactly those grounds. Its rejections are 401 and
-403, statuses that appear nowhere in IB-5, carrying reasons — missing credential,
-unknown key, revoked, expired, wrong portal, wrong dataset — that map onto no existing
-code.
+ADR-016 makes the Portal refuse on exactly those grounds, with a status that appears
+nowhere in IB-5, carrying reasons — missing credential, unknown key, revoked, expired,
+wrong portal, wrong dataset — that map onto no existing code.
 
 This is not a theoretical gap. A refusal that names no code is normalized by the
 middleware every routed response passes through: an unmatched client error is rewritten
 onto `malformed_request` and its bound status, 400. An authentication failure emitted
 outside this vocabulary therefore does not merely carry a vague code — it *stops being a
-401*, and a client cannot distinguish "your key is invalid" from "your query is
+refusal about the credential at all*, and a client cannot distinguish "your key is invalid" from "your query is
 malformed". The observability cost matches: every auth refusal lands on the metric as
 `error_code="malformed_request"`, indistinguishable from client query errors, so the one
 signal an operator needs during a cutover — how much traffic is being turned away, and
@@ -36,47 +36,56 @@ Add two `type` values and six `code` values to the ADR-011 vocabulary.
 | `authentication_error` | no | The credential is absent, unreadable, or does not authenticate |
 | `permission_error` | no | The credential authenticated but does not cover this request |
 
-| Code | Type | Status |
-|---|---|---|
-| `missing_credential` | `authentication_error` | 401 |
-| `invalid_credential` | `authentication_error` | 401 |
-| `revoked_credential` | `authentication_error` | 401 |
-| `expired_credential` | `authentication_error` | 401 |
-| `portal_not_allowed` | `permission_error` | 403 |
-| `dataset_not_allowed` | `permission_error` | 403 |
+All six answer **403**, and none carries `WWW-Authenticate`.
 
-Both new types are non-retryable: retrying with the same credential cannot succeed, and
-a client that treats an auth refusal as a transient failure produces exactly the refusal
-storm ADR-012 exists to prevent. Neither carries `Retry-After`; every 401 carries
-`WWW-Authenticate: Bearer`. A snapshot miss that could not be resolved is not an auth
-verdict: lookup saturation remains retryable overload, and lookup failure remains
-retryable upstream unavailability (DC-8).
+| Code | Type |
+|---|---|
+| `missing_credential` | `authentication_error` |
+| `invalid_credential` | `authentication_error` |
+| `revoked_credential` | `authentication_error` |
+| `expired_credential` | `authentication_error` |
+| `portal_not_allowed` | `permission_error` |
+| `dataset_not_allowed` | `permission_error` |
 
-**`invalid_credential` deliberately covers four distinct internal reasons** — a token the
-Portal could not parse, a key id it does not know, a key id whose secret does not match,
-and a record carrying no digest with which to prove the secret. They are one wire code
-because distinguishing them turns the endpoint into an enumeration oracle: a client that
-learns "this key id exists, wrong secret" has been told which of its guesses to keep. The
-operator's need for the distinction is real and is met on the *internal* axis — protected
-structured logs (OB-12) — which no client can read. The keyless metrics surface
-deliberately keeps the same coarsening as the wire. The remaining codes are only reachable
-by someone already holding the right secret, so they can be specific without leaking
-anything (INV-39). A digestless revoked or malformed tombstone cannot establish that fact
-and therefore remains `invalid_credential`; the current #143 implementation differs
-(GAP-34).
+**One status for all six, rather than RFC 9110's 401/403 split.** The split is drawn
+where valid credentials were presented, which is exactly where a guesser learns something:
+a wrong secret answering 401 while a wrong dataset answers 403 puts "your guess was
+correct" on the status line, and nothing bounds how often a guess may be made. The status
+therefore says only that a credential problem occurred; the code says which, to whoever
+already holds the key. AWS takes the same line for the same reason.
+
+The type axis survives the collapse because it answers a different question: whether the
+credential itself is the problem or its scope is. A client branching on `type` still
+knows whether to present a different key or to ask for a wider one.
+
+Both types are non-retryable: retrying with the same credential cannot succeed, and a
+client treating an auth refusal as transient produces exactly the refusal storm ADR-012
+exists to prevent. Neither carries `Retry-After`. With no usable grant, an exchange that
+could not be made is not an auth verdict: budget saturation remains retryable overload, and
+a failed exchange remains retryable upstream unavailability. A renewal suppressed while a
+grant remains usable keeps serving that grant (DC-8).
+
+**`invalid_credential` deliberately covers three distinct internal reasons** — a token the
+Portal could not parse, a key id the authority does not know, and a key id whose secret
+does not match. They are one wire code because distinguishing them turns the endpoint into
+an enumeration oracle: a client that learns "this key id exists, wrong secret" has been
+told which of its guesses to keep. The operator's need for the distinction is real and is
+met on the *internal* axis — protected structured logs (OB-12) — which no client can read.
+The keyless metrics surface deliberately keeps the same coarsening as the wire. The
+remaining codes are only reachable by someone already holding the right secret, so they can
+be specific without leaking anything (INV-39).
 
 `api_error` keeps its meaning: an auth refusal is never an `api_error` and must never
 page. The Portal turning away an unauthenticated request is the system working.
 
 ## Consequences
 
-IB-5's table gains six rows and the status set gains 401 and 403; CT-5 covers them like
-any other binding row. `ErrorType` grows the first values that are not about the
+IB-5's table gains six rows and the status set gains 403; CT-5 covers them like any other
+binding row. `ErrorType` grows the first values that are not about the
 Portal's own health, which is the point — the existing four all answer "is this
 retryable and does it page?", and both new ones answer no to both.
 
 The `code` vocabulary is public API twice over (wire field and metric label), so these
 names are frozen on first release, per ADR-011.
 
-Amends ADR-011; required by ADR-016. GAP-29 tracks the current implementation, which
-emits an envelope that predates this vocabulary and is consequently rewritten to 400.
+Amends ADR-011; required by ADR-016.

--- a/spec/decisions/ADR-018-signed-control-plane-requests.md
+++ b/spec/decisions/ADR-018-signed-control-plane-requests.md
@@ -1,0 +1,116 @@
+# ADR-018 — The Portal signs its control-plane requests
+
+Status: Proposed (2026-08-07)
+
+## Context
+
+ADR-016 puts one call on the request path: the Portal hands a client's credential to the
+control plane and is handed back a grant that decides whether to serve. That call needs
+two things the first draft settled in a clause. The control plane must know *which* portal
+is asking, because portal scope is one of the rungs and because attribution, quota and
+abuse control at the control plane have nowhere else to key. And the call must not be
+forgeable, with replay bounded explicitly, because anyone who can make it can ask the
+authority to bless a credential of their choosing.
+
+The first draft used a shared bearer service token, one secret per deployment, sent on
+every request. That is the weakest of the available options in a way worth naming: the
+token authenticates the *sender of a header*, not the request. Whoever reads it once —
+from a log line, a proxy, a misrouted request, a snapshot of a replica's environment — can
+make any exchange the Portal could, indefinitely, from anywhere. It is a secret at rest on
+both sides, rotating it is a coordinated change across every replica and the control plane
+at once, and it binds nothing to the bytes it travels with.
+
+## Decision
+
+Every request the Portal makes to the control plane carries exactly one of each:
+
+- `X-Portal-Id: <portal_id>` — the identity whose registered keys may verify the request;
+- `X-Signature-Timestamp: <unix_seconds>` — the timestamp covered by the signature;
+- `X-Signature: <signature>` — the signature under the Portal's configured signing key.
+
+Missing, repeated, or malformed signing headers are a failed exchange. The control plane
+uses `X-Portal-Id` to select that portal's active registered public keys and accepts when
+one verifies; registration forbids the same public key under two portal identities, so a
+valid signature has exactly one identity. The timestamp is accepted only when its absolute
+skew from the control plane's current Unix time is no greater than
+P-SIGNATURE-MAX-SKEW: a date too far in the past *or the future* is refused. The Portal
+follows no redirects on these requests: a redirected exchange carries a client's
+credential somewhere the operator did not configure, and its answer is not the control
+plane's.
+
+The signature authenticates the Portal *to* the control plane and nothing in the other
+direction. The control plane's own identity, and therefore the integrity of the grant that
+comes back, rests on the transport. This is worth stating rather than assuming: the grant's
+claims are what admit traffic, so a deployment that lets the exchange run over a channel it
+does not authenticate has not weakened a detail, it has moved the gate.
+
+## Mechanism
+
+**Ed25519 over a newline-joined canonical string, raw 64-byte signature, unpadded
+base64url.** A deployment may reuse an Ed25519 network identity or configure a dedicated
+Ed25519 signing identity; the wire contract is identical, and in neither case does the
+control plane hold secret key material. The verifier is in every standard library worth
+the name; in Node it is `crypto.verify(null, message, key, signature)` with no dependency
+at all, at roughly 80 µs per call, which is spent only on a cache miss.
+
+The registered value is the **raw 32-byte public key**, also unpadded base64url — not the
+peer id — and one raw key may belong to only one `portal_id`. A peer id wraps that key in
+protobuf inside a multihash, so verifying one means depending on a libp2p implementation;
+the raw bytes drop straight into a JWK `x` member, which is base64url already.
+
+Both encodings avoid `+`, `/` and `=`. Decoders reject padding and every byte outside the
+base64url alphabet, so two textual encodings cannot name the same key or signature. A test
+asserts the alphabet and compares the signature byte-for-byte across a real HTTP hop.
+
+```
+sqd-portal-v1
+<portal_id>
+<unix_seconds>
+<METHOD>
+<request_target>
+<sha256(body) as lowercase hex>
+```
+
+Those six ASCII fields are joined by one LF byte, with no trailing LF. `portal_id` uses
+`[A-Za-z0-9._:-]+`; `unix_seconds` is unsigned base-10 with no leading zero except the value
+zero; `METHOD` is the uppercase method sent on the wire. `request_target` is the exact HTTP
+origin-form path plus optional query as transmitted — percent escapes are neither decoded
+nor normalized, and a fragment is impossible on the wire. The digest is lowercase hex over
+the exact request-body octets passed to the transport; exchange requests use no content
+encoding. No field can contain LF, so no two distinct requests share a canonical form. The
+scheme tag leads, so a Portal and a control plane that disagree about the shape fail
+verification loudly rather than subtly. A test pins the exact bytes of a worked example —
+headers, key, message and signature — against which the verifying side can be checked
+without running the Portal.
+
+**Not HMAC**, though it would verify in a microsecond rather than eighty: it is a shared
+secret, which is the thing the paragraph above rejects. The control plane would be back to
+storing something that forges portal identities if it leaks, and rotation would be back to
+a synchronized change. Eighty microseconds on a cache miss is not a price worth that.
+
+**Not RFC 9421** HTTP Message Signatures, which is the standard and would be the right
+answer if either side already spoke it. Neither does, its Node implementations are thin,
+and its generality — signature suites, component lists, negotiation — is all cost here:
+there is exactly one signer, one algorithm, and one request shape to cover.
+
+The source of the configured private key — the Portal's network identity (REQ-43) or a
+purpose-issued identity — and how the control plane stores registrations are deployment
+choices. What the contract pins is the request-carried portal identity and timestamp, the
+canonical form, the algorithm, and the active-key lookup used to verify it.
+
+## Consequences
+
+Nothing secret is stored at the control plane for this: a compromised replica is contained
+by withdrawing one public key, and adding a portal is publishing one. Rotation stops being
+a synchronized secret change and becomes an overlap between two published keys.
+
+Binding the request target and body digest makes the signature request-specific: a captured
+`X-Signature` cannot be replayed against another route, query, or credential, and the
+timestamp bounds how long it can be replayed against the same one. The price is a clock.
+The Portal must be within P-SIGNATURE-MAX-SKEW of the control plane in either direction or
+every exchange fails — which is a new environmental assumption, recorded in 08 §0 rather
+than left implicit. The failure is at least loud and correctly classified:
+it is a dependency failure, refused retryably, never a claim that the client's credential
+is bad.
+
+Amends DC-8; required by ADR-016.


### PR DESCRIPTION
Specification-only change for conditional commercial access control.

It defines:

- the on-demand credential exchange and grant lifecycle;
- the authorization error taxonomy and enforcement modes;
- the signed control-plane request wire contract;
- the related conformance and observability requirements.

The documents are aligned on limiter behavior during renewal, exchange-generation
ordering, request-local credential handling, and the public shadow-mode projection.
Implementation status remains recorded as specification-only.

Validation:

- `python3 tools/spec-lint.py`: 0 errors, 0 warnings (two existing numbering info messages);
- `git diff --check`: clean.

The change also updates local ignore patterns for development artifacts.
