### PR TITLE
fix(auth): take the control plane's mount point from config

### DIFF
--- a/harness/src/portal.rs
+++ b/harness/src/portal.rs
@@ -91,7 +91,7 @@ pub fn write_config(
     let auth_block = match (auth, e.control_plane_port) {
         (Some(c), Some(port)) => format!(
             "auth:\n  \
-             control_plane_url: http://127.0.0.1:{port}/\n  \
+             control_plane_url: http://127.0.0.1:{port}/authority\n  \
              portal_id: {id}\n  \
              enforcement: {mode}\n{key_path}{limits}",
             id = c.portal_id,

--- a/harness/src/stubs/control_plane.rs
+++ b/harness/src/stubs/control_plane.rs
@@ -31,9 +31,10 @@ use sha2::{Digest, Sha256};
 
 use super::Ledger;
 
-/// The path the portal's client builds. The signature covers it, so the stub
-/// mounts it exactly or nothing verifies.
-pub const EXCHANGE_PATH: &str = "/internal/portal/v1/exchange";
+/// Where this stub mounts the endpoint. The prefix is its own — the portal
+/// appends `v1/exchange` to whatever base it is configured with — but the
+/// signature covers the whole path, so the two have to agree exactly.
+pub const EXCHANGE_PATH: &str = "/authority/v1/exchange";
 
 /// Both sides reimplement the canonical form, so its bytes are the contract.
 /// A drift here is what the scheme tag exists to make loud.

--- a/src/auth/client.rs
+++ b/src/auth/client.rs
@@ -7,7 +7,10 @@ use super::{
 };
 use crate::auth::extractor::Credential;
 
-const EXCHANGE_PATH: [&str; 4] = ["internal", "portal", "v1", "exchange"];
+/// The version and the operation only. Where the control plane mounts its
+/// portal API is its own routing, carried by `auth.control_plane_url`, so
+/// moving that mount point is a config change rather than a portal release.
+const EXCHANGE_PATH: [&str; 2] = ["v1", "exchange"];
 
 /// What one exchange established. Anything else propagates as an error, which
 /// the caller turns into a retryable refusal rather than a verdict.
@@ -88,7 +91,8 @@ impl ControlPlaneClient {
     }
 }
 
-/// Appends the internal API path to a base that may carry a prefix of its own.
+/// Appends the endpoint to a base that carries the control plane's own mount
+/// point, prefix and all.
 fn endpoint_url(base: &Url, segments: &[&str]) -> anyhow::Result<Url> {
     let mut url = base.clone();
     url.set_query(None);
@@ -226,7 +230,7 @@ mod tests {
     async fn the_exchange_does_not_follow_redirects() {
         let app = Router::new()
             .route(
-                "/internal/portal/v1/exchange",
+                "/authority/v1/exchange",
                 post(|| async { Redirect::temporary("/elsewhere") }),
             )
             .route(
@@ -241,7 +245,7 @@ mod tests {
 
         let cp = MockControlPlane::spawn().await;
         let mut config = cp.config();
-        config.control_plane_url = format!("http://{addr}").parse().unwrap();
+        config.control_plane_url = format!("http://{addr}/authority").parse().unwrap();
 
         let err = client_for(&config)
             .await
@@ -262,19 +266,23 @@ mod tests {
     fn endpoint_url_appends_to_bases_with_and_without_trailing_slash() {
         assert_eq!(
             url_for("https://cp.example"),
-            "https://cp.example/internal/portal/v1/exchange"
+            "https://cp.example/v1/exchange"
         );
         assert_eq!(
             url_for("https://cp.example/"),
-            "https://cp.example/internal/portal/v1/exchange"
+            "https://cp.example/v1/exchange"
         );
         assert_eq!(
-            url_for("https://cp.example/saas/"),
-            "https://cp.example/saas/internal/portal/v1/exchange"
+            url_for("https://cp.example/authority"),
+            "https://cp.example/authority/v1/exchange"
         );
         assert_eq!(
-            url_for("https://cp.example/saas?x=1#f"),
-            "https://cp.example/saas/internal/portal/v1/exchange"
+            url_for("https://cp.example/authority/"),
+            "https://cp.example/authority/v1/exchange"
+        );
+        assert_eq!(
+            url_for("https://cp.example/authority?x=1#f"),
+            "https://cp.example/authority/v1/exchange"
         );
     }
 

--- a/src/auth/config.rs
+++ b/src/auth/config.rs
@@ -27,6 +27,10 @@ pub(crate) struct KeySource {
 /// requires a key. Absent, the portal behaves exactly like an OSS build.
 #[derive(Debug, Clone, Deserialize)]
 pub struct AuthConfig {
+    /// Where the control plane mounts its portal API, prefix and all — the
+    /// portal appends only the version and the operation. The route is the
+    /// other side's to move, and this is what lets it move without a release
+    /// here, and without fixing what an operator has to expose.
     pub control_plane_url: Url,
 
     /// What the control plane knows this portal as, and what it attributes the
@@ -349,7 +353,7 @@ mod tests {
     use crate::auth::test_support::env_guard;
 
     const MINIMAL: &str = r#"
-control_plane_url: https://cp.example/
+control_plane_url: https://cp.example/authority
 portal_id: portal-premium-eu
 "#;
 

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -143,7 +143,7 @@ mod tests {
 
     fn config_with(key: Option<KeySource>) -> ResolvedAuth {
         ResolvedAuth {
-            control_plane_url: "https://cp.example/".parse().unwrap(),
+            control_plane_url: "https://cp.example/authority".parse().unwrap(),
             portal_id: "portal-premium-eu".to_string(),
             key,
             enforcement: Enforcement::Enforce,

--- a/src/auth/signing.rs
+++ b/src/auth/signing.rs
@@ -99,7 +99,7 @@ pub(super) fn sign_for_test(
     .expect("a credential serializes");
     let signer = RequestSigner::new(test_keypair(), config.portal_id.clone());
     signer
-        .headers("POST", "/internal/portal/v1/exchange", &body, now_secs)
+        .headers("POST", "/authority/v1/exchange", &body, now_secs)
         .expect("signing should succeed")
         .into_iter()
         .find(|(name, _)| *name == SIGNATURE_HEADER)
@@ -124,7 +124,7 @@ mod tests {
 
     fn signature_of(signer: &RequestSigner, body: &[u8], timestamp: u64) -> String {
         let headers = signer
-            .headers("POST", "/internal/portal/v1/exchange", body, timestamp)
+            .headers("POST", "/authority/v1/exchange", body, timestamp)
             .expect("signing should succeed");
         headers
             .iter()
@@ -143,7 +143,7 @@ mod tests {
             "portal-premium-eu",
             1_800_000_000,
             "POST",
-            "/internal/portal/v1/exchange",
+            "/authority/v1/exchange",
             body,
         );
         assert!(signer
@@ -216,16 +216,16 @@ mod tests {
                 "portal-premium-eu",
                 1_800_000_000,
                 "POST",
-                "/internal/portal/v1/exchange",
+                "/authority/v1/exchange",
                 body
             ),
             "sqd-portal-v1\nportal-premium-eu\n1800000000\nPOST\n\
-             /internal/portal/v1/exchange\n\
+             /authority/v1/exchange\n\
              30650daa6d3b90517f572c1154da8fcfb1ebf678003a3e74eaa7a33826d6dd56"
         );
         assert_eq!(
             signature_of(&signer, body, 1_800_000_000),
-            "_ThgFiJAgcGa7dKAE_EOMDYaL_myOdX2BIlz6RT66ziWZtzCFrFbQ6e9hcvV0zsb0A0bYhyC5GK6Kj6EU36eCA"
+            "hiBZVhdu2sWi_FnVuywQY0JiIeAPTZI0o6GIJXUYv1RMAEf3ZXCxzQwV8da21NVKSrNsdfOMICEzIJhRx1sDDQ"
         );
     }
 

--- a/src/auth/test_support.rs
+++ b/src/auth/test_support.rs
@@ -48,7 +48,7 @@ impl DatasetCatalog for NoCatalog {
 /// ladder want [`MockControlPlane`].
 pub fn gate_with(enforcement: Enforcement) -> Arc<Gate> {
     let config = ResolvedAuth {
-        control_plane_url: "http://127.0.0.1:1/".parse().unwrap(),
+        control_plane_url: "http://127.0.0.1:1/authority".parse().unwrap(),
         portal_id: "portal-premium-eu".to_string(),
         key: None,
         enforcement,
@@ -106,7 +106,7 @@ impl MockControlPlane {
     pub async fn spawn() -> Self {
         let state = Arc::new(MockState::default());
         let app = Router::new()
-            .route("/internal/portal/v1/exchange", post(exchange))
+            .route("/authority/v1/exchange", post(exchange))
             .with_state(state.clone());
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -124,7 +124,7 @@ impl MockControlPlane {
             ..config::Limits::default()
         };
         ResolvedAuth {
-            control_plane_url: format!("http://{}", self.addr).parse().unwrap(),
+            control_plane_url: format!("http://{}/authority", self.addr).parse().unwrap(),
             portal_id: "portal-premium-eu".to_string(),
             key: None,
             enforcement: Enforcement::Enforce,

--- a/src/config.rs
+++ b/src/config.rs
@@ -560,7 +560,7 @@ sqd_network:
         let _guard = crate::auth::test_support::env_guard();
         let yaml = format!(
             "{MINIMAL_YAML}auth:\n  \
-             control_plane_url: https://cp.example/\n  \
+             control_plane_url: https://cp.example/authority\n  \
              portal_id: portal-premium-eu\n  \
              enforcement: log_only\n"
         );
@@ -590,7 +590,7 @@ sqd_network:
     fn a_misspelled_key_under_auth_refuses_to_start() {
         let yaml = format!(
             "{MINIMAL_YAML}auth:\n  \
-             control_plane_url: https://cp.example/\n  \
+             control_plane_url: https://cp.example/authority\n  \
              portal_id: portal-premium-eu\n  \
              key-path: /keys/exchange.key\n"
         );
@@ -608,7 +608,7 @@ sqd_network:
         let _guard = crate::auth::test_support::env_guard();
         let yaml = format!(
             "{MINIMAL_YAML}auth:\n  \
-             control_plane_url: https://cp.example/\n  \
+             control_plane_url: https://cp.example/authority\n  \
              portal_id: portal-premium-eu\n  \
              limits:\n    \
              max_grant_lifetime_seconds: 60\n"
@@ -636,7 +636,7 @@ sqd_network:
     #[test]
     fn an_unrecognized_top_level_block_refuses_to_start_when_nothing_authorizes() {
         let _guard = crate::auth::test_support::env_guard();
-        let block = "  control_plane_url: https://cp.example/\n  \
+        let block = "  control_plane_url: https://cp.example/authority\n  \
                      portal_id: portal-premium-eu\n";
 
         let err = Config::from_reader(format!("{MINIMAL_YAML}authorisation:\n{block}").as_bytes())
@@ -657,7 +657,7 @@ sqd_network:
         let _guard = crate::auth::test_support::env_guard();
         let yaml = format!(
             "{MINIMAL_YAML}stray_key: 1\nauth:\n  \
-             control_plane_url: https://cp.example/\n  \
+             control_plane_url: https://cp.example/authority\n  \
              portal_id: portal-premium-eu\n"
         );
 


### PR DESCRIPTION
## What

`EXCHANGE_PATH` drops to `["v1", "exchange"]`. Where the control plane mounts its API moves
into `auth.control_plane_url`, which the portal already appends to:

```yaml
auth:
  control_plane_url: https://cp.example/authority   # was: https://cp.example
```

Tests and stubs mount the endpoint under a placeholder prefix, which is also what proves the
base's prefix is preserved rather than dropped.

## Why

The mount point is the control plane's routing, not the data plane's. Composing it here made
two things true that should not be: moving that route needs a portal release, and every
deployment has to expose the endpoint under the one path this side picked.

## Compatibility

Breaking for an existing `auth:` block — the base URL must now carry the prefix.

## Tests

- 280 unit tests, 105 of them under `auth::`.
- `harness/tests/ct10_authorization.rs`, all five: the stub serves the endpoint under its own
  prefix and the portal reaches it from the configured base. A wrong composition 404s, which
  is what the enforcing-gate and dedicated-key cases fail on.
- `endpoint_url` now covers a bare base, a trailing slash, a prefixed base, and one carrying a
  query and fragment.
- The published wire vector is re-derived: the canonical form covers the path, so the signature
  in it changes with the path the test signs.
- `cargo fmt --check` clean; `clippy --all-targets` reports nothing new on the touched files.