### PR TITLE
 feat(network): choose the assignment artifact by config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,7 +1700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2472,9 +2472,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flatbuffers"
-version = "25.2.10"
+version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1045398c1bfd89168b5fd3f1fc11f6e70b34f6f66300c87d44d3de849463abf1"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
  "bitflags 2.10.0",
  "rustc_version 0.4.1",
@@ -3869,7 +3869,7 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 [[package]]
 name = "libp2p"
 version = "0.56.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "bytes 1.11.1",
  "either",
@@ -3902,7 +3902,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.6.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -3912,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.15.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -3936,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.6.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -3946,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.43.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "either",
  "fnv",
@@ -3970,7 +3970,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.44.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -3985,7 +3985,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.50.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -4015,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.47.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -4035,8 +4035,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identity"
 version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3104e13b51e4711ff5738caa1fb54467c8604c2e94d607e27745bcf709068774"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -4054,7 +4053,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.49.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.11.1",
@@ -4081,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.48.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures 0.3.31",
  "hickory-proto",
@@ -4099,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.17.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures 0.3.31",
  "libp2p-core",
@@ -4116,7 +4115,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.47.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -4131,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.13.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -4152,7 +4151,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.29.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -4168,7 +4167,7 @@ dependencies = [
 [[package]]
 name = "libp2p-stream"
 version = "0.4.0-alpha"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures 0.3.31",
  "libp2p-core",
@@ -4181,7 +4180,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.47.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "either",
  "fnv",
@@ -4201,7 +4200,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -4211,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.44.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -4226,7 +4225,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.6.2"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures 0.3.31",
  "futures-rustls",
@@ -4244,7 +4243,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.5.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -4602,7 +4601,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "bytes 1.11.1",
  "futures 0.3.31",
@@ -6324,7 +6323,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.11.1",
@@ -7038,7 +7037,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures 0.3.31",
  "pin-project",
@@ -7733,7 +7732,7 @@ dependencies = [
 [[package]]
 name = "sqd-assignments"
 version = "0.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=360bbd4#360bbd4f115b44733dbfbf169bd5011f74cecb65"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=67f54cc#67f54ccec1e82a80ef95bd419af2fc20bb942129"
 dependencies = [
  "anyhow",
  "crypto_box",
@@ -7757,7 +7756,7 @@ dependencies = [
 [[package]]
 name = "sqd-contract-client"
 version = "1.3.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=e9a3434#e9a34341035ac7745b71eb87dabc8501aa434376"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=67f54cc#67f54ccec1e82a80ef95bd419af2fc20bb942129"
 dependencies = [
  "async-trait",
  "clap",
@@ -7766,6 +7765,7 @@ dependencies = [
  "libp2p",
  "log",
  "num-rational",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -7777,7 +7777,7 @@ dependencies = [
 [[package]]
 name = "sqd-messages"
 version = "2.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=e9a3434#e9a34341035ac7745b71eb87dabc8501aa434376"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=67f54cc#67f54ccec1e82a80ef95bd419af2fc20bb942129"
 dependencies = [
  "bytemuck",
  "flate2",
@@ -7793,7 +7793,7 @@ dependencies = [
 [[package]]
 name = "sqd-network-transport"
 version = "3.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=e9a3434#e9a34341035ac7745b71eb87dabc8501aa434376"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=67f54cc#67f54ccec1e82a80ef95bd419af2fc20bb942129"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,7 +1700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 2.0.96",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3869,7 +3869,7 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 [[package]]
 name = "libp2p"
 version = "0.56.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "bytes 1.11.1",
  "either",
@@ -3902,7 +3902,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.6.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -3912,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.15.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -3936,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.6.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -3946,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.43.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "either",
  "fnv",
@@ -3970,7 +3970,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.44.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -3985,7 +3985,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.50.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -4015,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.47.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -4035,7 +4035,8 @@ dependencies = [
 [[package]]
 name = "libp2p-identity"
 version = "0.2.12"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3104e13b51e4711ff5738caa1fb54467c8604c2e94d607e27745bcf709068774"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -4053,7 +4054,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.49.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.11.1",
@@ -4080,7 +4081,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.48.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "futures 0.3.31",
  "hickory-proto",
@@ -4098,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.17.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "futures 0.3.31",
  "libp2p-core",
@@ -4115,7 +4116,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.47.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -4130,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.13.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -4151,7 +4152,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.29.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -4167,7 +4168,7 @@ dependencies = [
 [[package]]
 name = "libp2p-stream"
 version = "0.4.0-alpha"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "futures 0.3.31",
  "libp2p-core",
@@ -4180,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.47.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "either",
  "fnv",
@@ -4200,7 +4201,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -4210,7 +4211,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.44.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -4225,7 +4226,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.6.2"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "futures 0.3.31",
  "futures-rustls",
@@ -4243,7 +4244,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.5.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -4601,7 +4602,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "bytes 1.11.1",
  "futures 0.3.31",
@@ -6323,7 +6324,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.11.1",
@@ -7037,7 +7038,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "futures 0.3.31",
  "pin-project",
@@ -7756,7 +7757,7 @@ dependencies = [
 [[package]]
 name = "sqd-contract-client"
 version = "1.3.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=67f54cc#67f54ccec1e82a80ef95bd419af2fc20bb942129"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=e9a3434#e9a34341035ac7745b71eb87dabc8501aa434376"
 dependencies = [
  "async-trait",
  "clap",
@@ -7765,7 +7766,6 @@ dependencies = [
  "libp2p",
  "log",
  "num-rational",
- "reqwest 0.11.27",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -7777,7 +7777,7 @@ dependencies = [
 [[package]]
 name = "sqd-messages"
 version = "2.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=67f54cc#67f54ccec1e82a80ef95bd419af2fc20bb942129"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=e9a3434#e9a34341035ac7745b71eb87dabc8501aa434376"
 dependencies = [
  "bytemuck",
  "flate2",
@@ -7793,7 +7793,7 @@ dependencies = [
 [[package]]
 name = "sqd-network-transport"
 version = "3.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=67f54cc#67f54ccec1e82a80ef95bd419af2fc20bb942129"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=e9a3434#e9a34341035ac7745b71eb87dabc8501aa434376"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,10 +96,12 @@ sqd-query = { git = "https://github.com/subsquid/data.git", rev = "eaa9f86" }
 
 sql_query_plan = { git = "https://github.com/subsquid/qplan.git", rev = "2e61b51", optional = true }
 
-# Required by the sqd-network bump: its libp2p fork moved to fac3b0c9, which builds its crates
-# against an in-tree libp2p-identity, while `multiaddr` still pulls the crates.io one. Both then
-# land in the graph and libp2p-swarm fails to compile on mismatched `PeerId` types. sqd-network
-# carries this same patch in its own root manifest, but Cargo only honours `[patch]` from the
-# workspace root, so every consumer has to repeat it.
+# Required by the span the sqd-network bump crosses, not by its tip: 541684c ("Migrate worker
+# server behaviour to libp2p-stream") moved the libp2p fork from c0ed330 to fac3b0c9, and the
+# transport pin used to sit below it. That fork builds its crates against an in-tree
+# libp2p-identity while `multiaddr` still pulls the crates.io one; both then land in the graph
+# and libp2p-swarm fails to compile on mismatched `PeerId` types. sqd-network carries this same
+# patch in its own root manifest, but Cargo only honours `[patch]` from the workspace root, so
+# every consumer has to repeat it.
 [patch.crates-io]
 libp2p-identity = { git = "https://github.com/kalabukdima/rust-libp2p.git", rev = "fac3b0c9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,10 @@ sqd-query = { git = "https://github.com/subsquid/data.git", rev = "eaa9f86" }
 
 sql_query_plan = { git = "https://github.com/subsquid/qplan.git", rev = "2e61b51", optional = true }
 
-# The libp2p fork used by sqd-network builds against its in-tree libp2p-identity, so we must
-# redirect the crates.io one to the same source or two incompatible copies get linked.
+# Required by the sqd-network bump: its libp2p fork moved to fac3b0c9, which builds its crates
+# against an in-tree libp2p-identity, while `multiaddr` still pulls the crates.io one. Both then
+# land in the graph and libp2p-swarm fails to compile on mismatched `PeerId` types. sqd-network
+# carries this same patch in its own root manifest, but Cargo only honours `[patch]` from the
+# workspace root, so every consumer has to repeat it.
 [patch.crates-io]
 libp2p-identity = { git = "https://github.com/kalabukdima/rust-libp2p.git", rev = "fac3b0c9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,22 +86,15 @@ tempfile = "3"
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", features = ["profiling"] }
 
+# Only sqd-assignments moves: 67f54cc is where the portal-oriented artifact and its reader
+# live. The rest stay on e9a3434 — the transport revs in between move the libp2p fork and
+# change the worker server's API, which this change has no need for.
 sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "67f54cc", features = ["reader"] }
-sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "67f54cc", version = "1.3.0" }
-sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "67f54cc", version = "2.1.0", features = ["semver", "bitstring"] }
-sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "67f54cc", version = "3.1.0", features = ["portal", "metrics"] }
+sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "1.3.0" }
+sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "2.1.0", features = ["semver", "bitstring"] }
+sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "3.1.0", features = ["portal", "metrics"] }
 
 sqd-primitives = { git = "https://github.com/subsquid/data.git", rev = "eaa9f86", features = ["serde"] }
 sqd-query = { git = "https://github.com/subsquid/data.git", rev = "eaa9f86" }
 
 sql_query_plan = { git = "https://github.com/subsquid/qplan.git", rev = "2e61b51", optional = true }
-
-# Required by the span the sqd-network bump crosses, not by its tip: 541684c ("Migrate worker
-# server behaviour to libp2p-stream") moved the libp2p fork from c0ed330 to fac3b0c9, and the
-# transport pin used to sit below it. That fork builds its crates against an in-tree
-# libp2p-identity while `multiaddr` still pulls the crates.io one; both then land in the graph
-# and libp2p-swarm fails to compile on mismatched `PeerId` types. sqd-network carries this same
-# patch in its own root manifest, but Cargo only honours `[patch]` from the workspace root, so
-# every consumer has to repeat it.
-[patch.crates-io]
-libp2p-identity = { git = "https://github.com/kalabukdima/rust-libp2p.git", rev = "fac3b0c9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,9 +86,6 @@ tempfile = "3"
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", features = ["profiling"] }
 
-# Only sqd-assignments moves: 67f54cc is where the portal-oriented artifact and its reader
-# live. The rest stay on e9a3434 — the transport revs in between move the libp2p fork and
-# change the worker server's API, which this change has no need for.
 sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "67f54cc", features = ["reader"] }
 sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "1.3.0" }
 sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "2.1.0", features = ["semver", "bitstring"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ default-run = "sqd-portal"
 
 [features]
 sql = ["dep:once_cell", "dep:substrait", "dep:sql_query_plan"]
-mvcc-chunks = ["sqd-assignments/mvcc-chunks"]
 
 [dependencies]
 anyhow = "1"
@@ -87,12 +86,17 @@ tempfile = "3"
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", features = ["profiling"] }
 
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "360bbd4", features = ["reader"] }
-sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "1.3.0" }
-sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "2.1.0", features = ["semver", "bitstring"] }
-sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "3.1.0", features = ["portal", "metrics"] }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "67f54cc", features = ["reader"] }
+sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "67f54cc", version = "1.3.0" }
+sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "67f54cc", version = "2.1.0", features = ["semver", "bitstring"] }
+sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "67f54cc", version = "3.1.0", features = ["portal", "metrics"] }
 
 sqd-primitives = { git = "https://github.com/subsquid/data.git", rev = "eaa9f86", features = ["serde"] }
 sqd-query = { git = "https://github.com/subsquid/data.git", rev = "eaa9f86" }
 
 sql_query_plan = { git = "https://github.com/subsquid/qplan.git", rev = "2e61b51", optional = true }
+
+# The libp2p fork used by sqd-network builds against its in-tree libp2p-identity, so we must
+# redirect the crates.io one to the same source or two incompatible copies get linked.
+[patch.crates-io]
+libp2p-identity = { git = "https://github.com/kalabukdima/rust-libp2p.git", rev = "fac3b0c9" }

--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -945,7 +945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2523,6 +2523,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,7 +2655,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "libp2p"
 version = "0.56.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "bytes",
  "either",
@@ -2679,7 +2688,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.6.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -2689,7 +2698,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.15.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -2713,7 +2722,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.6.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -2723,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.43.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "either",
  "fnv",
@@ -2747,7 +2756,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.44.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "async-trait",
  "futures",
@@ -2762,7 +2771,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.50.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -2792,7 +2801,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.47.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -2811,14 +2820,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.12"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
 dependencies = [
  "bs58",
  "ed25519-dalek",
  "hkdf",
  "multihash",
- "quick-protobuf",
+ "prost 0.14.4",
  "rand 0.8.7",
  "serde",
  "sha2",
@@ -2830,7 +2840,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.49.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -2857,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.48.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -2875,7 +2885,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.17.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -2892,7 +2902,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.47.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2907,7 +2917,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.13.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2928,7 +2938,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.29.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "async-trait",
  "futures",
@@ -2944,7 +2954,7 @@ dependencies = [
 [[package]]
 name = "libp2p-stream"
 version = "0.4.0-alpha"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -2957,7 +2967,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.47.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "either",
  "fnv",
@@ -2977,7 +2987,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -2987,7 +2997,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.44.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3002,7 +3012,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.6.2"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -3020,7 +3030,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.5.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3225,7 +3235,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "bytes",
  "futures",
@@ -3889,6 +3899,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.4",
+]
+
+[[package]]
 name = "prost-build"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3929,7 +3949,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3956,7 +3989,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4510,7 +4543,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
 dependencies = [
  "futures",
  "pin-project",
@@ -4887,7 +4920,7 @@ dependencies = [
 [[package]]
 name = "sqd-contract-client"
 version = "1.3.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=67f54cc#67f54ccec1e82a80ef95bd419af2fc20bb942129"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=e9a3434#e9a34341035ac7745b71eb87dabc8501aa434376"
 dependencies = [
  "async-trait",
  "clap",
@@ -4896,7 +4929,6 @@ dependencies = [
  "libp2p",
  "log",
  "num-rational",
- "reqwest 0.11.27",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -4908,7 +4940,7 @@ dependencies = [
 [[package]]
 name = "sqd-messages"
 version = "2.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=67f54cc#67f54ccec1e82a80ef95bd419af2fc20bb942129"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=e9a3434#e9a34341035ac7745b71eb87dabc8501aa434376"
 dependencies = [
  "hex",
  "libp2p-identity",
@@ -4922,7 +4954,7 @@ dependencies = [
 [[package]]
 name = "sqd-network-transport"
 version = "3.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=67f54cc#67f54ccec1e82a80ef95bd419af2fc20bb942129"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=e9a3434#e9a34341035ac7745b71eb87dabc8501aa434376"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -945,7 +945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.119",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2523,15 +2523,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2655,7 +2646,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "libp2p"
 version = "0.56.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "bytes",
  "either",
@@ -2688,7 +2679,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.6.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -2698,7 +2689,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.15.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -2722,7 +2713,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.6.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -2732,7 +2723,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.43.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "either",
  "fnv",
@@ -2756,7 +2747,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.44.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "async-trait",
  "futures",
@@ -2771,7 +2762,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.50.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -2801,7 +2792,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.47.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -2820,15 +2811,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
+version = "0.2.12"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "bs58",
  "ed25519-dalek",
  "hkdf",
  "multihash",
- "prost 0.14.4",
+ "quick-protobuf",
  "rand 0.8.7",
  "serde",
  "sha2",
@@ -2840,7 +2830,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.49.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -2867,7 +2857,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.48.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -2885,7 +2875,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.17.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -2902,7 +2892,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.47.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2917,7 +2907,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.13.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2938,7 +2928,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.29.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "async-trait",
  "futures",
@@ -2954,7 +2944,7 @@ dependencies = [
 [[package]]
 name = "libp2p-stream"
 version = "0.4.0-alpha"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -2967,7 +2957,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.47.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "either",
  "fnv",
@@ -2987,7 +2977,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -2997,7 +2987,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.44.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3012,7 +3002,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.6.2"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -3030,7 +3020,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.5.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3235,7 +3225,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "bytes",
  "futures",
@@ -3899,16 +3889,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
-dependencies = [
- "bytes",
- "prost-derive 0.14.4",
-]
-
-[[package]]
 name = "prost-build"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3949,20 +3929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3989,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4543,7 +4510,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures",
  "pin-project",
@@ -4900,7 +4867,7 @@ dependencies = [
 [[package]]
 name = "sqd-assignments"
 version = "0.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=e9a3434#e9a34341035ac7745b71eb87dabc8501aa434376"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=67f54cc#67f54ccec1e82a80ef95bd419af2fc20bb942129"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4920,7 +4887,7 @@ dependencies = [
 [[package]]
 name = "sqd-contract-client"
 version = "1.3.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=e9a3434#e9a34341035ac7745b71eb87dabc8501aa434376"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=67f54cc#67f54ccec1e82a80ef95bd419af2fc20bb942129"
 dependencies = [
  "async-trait",
  "clap",
@@ -4929,6 +4896,7 @@ dependencies = [
  "libp2p",
  "log",
  "num-rational",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -4940,7 +4908,7 @@ dependencies = [
 [[package]]
 name = "sqd-messages"
 version = "2.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=e9a3434#e9a34341035ac7745b71eb87dabc8501aa434376"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=67f54cc#67f54ccec1e82a80ef95bd419af2fc20bb942129"
 dependencies = [
  "hex",
  "libp2p-identity",
@@ -4954,7 +4922,7 @@ dependencies = [
 [[package]]
 name = "sqd-network-transport"
 version = "3.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=e9a3434#e9a34341035ac7745b71eb87dabc8501aa434376"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=67f54cc#67f54ccec1e82a80ef95bd419af2fc20bb942129"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -24,13 +24,20 @@ hex = "0.4"
 sha2 = "0.10"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-libp2p-identity = { version = "0.2", features = ["ed25519", "rand", "peerid"] }
+# Pinned exactly, not `0.2`: the patch below supplies 0.2.12, and a caret range would let the
+# resolver pick a newer crates.io release instead, putting two libp2p_identity copies in the graph.
+libp2p-identity = { version = "=0.2.12", features = ["ed25519", "rand", "peerid"] }
 
 # Same pinned rev as the portal's Cargo.toml — the stubs must speak the exact wire ABI.
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", features = ["builder", "reader"] }
-sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", features = ["signatures"] }
-sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", features = ["worker"] }
-sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434" }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "67f54cc", features = ["builder", "reader"] }
+sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "67f54cc", features = ["signatures"] }
+sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "67f54cc", features = ["worker"] }
+sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "67f54cc" }
+
+# Mirrors the portal's own patch: the libp2p fork builds against its in-tree libp2p-identity, so
+# consumers must redirect the crates.io one or two incompatible copies get linked.
+[patch.crates-io]
+libp2p-identity = { git = "https://github.com/kalabukdima/rust-libp2p.git", rev = "fac3b0c9" }
 
 [profile.dev]
 # The libp2p tree is slow at opt-level 0 and QUIC handshakes are timing-sensitive.

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -24,20 +24,13 @@ hex = "0.4"
 sha2 = "0.10"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-# Pinned exactly, not `0.2`: the patch below supplies 0.2.12, and a caret range would let the
-# resolver pick a newer crates.io release instead, putting two libp2p_identity copies in the graph.
-libp2p-identity = { version = "=0.2.12", features = ["ed25519", "rand", "peerid"] }
+libp2p-identity = { version = "0.2", features = ["ed25519", "rand", "peerid"] }
 
-# Same pinned rev as the portal's Cargo.toml — the stubs must speak the exact wire ABI.
+# Same pinned revs as the portal's Cargo.toml — the stubs must speak the exact wire ABI.
 sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "67f54cc", features = ["builder", "reader"] }
-sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "67f54cc", features = ["signatures"] }
-sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "67f54cc", features = ["worker"] }
-sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "67f54cc" }
-
-# Mirrors the portal's own patch: the libp2p fork builds against its in-tree libp2p-identity, so
-# consumers must redirect the crates.io one or two incompatible copies get linked.
-[patch.crates-io]
-libp2p-identity = { git = "https://github.com/kalabukdima/rust-libp2p.git", rev = "fac3b0c9" }
+sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", features = ["signatures"] }
+sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", features = ["worker"] }
+sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434" }
 
 [profile.dev]
 # The libp2p tree is slow at opt-level 0 and QUIC handshakes are timing-sensitive.

--- a/harness/src/artifact.rs
+++ b/harness/src/artifact.rs
@@ -11,8 +11,10 @@ use sqd_assignments::{AssignmentBuilder, PortalAssignmentBuilder};
 use crate::world::ToyWorld;
 
 /// Which artifact the portal under test is configured to route from, mirroring its own
-/// `assignment_source`. The publisher stub always serves both — that is the migration state
-/// the portal has to work in — so this only picks which one the portal is pointed at.
+/// `assignment_source`. The stub publishes both, which models the migration window and not the
+/// states either side of it: here this picks which artifact the portal reads, never which ones
+/// exist. A network that has finished migrating publishes only the split pair, and that shape
+/// is not covered by this harness.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AssignmentSource {
     Legacy,

--- a/harness/src/artifact.rs
+++ b/harness/src/artifact.rs
@@ -30,6 +30,12 @@ impl AssignmentSource {
     }
 }
 
+impl std::fmt::Display for AssignmentSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Build the artifact assigning every archival chunk to every worker, then
 /// gzip it. The portal pre-leases `1 + retries` *distinct* workers per chunk,
 /// so a realistic world needs at least two.

--- a/harness/src/artifact.rs
+++ b/harness/src/artifact.rs
@@ -6,9 +6,27 @@ use std::io::Write;
 
 use flate2::{write::GzEncoder, Compression};
 use libp2p_identity::PeerId;
-use sqd_assignments::AssignmentBuilder;
+use sqd_assignments::{AssignmentBuilder, PortalAssignmentBuilder};
 
 use crate::world::ToyWorld;
+
+/// Which artifact the portal under test is configured to route from, mirroring its own
+/// `assignment_source`. The publisher stub always serves both — that is the migration state
+/// the portal has to work in — so this only picks which one the portal is pointed at.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AssignmentSource {
+    Legacy,
+    Portal,
+}
+
+impl AssignmentSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Legacy => "legacy",
+            Self::Portal => "portal",
+        }
+    }
+}
 
 /// Build the artifact assigning every archival chunk to every worker, then
 /// gzip it. The portal pre-leases `1 + retries` *distinct* workers per chunk,
@@ -55,7 +73,48 @@ pub fn build_gzipped(world: &ToyWorld, workers: &[PeerId]) -> anyhow::Result<Vec
         );
     }
 
-    let bytes = b.finish();
+    gzip(b.finish())
+}
+
+/// The same world in the portal-oriented format. It carries no download or auth fields at
+/// all, so what the portal routes from here is strictly less than the legacy artifact holds —
+/// which is the point of running the smoke against both.
+pub fn build_portal_gzipped(world: &ToyWorld, workers: &[PeerId]) -> anyhow::Result<Vec<u8>> {
+    let mut workers: Vec<PeerId> = workers.to_vec();
+    workers.sort();
+    let worker_indexes: Vec<u16> = (0..workers.len() as u16).collect();
+
+    let mut b = PortalAssignmentBuilder::new();
+
+    for ds in &world.datasets {
+        let Some(network_id) = &ds.network_id else {
+            continue;
+        };
+        let mut head_hash = None;
+        for chunk in &ds.chunks {
+            b.new_chunk()
+                .id(&chunk.id(&ds.name))
+                .dataset_id(network_id)
+                .block_range(chunk.first..=chunk.last)
+                .last_block_timestamp(world.timestamp(chunk.last))
+                .worker_indexes(&worker_indexes)
+                .finish()
+                .map_err(|e| anyhow::anyhow!("chunk build: {e}"))?;
+            head_hash = Some(world.hash(&ds.name, chunk.last));
+        }
+        // Only the dataset's head hash survives the split; per-chunk hashes were dropped
+        // because no query needs one. Schema ids are inert — the portal doesn't read them yet.
+        b.finish_dataset(0, head_hash.as_deref());
+    }
+
+    for worker in &workers {
+        b.add_worker(*worker, sqd_assignments::WorkerStatus::Ok);
+    }
+
+    gzip(b.finish())
+}
+
+fn gzip(bytes: Vec<u8>) -> anyhow::Result<Vec<u8>> {
     let mut enc = GzEncoder::new(Vec::new(), Compression::default());
     enc.write_all(&bytes)?;
     Ok(enc.finish()?)

--- a/harness/src/fixture.rs
+++ b/harness/src/fixture.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 use anyhow::Context;
 use tempfile::TempDir;
 
+use crate::artifact::AssignmentSource;
 use crate::portal::{Auth, Endpoints, PortalProcess};
 use crate::stubs::control_plane::ControlPlane;
 use crate::stubs::worker::{WorkerFaults, WorkerStub};
@@ -89,11 +90,11 @@ impl Fixture {
             dummy_chain::dummy_data_json(&worker_peers, portal_id.peer_id),
         )?;
 
-        let artifact_gz = artifact::build_gzipped(&world, &worker_peers)?;
         let publisher_ledger = stubs::publisher::start(
             endpoints.publisher_port,
             stubs::publisher::network_state_json(endpoints.publisher_port, "toy-assignment-1", 0),
-            artifact_gz,
+            artifact::build_gzipped(&world, &worker_peers)?,
+            artifact::build_portal_gzipped(&world, &worker_peers)?,
         )
         .await?;
         let _registry_ledger = stubs::registry::start(endpoints.registry_port, &world).await?;
@@ -140,7 +141,13 @@ impl Fixture {
             .map(|(id, port)| format!("{} /ip4/127.0.0.1/udp/{port}/quic-v1", id.peer_id))
             .collect::<Vec<_>>()
             .join(",");
-        let config = portal::write_config(&scratch, &world, &endpoints, auth.as_ref())?;
+        let config = portal::write_config(
+            &scratch,
+            &world,
+            &endpoints,
+            auth.as_ref(),
+            AssignmentSource::Legacy,
+        )?;
         let portal = portal::spawn(
             &scratch,
             &config,

--- a/harness/src/fixture.rs
+++ b/harness/src/fixture.rs
@@ -33,12 +33,29 @@ pub struct Fixture {
     scratch: Option<TempDir>,
 }
 
+/// Which artifacts the publisher offers, and which one the portal is pointed at. Defaults to
+/// the migration window: both published, the portal reading the legacy one. Separating the two
+/// is what lets a test put the portal on an artifact that is not on offer.
+pub struct Assignments {
+    pub source: AssignmentSource,
+    pub published: Vec<AssignmentSource>,
+}
+
+impl Default for Assignments {
+    fn default() -> Self {
+        Self {
+            source: AssignmentSource::Legacy,
+            published: vec![AssignmentSource::Legacy, AssignmentSource::Portal],
+        }
+    }
+}
+
 impl Fixture {
     /// `workers` stub workers on the toy world. The portal pre-leases
     /// 1 + retries distinct workers per chunk, so two is the minimum that lets
     /// a reroute actually find somewhere to go.
     pub async fn start(world: ToyWorld, workers: usize) -> anyhow::Result<Self> {
-        Self::start_with(world, workers, None).await
+        Self::start_with(world, workers, None, Assignments::default()).await
     }
 
     /// The same world with an `auth:` block and the DC-8 stub behind it.
@@ -49,13 +66,25 @@ impl Fixture {
         workers: usize,
         auth: Auth,
     ) -> anyhow::Result<Self> {
-        Self::start_with(world, workers, Some(auth)).await
+        Self::start_with(world, workers, Some(auth), Assignments::default()).await
+    }
+
+    /// A fixture whose publisher shape and configured source are set by the caller — the DC-2
+    /// source-selection cases. Note this does not wait for readiness: a portal pointed at an
+    /// artifact nobody publishes never becomes ready, which is the point of those cases.
+    pub async fn start_with_assignments(
+        world: ToyWorld,
+        workers: usize,
+        assignments: Assignments,
+    ) -> anyhow::Result<Self> {
+        Self::start_with(world, workers, None, assignments).await
     }
 
     async fn start_with(
         world: ToyWorld,
         workers: usize,
         auth: Option<Auth>,
+        assignments: Assignments,
     ) -> anyhow::Result<Self> {
         anyhow::ensure!(workers >= 1, "need at least one worker");
         // Loopback p2p addresses are filtered as unreachable unless this is set.
@@ -92,7 +121,12 @@ impl Fixture {
 
         let publisher_ledger = stubs::publisher::start(
             endpoints.publisher_port,
-            stubs::publisher::network_state_json(endpoints.publisher_port, "toy-assignment-1", 0),
+            stubs::publisher::network_state_json_publishing(
+                endpoints.publisher_port,
+                "toy-assignment-1",
+                0,
+                &assignments.published,
+            ),
             artifact::build_gzipped(&world, &worker_peers)?,
             artifact::build_portal_gzipped(&world, &worker_peers)?,
         )
@@ -146,7 +180,7 @@ impl Fixture {
             &world,
             &endpoints,
             auth.as_ref(),
-            AssignmentSource::Legacy,
+            assignments.source,
         )?;
         let portal = portal::spawn(
             &scratch,

--- a/harness/src/metrics_audit.rs
+++ b/harness/src/metrics_audit.rs
@@ -4,6 +4,10 @@
 use std::collections::HashMap;
 
 /// Sum all samples of a metric family from OpenMetrics text.
+///
+/// Matches the family name exactly, so this is for gauges. A counter is exposed as
+/// `<family>_total` and reads as `None` here — use [`sum_where`] for those, or an assertion on
+/// a counter silently passes against nothing.
 pub fn family_sum(text: &str, family: &str) -> Option<f64> {
     let mut sum = None;
     for line in text.lines() {

--- a/harness/src/portal.rs
+++ b/harness/src/portal.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::Context;
 
+use crate::artifact::AssignmentSource;
 use crate::world::ToyWorld;
 
 pub struct Endpoints {
@@ -65,6 +66,7 @@ pub fn write_config(
     world: &ToyWorld,
     e: &Endpoints,
     auth: Option<&Auth>,
+    assignment_source: AssignmentSource,
 ) -> anyhow::Result<PathBuf> {
     let mut datasets = String::new();
     for ds in &world.datasets {
@@ -116,6 +118,7 @@ pre_drain_grace_period_sec: 1
 drain_timeout_sec: 2
 assignments_url: http://127.0.0.1:{publisher}
 assignments_update_interval_sec: 1
+assignment_source: {assignment_source}
 datasets_update_interval_sec: 600
 chain_update_interval_sec: 60
 send_logs: false
@@ -135,6 +138,7 @@ datasets:
 {datasets}{auth_block}"#,
         http = e.http_port,
         publisher = e.publisher_port,
+        assignment_source = assignment_source.as_str(),
         registry = e.registry_port,
         datasets = datasets,
         auth_block = auth_block,

--- a/harness/src/stubs/publisher.rs
+++ b/harness/src/stubs/publisher.rs
@@ -4,6 +4,7 @@ use axum::{extract::State, response::IntoResponse, routing::get, Router};
 use serde_json::json;
 
 use super::Ledger;
+use crate::artifact::AssignmentSource;
 
 #[derive(Clone)]
 struct PublisherState {
@@ -16,20 +17,36 @@ struct PublisherState {
 /// Publishes both artifacts, which is the state the scheduler holds throughout the migration —
 /// so which one the portal reads is decided by its config alone, never by what is on offer.
 pub fn network_state_json(port: u16, assignment_id: &str, effective_from: u64) -> String {
-    json!({
-        "network": "tethys",
-        "assignment": {
+    network_state_json_publishing(
+        port,
+        assignment_id,
+        effective_from,
+        &[AssignmentSource::Legacy, AssignmentSource::Portal],
+    )
+}
+
+/// The same document carrying only `published`. Every descriptor is optional upstream because
+/// migration walks the state through legacy-only, both, then split-only — so a portal has to
+/// cope with the artifact it was pointed at simply not being there.
+pub fn network_state_json_publishing(
+    port: u16,
+    assignment_id: &str,
+    effective_from: u64,
+    published: &[AssignmentSource],
+) -> String {
+    let mut state = json!({ "network": "tethys" });
+    for source in published {
+        let (key, file) = match source {
+            AssignmentSource::Legacy => ("assignment", "assignment.fb.gz"),
+            AssignmentSource::Portal => ("portal_assignment", "portal-assignment.fb.gz"),
+        };
+        state[key] = json!({
             "id": assignment_id,
             "effective_from": effective_from,
-            "fb_url_v1": format!("http://127.0.0.1:{port}/assignment.fb.gz"),
-        },
-        "portal_assignment": {
-            "id": assignment_id,
-            "effective_from": effective_from,
-            "fb_url_v1": format!("http://127.0.0.1:{port}/portal-assignment.fb.gz"),
-        }
-    })
-    .to_string()
+            "fb_url_v1": format!("http://127.0.0.1:{port}/{file}"),
+        });
+    }
+    state.to_string()
 }
 
 pub async fn start(

--- a/harness/src/stubs/publisher.rs
+++ b/harness/src/stubs/publisher.rs
@@ -9,9 +9,12 @@ use super::Ledger;
 struct PublisherState {
     network_state: String,
     artifact_gz: Vec<u8>,
+    portal_artifact_gz: Vec<u8>,
     ledger: Ledger,
 }
 
+/// Publishes both artifacts, which is the state the scheduler holds throughout the migration —
+/// so which one the portal reads is decided by its config alone, never by what is on offer.
 pub fn network_state_json(port: u16, assignment_id: &str, effective_from: u64) -> String {
     json!({
         "network": "tethys",
@@ -19,6 +22,11 @@ pub fn network_state_json(port: u16, assignment_id: &str, effective_from: u64) -
             "id": assignment_id,
             "effective_from": effective_from,
             "fb_url_v1": format!("http://127.0.0.1:{port}/assignment.fb.gz"),
+        },
+        "portal_assignment": {
+            "id": assignment_id,
+            "effective_from": effective_from,
+            "fb_url_v1": format!("http://127.0.0.1:{port}/portal-assignment.fb.gz"),
         }
     })
     .to_string()
@@ -28,11 +36,13 @@ pub async fn start(
     port: u16,
     network_state: String,
     artifact_gz: Vec<u8>,
+    portal_artifact_gz: Vec<u8>,
 ) -> anyhow::Result<Ledger> {
     let ledger = Ledger::default();
     let state = PublisherState {
         network_state,
         artifact_gz,
+        portal_artifact_gz,
         ledger: ledger.clone(),
     };
     let app = Router::new()
@@ -51,6 +61,14 @@ pub async fn start(
             get(|State(s): State<PublisherState>| async move {
                 s.ledger.push("artifact");
                 s.artifact_gz.clone().into_response()
+            }),
+        )
+        .route(
+            // Prefixed "artifact" so a fetch of either format satisfies the same ledger check.
+            "/portal-assignment.fb.gz",
+            get(|State(s): State<PublisherState>| async move {
+                s.ledger.push("artifact-portal");
+                s.portal_artifact_gz.clone().into_response()
             }),
         )
         .with_state(state);

--- a/harness/src/stubs/worker.rs
+++ b/harness/src/stubs/worker.rs
@@ -15,7 +15,7 @@ use clap::Parser;
 use flate2::{write::GzEncoder, Compression};
 use futures::StreamExt;
 use libp2p_identity::Keypair;
-use sqd_messages::{query_error, ProstMsg};
+use sqd_messages::query_error;
 use sqd_network_transport::{
     AgentInfo, P2PTransportBuilder, TransportArgs, WorkerConfig, WorkerEvent,
 };
@@ -142,31 +142,19 @@ pub async fn start(
     let ledger = Ledger::default();
     let ledger2 = ledger.clone();
     tokio::spawn(async move {
-        // Responses now go straight down `resp_chan`, so nothing here calls the handle — but
-        // dropping it stops the transport task, so it has to outlive the event loop.
-        let _handle = handle;
         futures::pin_mut!(events);
         while let Some(event) = events.next().await {
             match event {
-                // The transport hands over raw protobuf now: decoding moved to the consumer,
-                // so a stub worker has to do exactly what a real one does with the bytes.
                 WorkerEvent::Query {
                     peer_id,
-                    request,
+                    query,
                     resp_chan,
                 } => {
-                    let query = match sqd_messages::Query::decode(request.as_ref()) {
-                        Ok(query) => query,
-                        Err(e) => {
-                            tracing::warn!(%peer_id, error = %e, "undecodable query");
-                            continue;
-                        }
-                    };
                     let fault = faults.next();
                     tracing::info!(%peer_id, chunk = %query.chunk_id, ?fault, "stub worker query");
                     let result = answer(&world, &signing_keypair, &query, &ledger2, fault);
-                    if let Err(e) = resp_chan.send(&result.encode_to_vec()).await {
-                        tracing::warn!(%peer_id, error = %e, "failed to send query result");
+                    if handle.send_query_result(result, resp_chan).is_err() {
+                        tracing::warn!("query result queue full");
                     }
                 }
                 other => tracing::debug!("ignoring worker event: {other:?}"),

--- a/harness/src/stubs/worker.rs
+++ b/harness/src/stubs/worker.rs
@@ -15,7 +15,7 @@ use clap::Parser;
 use flate2::{write::GzEncoder, Compression};
 use futures::StreamExt;
 use libp2p_identity::Keypair;
-use sqd_messages::query_error;
+use sqd_messages::{query_error, ProstMsg};
 use sqd_network_transport::{
     AgentInfo, P2PTransportBuilder, TransportArgs, WorkerConfig, WorkerEvent,
 };
@@ -142,19 +142,31 @@ pub async fn start(
     let ledger = Ledger::default();
     let ledger2 = ledger.clone();
     tokio::spawn(async move {
+        // Responses now go straight down `resp_chan`, so nothing here calls the handle — but
+        // dropping it stops the transport task, so it has to outlive the event loop.
+        let _handle = handle;
         futures::pin_mut!(events);
         while let Some(event) = events.next().await {
             match event {
+                // The transport hands over raw protobuf now: decoding moved to the consumer,
+                // so a stub worker has to do exactly what a real one does with the bytes.
                 WorkerEvent::Query {
                     peer_id,
-                    query,
+                    request,
                     resp_chan,
                 } => {
+                    let query = match sqd_messages::Query::decode(request.as_ref()) {
+                        Ok(query) => query,
+                        Err(e) => {
+                            tracing::warn!(%peer_id, error = %e, "undecodable query");
+                            continue;
+                        }
+                    };
                     let fault = faults.next();
                     tracing::info!(%peer_id, chunk = %query.chunk_id, ?fault, "stub worker query");
                     let result = answer(&world, &signing_keypair, &query, &ledger2, fault);
-                    if handle.send_query_result(result, resp_chan).is_err() {
-                        tracing::warn!("query result queue full");
+                    if let Err(e) = resp_chan.send(&result.encode_to_vec()).await {
+                        tracing::warn!(%peer_id, error = %e, "failed to send query result");
                     }
                 }
                 other => tracing::debug!("ignoring worker event: {other:?}"),

--- a/harness/tests/ct1_smoke.rs
+++ b/harness/tests/ct1_smoke.rs
@@ -8,6 +8,7 @@
 use std::time::{Duration, Instant};
 
 use anyhow::{bail, ensure, Context};
+use harness::artifact::AssignmentSource;
 use harness::driver::Decoded;
 use harness::model::{model, Expect, StreamReq};
 use harness::portal::{Endpoints, PortalProcess};
@@ -77,6 +78,18 @@ struct Ctx {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn ct1_smoke() -> anyhow::Result<()> {
+    smoke(AssignmentSource::Legacy).await
+}
+
+/// The same conformance run, routed from the portal-oriented artifact. It carries strictly less
+/// than the legacy one — no per-chunk hashes, sizes, or download urls — so this is what shows
+/// the portal never needed those fields before the network stops publishing them.
+#[tokio::test(flavor = "multi_thread")]
+async fn ct1_smoke_from_portal_assignment() -> anyhow::Result<()> {
+    smoke(AssignmentSource::Portal).await
+}
+
+async fn smoke(assignment_source: AssignmentSource) -> anyhow::Result<()> {
     // Loopback p2p addresses are filtered as unreachable unless this is set.
     std::env::set_var("PRIVATE_NETWORK", "1");
     let _ = tracing_subscriber::fmt()
@@ -115,11 +128,11 @@ async fn ct1_smoke() -> anyhow::Result<()> {
     )?;
 
     // IB-7 stubs.
-    let artifact_gz = artifact::build_gzipped(&world, &worker_peers)?;
     let publisher_ledger = stubs::publisher::start(
         endpoints.publisher_port,
         stubs::publisher::network_state_json(endpoints.publisher_port, "toy-assignment-1", 0),
-        artifact_gz,
+        artifact::build_gzipped(&world, &worker_peers)?,
+        artifact::build_portal_gzipped(&world, &worker_peers)?,
     )
     .await?;
     let _registry_ledger = stubs::registry::start(endpoints.registry_port, &world).await?;
@@ -147,7 +160,7 @@ async fn ct1_smoke() -> anyhow::Result<()> {
         .map(|(id, port)| format!("{} /ip4/127.0.0.1/udp/{port}/quic-v1", id.peer_id))
         .collect::<Vec<_>>()
         .join(",");
-    let config = portal::write_config(&scratch, &world, &endpoints, None)?;
+    let config = portal::write_config(&scratch, &world, &endpoints, None, assignment_source)?;
     let mut portal_proc = portal::spawn(
         &scratch,
         &config,

--- a/harness/tests/ct1_smoke.rs
+++ b/harness/tests/ct1_smoke.rs
@@ -74,6 +74,7 @@ struct Ctx {
     worker_ledgers: Vec<stubs::Ledger>,
     hotblocks_ledger: stubs::Ledger,
     publisher_ledger: stubs::Ledger,
+    assignment_source: AssignmentSource,
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -177,6 +178,7 @@ async fn smoke(assignment_source: AssignmentSource) -> anyhow::Result<()> {
         worker_ledgers,
         hotblocks_ledger,
         publisher_ledger,
+        assignment_source,
     };
 
     let result = run_smoke(&ctx, &mut portal_proc).await;
@@ -494,9 +496,21 @@ async fn run_smoke(ctx: &Ctx, portal_proc: &mut PortalProcess) -> anyhow::Result
         "hotblocks ledger misses stream calls: {:?}",
         ctx.hotblocks_ledger.entries()
     );
+    // Exact entries, not a prefix: "artifact" prefixes "artifact-portal", so a prefix match
+    // would let the portal-source run pass on a legacy fetch. Asserting the other artifact was
+    // never fetched is what pins the selector's no-fallback promise end to end.
+    let (expected, forbidden) = match ctx.assignment_source {
+        AssignmentSource::Legacy => ("artifact", "artifact-portal"),
+        AssignmentSource::Portal => ("artifact-portal", "artifact"),
+    };
+    let fetched = ctx.publisher_ledger.entries();
     ensure!(
-        ctx.publisher_ledger.count_with_prefix("artifact") >= 1,
-        "artifact never fetched"
+        fetched.iter().any(|e| e == expected),
+        "{expected} never fetched: {fetched:?}"
+    );
+    ensure!(
+        !fetched.iter().any(|e| e == forbidden),
+        "fetched {forbidden} while configured for {expected}: {fetched:?}"
     );
 
     // Quiescence (one heartbeat interval, no in-flight work), then the gauge

--- a/harness/tests/ct2_publisher_faults.rs
+++ b/harness/tests/ct2_publisher_faults.rs
@@ -1,0 +1,88 @@
+//! CT-2, DC-2: the publisher does not offer the artifact the portal is pointed at.
+//!
+//! Splitting the assignment gave the publisher a shape a portal can be wrong about — it may
+//! carry only one of the two artifacts while a portal is configured for the other, either
+//! before the split blobs appear or after the legacy one stops being published. Selection is
+//! absolute, so the portal has to refuse rather than quietly route from whichever artifact it
+//! can see. Falling back would make a `portal` canary that never ran indistinguishable from one
+//! that passed, and would leave the `legacy` kill switch switching nothing off.
+
+use std::time::Duration;
+
+use anyhow::ensure;
+use harness::artifact::AssignmentSource;
+use harness::fixture::{Assignments, Fixture};
+use harness::{metrics_audit, ToyWorld};
+
+/// Long enough for several rounds of the 1 s assignment poll, so "never applied" means the
+/// portal had the chance and declined rather than not having got there yet.
+const POLLS: Duration = Duration::from_secs(5);
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ct2_portal_source_absent_does_not_fall_back_to_legacy() -> anyhow::Result<()> {
+    absent_source_is_refused(AssignmentSource::Portal, AssignmentSource::Legacy).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ct2_legacy_source_absent_does_not_fall_back_to_portal() -> anyhow::Result<()> {
+    absent_source_is_refused(AssignmentSource::Legacy, AssignmentSource::Portal).await
+}
+
+/// The portal is configured for `configured`; the publisher offers only `published`.
+async fn absent_source_is_refused(
+    configured: AssignmentSource,
+    published: AssignmentSource,
+) -> anyhow::Result<()> {
+    let mut fx = Fixture::start_with_assignments(
+        ToyWorld::standard(),
+        2,
+        Assignments {
+            source: configured,
+            published: vec![published],
+        },
+    )
+    .await?;
+
+    let result = async {
+        tokio::time::sleep(POLLS).await;
+
+        // No assignment applied means no workers, so readiness never arrives. This is the
+        // deliberate cost of refusing: a misconfigured portal fails visibly instead of serving
+        // the wrong wire format.
+        ensure!(
+            fx.wait_ready(Duration::from_secs(5)).await.is_err(),
+            "portal became ready with no {configured} assignment published",
+        );
+
+        // The other artifact is on offer and reachable. Not fetching it is the whole claim.
+        let fetched = fx.publisher_ledger.entries();
+        ensure!(
+            fetched.iter().any(|e| e == "network-state"),
+            "publisher was never polled at all: {fetched:?}",
+        );
+        ensure!(
+            !fetched.iter().any(|e| e.starts_with("artifact")),
+            "fetched an artifact though {configured} was not published: {fetched:?}",
+        );
+
+        // Distinguishes a deliberate refusal from any other reason nothing was applied.
+        // `sum_where`, not `family_sum`: the counter is exposed as `..._total`, which only the
+        // former matches — the latter would read 0 here and pass vacuously.
+        let text = fx.scrape().await?;
+        let missing = metrics_audit::sum_where(&text, "portal_missing_assignment_source", &[]);
+        ensure!(
+            missing >= 1.0,
+            "portal_missing_assignment_source never incremented (got {missing}); assignment \
+             series in the scrape:\n{}",
+            text.lines()
+                .filter(|l| l.contains("assignment"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
+
+        Ok(())
+    }
+    .await;
+
+    fx.finish(result)
+}

--- a/spec/02-requirements.md
+++ b/spec/02-requirements.md
@@ -575,7 +575,11 @@ Deliberately left open — tests and clients must not pin these:
 
 Closed: **OQ-6** (should the clamp-bypassing debug stream variant be exposed unconditionally,
 or gated behind an operator flag?) — resolved by ADR-014: the variant is gated behind an
-operator flag and disabled by default (GAP-21 until implemented). **OQ-12** (what does an
+operator flag and disabled by default (GAP-21 until implemented). **OQ-8** (ratify the HTTP
+field or header carrying DEF-8's coverage cursor) — dissolved rather than answered: the
+question assumed the wire lacked a cursor, and it never did. Every served chunk's boundary
+blocks ship as records, so the last record is the cursor and there is no field to name
+(GAP-15). **OQ-12** (what does an
 enforcing Portal do once its key set is older than its staleness bound?) — moot since
 the on-demand exchange: there is no mirrored key set to age. Its answer survives as
 the reasoning REQ-54 and INV-31 still rest on — readiness never turns on the control plane's

--- a/spec/09-failure-model.md
+++ b/spec/09-failure-model.md
@@ -54,6 +54,7 @@ requests only; the publisher ⇒ freshness only; chain RPC ⇒ status only (REQ-
 | Corrupt / truncated artifact | integrity: reject, keep last good, alarm — **intent** (today: adopted unverified — GAP-1, ADR-002) |
 | Stale (identifier never advances) | degrade + alarm past P-ASSIGNMENT-MAX-AGE ⚠ (ADR-013) |
 | Regressive (older identifier republished) | mask — application legality ignores it (INV-2) |
+| Configured artifact absent (P-ASSIGNMENT-SOURCE names one the state does not carry) | refuse: apply nothing, keep last good, count `missing_assignment_source`. Never substitute the other artifact — a silent substitution makes a canary that never ran indistinguishable from one that passed, and leaves the kill switch switching nothing off |
 
 ## Real-time source faults (DC-4)
 

--- a/spec/13-conformance.md
+++ b/spec/13-conformance.md
@@ -17,11 +17,14 @@ reads an error code.
 **CT-2 has started**: the worker stub is now a DC-1 fault injector (wrong-range both
 directions, bad signature, server-error and not-found verdicts) shared across workers so
 a fault lands wherever the portal routes, and `Fixture` boots the whole stub world for
-any class that needs it. Caveat: production workers pin a newer transport rev whose
-server was rewritten (stream-based accept with silent drop at buffer capacity); the stub
-speaks the portal's older pinned rev, so the production server's drop paths are not
-exercised — re-verify on the next dependency bump. `ct2_worker_faults` covers the worker-fault reroute rows and the
-exhaustion split; the rest of CT-2 and CT-3..CT-9 remain to be built per the build order.
+any class that needs it. The rev gap is closed: the portal and the stub both pin the
+transport at 67f54cc, where the server hands raw protobuf to the consumer and the stub
+decodes and answers on the response stream as a production worker does. Its silent drop
+at buffer capacity is still not driven, so that path stays unexercised.
+`ct2_worker_faults` covers the worker-fault reroute rows and the exhaustion split, and
+`ct2_publisher_faults` covers the DC-2 row where the publisher omits the artifact the
+portal is configured for; the rest of CT-2 and CT-3..CT-9 remain to be built per the
+build order.
 **CT-10 exists**: a DC-8 control-plane stub that verifies the exchange signature for real
 rather than trusting the headers, with a ledger of every credential it was asked about and
 the fault rows of DC-8's error table as injectors. `ct10_authorization` drives five
@@ -148,7 +151,7 @@ chunk-boundary records FV-6 licenses.
 
 | Property | CT | Status | Note |
 |---|---|---|---|
-| INV-1, INV-2 | CT-3/2 | U | artifact-variant selection unit-tested only |
+| INV-1, INV-2 | CT-3/2 | P | artifact-variant selection is now end-to-end: the CT-1 smoke runs against both wire formats and asserts the unselected artifact is never fetched, and `ct2_publisher_faults` proves a configured artifact the publisher omits is refused rather than substituted. Swap-race atomicity (INV-1) remains CT-3 territory |
 | INV-3 | CT-3 | P | quiescent lease census asserted zero after every randomized scheduling case and after client disconnect (controller-level, mock network); CT-3 swarm still absent |
 | INV-4 | CT-1/3 | P | window grow/shrink/priority unit tests |
 | INV-5 | CT-3 | U | transient overshoot untested |

--- a/spec/13-conformance.md
+++ b/spec/13-conformance.md
@@ -17,10 +17,10 @@ reads an error code.
 **CT-2 has started**: the worker stub is now a DC-1 fault injector (wrong-range both
 directions, bad signature, server-error and not-found verdicts) shared across workers so
 a fault lands wherever the portal routes, and `Fixture` boots the whole stub world for
-any class that needs it. The rev gap is closed: the portal and the stub both pin the
-transport at 67f54cc, where the server hands raw protobuf to the consumer and the stub
-decodes and answers on the response stream as a production worker does. Its silent drop
-at buffer capacity is still not driven, so that path stays unexercised.
+any class that needs it. Caveat: production workers pin a newer transport rev whose
+server was rewritten (stream-based accept with silent drop at buffer capacity); the stub
+speaks the portal's older pinned rev, so the production server's drop paths are not
+exercised — re-verify on the next transport bump.
 `ct2_worker_faults` covers the worker-fault reroute rows and the exhaustion split, and
 `ct2_publisher_faults` covers the DC-2 row where the publisher omits the artifact the
 portal is configured for; the rest of CT-2 and CT-3..CT-9 remain to be built per the

--- a/spec/13-conformance.md
+++ b/spec/13-conformance.md
@@ -1,7 +1,7 @@
 # 13 — Conformance & TDD plan
 
-**Mutable doc.** Statuses as of **2026-08-07** (0.12.1,
-`master@e9a1878f863c4d87615bcf21ba1ef79fdf649385`). Statuses: **C** covered · **P** partial ·
+**Mutable doc.** Statuses as of **2026-08-13** (0.13.1,
+`master@ab821f91d5b4345ec6dc6cbf05595867f41eb7de`). Statuses: **C** covered · **P** partial ·
 **U** unchecked; *known-violated* / *known-suspect* where reality contradicts the property.
 **The authorization band (REQ-50..56, DC-8, OP-11 and the invariants scoped to them) has
 landed and is CT-10-covered on its request path.** A deployment with no `auth:` block
@@ -239,7 +239,7 @@ chunk-boundary records FV-6 licenses.
 | REQ-55 | P | CT-10 runs a shadow portal: a request with no credential, one with an ungrammatical token and one the control plane denies are all served, the verdict enforcement would have returned is in the protected log, and the keyless scrape carries only the neutral `shadow_evaluated` series with no code and no exchange counters. The control-plane ledger shows it exchanging on the same cache-miss rule enforcement uses — once, for the only request that presented something to exchange. Indeterminate exchange outcomes are not separately driven |
 | REQ-56 | P | CT-10 runs a portal with no `auth:` block: gated routes are served without a credential, a credential presented anyway is not a reason to refuse, and no authorization series appears in the scrape at all. The empty-block startup error is unit-tested in `auth::config` rather than here, and the startup mode line is logged but not asserted |
 
-## Gap register — 2026-08-07
+## Gap register — 2026-08-13
 
 Priorities: P0 blocks the program · P1 active production risk · P2 correctness hole
 with plausible trigger · P3 polish. "Next" = cheapest failing-test-first entry.
@@ -278,6 +278,13 @@ with plausible trigger · P3 polish. "Next" = cheapest failing-test-first entry.
 | GAP-33 | CT-10's harness exists and its request-path rows are driven black-box, but every row whose claim is about *time* is still unwritten: LIV-13's convergence at `refresh_after` and at `expires_at` with the control plane stopped, a retired generation completing after its successor (INV-6), the denial TTL and the grace window, and HZ-12's renewal spread. All of them need either a controllable clock or a run long enough to cross a real one, and the stub has neither | CT-10, DC-8, INV-6, LIV-13, HZ-12 | P2 | give the control-plane stub a settable clock offset, or drive the cases with second-scale lifetimes; `expires_at` convergence with the control plane stopped is the one carrying the security claim |
 
 ### Closed findings
+
+- **GAP-35** (closed 2026-08-07): the commercial band was specification only — the binary
+  carried no authorization code, so REQ-50..56, DC-8, OP-11, INV-6/14/15/38/39 and
+  LIV-13/14 were unmet by absence rather than by defect. The band landed with CT-10
+  covering its request path, which is what the entry asked for. Its unfinished half was
+  never the code but the clock: every row whose claim is about *time* is still unwritten,
+  and that residual is GAP-33, not this entry.
 
 - **GAP-31** (closed 2026-08-06; superseded 2026-08-07): key-snapshot staleness was
   unbounded and unexported, and was closed by exporting an age gauge and alarming on it.
@@ -320,6 +327,14 @@ with plausible trigger · P3 polish. "Next" = cheapest failing-test-first entry.
   the common shape when a replica dies with the request still unread — was never
   replayed, and the fix would have missed most of the incident it was written for.
   GAP-22 now tracks only the indicator residual.
+- **GAP-15** (closed 2026-07-19): the HTTP response was believed not to expose DEF-8's
+  coverage cursor, marking REQ-2 known-violated for selective zero-record progress. It was
+  never missing: sqd-query pins the min and max block of every served chunk at weight 0, so
+  the coverage boundary always ships as a record — header-only when it matches no filter —
+  and the last record *is* the cursor. No field or header needed ratifying, which closed
+  OQ-8 with it. Grounding the claim cost a free variable rather than a fix: `Plan::execute`
+  runs per chunk, so a multi-chunk selective response also carries header-only records at
+  interior boundaries, and FV-6 licenses them.
 - **GAP-9** (closed 2026-07-17): EMPTY delay occurs after the stream census permit is
   released. It can occupy an HTTP connection/task (HZ-3), but does not consume the
   stream cap.

--- a/spec/15-parameters.md
+++ b/spec/15-parameters.md
@@ -33,6 +33,7 @@ assumes, not knobs it owns.
 | P-HOTBLOCKS-READ-TIMEOUT | Real-time source per-read deadline; must stay < P-CLIENT-TIMEOUT (REQ-22, ADR-010). A replayed request spends it twice (ADR-015) | 20 s | 20 s |
 | P-CLIENT-TIMEOUT | *Environmental:* the request deadline callers default to (ADR-010) | 30 s | ≥ 30 s assumed |
 | P-ASSIGNMENT-REFRESH | Assignment poll interval (REQ-40, REQ-11) | 60 s | 60 s |
+| P-ASSIGNMENT-SOURCE | Which published artifact routing reads: `legacy` or `portal`. Absolute — if the selected one isn't published, nothing is applied and the portal keeps serving what it has | `legacy` | `portal` |
 | P-ASSIGNMENT-FETCH-TIMEOUT | Assignment fetch connect/read deadlines (REQ-22) | 5 s / 5 s | 5 s / 5 s |
 | P-ASSIGNMENT-MAX-AGE | ⚠ Max tolerated assignment age before readiness degrades (REQ-23, ADR-013) | **unbounded — violated in intent** | ⚠ 15 min (draft; ratify via ADR-013) |
 | P-DATASETS-REFRESH | Dataset catalog/metadata poll interval (REQ-12) | 600 s | 600 s |

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use url::Url;
 
 use crate::auth::AuthConfig;
-use crate::network::PrioritiesConfig;
+use crate::network::{AssignmentSource, PrioritiesConfig};
 use crate::types::DatasetRef;
 
 #[serde_as]
@@ -126,11 +126,12 @@ pub struct Config {
     #[serde(default)]
     pub ignore_deprecated_workers: bool,
 
-    /// Whether to prefer the portal-oriented assignment over the legacy one when both are
-    /// available (`mvcc-chunks` builds only). A runtime kill switch: can be flipped back to
-    /// `false` without a rebuild if `portal_assignment` needs to be reverted.
-    #[serde(default = "default_true")]
-    pub prefer_portal_assignment: bool,
+    /// Which published assignment artifact to route from: `legacy` or `portal`. The scheduler
+    /// publishes both during the migration, and the selected one is the only one consulted -- if
+    /// it isn't published, the portal keeps serving what it already has rather than falling back.
+    /// Overridden by `--assignment-source` / `ASSIGNMENT_SOURCE`.
+    #[serde(default)]
+    pub assignment_source: AssignmentSource,
 
     /// Please avoid overriding this value. It may eventually become unsupported.
     #[serde(default = "default_query_size_limit")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use sqd_portal::config::Config;
 use sqd_portal::controller::task_manager::TaskManager;
 use sqd_portal::datasets::Datasets;
 use sqd_portal::http_server::run_server;
-use sqd_portal::network::NetworkClient;
+use sqd_portal::network::{AssignmentSource, NetworkClient};
 use sqd_portal::utils::RwLock;
 use tokio_util::sync::CancellationToken;
 
@@ -28,6 +28,11 @@ pub struct Cli {
     /// Path to config file
     #[arg(long, env, value_parser = Config::read)]
     pub config: Config,
+
+    /// Which published assignment artifact to route from. Overrides `assignment_source` in the
+    /// config file, so the format can be switched at deploy time without editing the config.
+    #[arg(long, env = "ASSIGNMENT_SOURCE", value_enum)]
+    pub assignment_source: Option<AssignmentSource>,
 
     /// Whether the logs should be structured in JSON format
     #[arg(long, env)]
@@ -182,7 +187,17 @@ async fn main() -> anyhow::Result<()> {
 
     let datasets = Arc::new(RwLock::new(Datasets::load(&args.config).await?, "datasets"));
 
-    let config = Arc::new(args.config);
+    let mut config = args.config;
+    if let Some(source) = args.assignment_source {
+        config.assignment_source = source;
+    }
+    // Which wire format routing came from is otherwise invisible: both artifacts describe the
+    // same network, so a portal on the wrong one looks healthy while serving the wrong thing.
+    tracing::info!(
+        assignment_source = %config.assignment_source,
+        "assignment source selected"
+    );
+    let config = Arc::new(config);
     let hotblocks = Arc::new(sqd_portal::hotblocks::build_client(&config).await?);
     let network_client_builder =
         NetworkClient::builder(args.transport, config.clone(), datasets.clone()).await?;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -188,6 +188,7 @@ lazy_static::lazy_static! {
     static ref KNOWN_CHUNKS: Family<Labels, Gauge> = Default::default();
     static ref LAST_STORAGE_BLOCK: Family<Labels, Gauge> = Default::default();
     pub static ref STALE_ASSIGNMENTS_REJECTED: Counter = Default::default();
+    pub static ref MISSING_ASSIGNMENT_SOURCE: Counter = Default::default();
 
     // Authorizing deployments only: inert without an `auth:` block.
     static ref AUTH_DECISIONS: Family<Labels, Counter> = Default::default();
@@ -669,6 +670,11 @@ pub fn register_metrics(registry: &mut Registry) {
         "dataset_storage_highest_block",
         "The highest block existing in the persistent storage",
         LAST_STORAGE_BLOCK.clone(),
+    );
+    registry.register(
+        "missing_assignment_source",
+        "Number of polls where the network state published no assignment of the configured source",
+        MISSING_ASSIGNMENT_SOURCE.clone(),
     );
     registry.register(
         "stale_assignments_rejected",

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -703,11 +703,6 @@ impl NetworkClient {
             timestamp_ms: timestamp_now_ms(),
             signature: Default::default(),
             compression,
-            // Both defaults, deliberately: `msg_to_sign` only appends these to the signed payload
-            // when one is non-zero, so leaving them alone keeps signatures byte-identical to what
-            // workers that predate the fields already verify.
-            query_engine: sqd_messages::QueryEngine::Default as i32,
-            output_format: sqd_messages::OutputFormat::Jsonl as i32,
         };
         tokio::task::spawn_blocking({
             let keypair = self.keypair.clone();

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -323,7 +323,7 @@ impl NetworkClientBuilder {
         if config.ignore_deprecated_workers {
             network_state.ignore_deprecated_workers();
         }
-        network_state.set_prefer_portal_assignment(config.prefer_portal_assignment);
+        network_state.set_assignment_source(config.assignment_source);
 
         let read_scheduler = if config.congestion.enabled {
             let sched = Arc::new(DownloadScheduler::new(config.congestion.clone()));
@@ -703,6 +703,11 @@ impl NetworkClient {
             timestamp_ms: timestamp_now_ms(),
             signature: Default::default(),
             compression,
+            // Both defaults, deliberately: `msg_to_sign` only appends these to the signed payload
+            // when one is non-zero, so leaving them alone keeps signatures byte-identical to what
+            // workers that predate the fields already verify.
+            query_engine: sqd_messages::QueryEngine::Default as i32,
+            output_format: sqd_messages::OutputFormat::Jsonl as i32,
         };
         tokio::task::spawn_blocking({
             let keypair = self.keypair.clone();

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -13,4 +13,4 @@ pub use priorities::{NoWorker, PrioritiesConfig, Priority};
 #[cfg(test)]
 pub(crate) use state::TestLeasePool;
 pub use state::{NetworkState, WorkerLease};
-pub use storage::{ChunkNotFound, StorageClient};
+pub use storage::{AssignmentSource, ChunkNotFound, StorageClient};

--- a/src/network/state.rs
+++ b/src/network/state.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use sqd_network_transport::PeerId;
 
 use crate::network::priorities::PrioritiesConfig;
-use crate::network::StorageClient;
+use crate::network::{AssignmentSource, StorageClient};
 use crate::types::api_types::WorkerDebugInfo;
 use crate::types::DatasetId;
 use crate::utils::RwLock;
@@ -101,8 +101,8 @@ impl NetworkState {
         self.dataset_storage.ignore_deprecated_workers();
     }
 
-    pub fn set_prefer_portal_assignment(&mut self, prefer: bool) {
-        self.dataset_storage.set_prefer_portal_assignment(prefer);
+    pub fn set_assignment_source(&mut self, source: AssignmentSource) {
+        self.dataset_storage.set_assignment_source(source);
     }
 
     pub async fn try_update_assignment(&self) {

--- a/src/network/storage.rs
+++ b/src/network/storage.rs
@@ -131,20 +131,13 @@ impl StorageClient {
     async fn update_assignment(&self) -> anyhow::Result<()> {
         tracing::debug!("Checking for new assignment");
         let network_state = self.fetch_network_state().await?;
-        let Some(selected) = select_assignment(&network_state, self.assignment_source) else {
-            // Never falls back to the other source: that would make a portal pinned to one format
-            // silently serve the other, defeating both the kill switch and the canary.
-            metrics::MISSING_ASSIGNMENT_SOURCE.inc();
-            return Err(anyhow!(
-                "network state publishes no {} assignment",
-                self.assignment_source
-            ));
-        };
+        // Never falls back to the other source: that would make a portal pinned to one format
+        // silently serve the other, defeating both the kill switch and the canary.
+        let (selected, assignment_url) = usable_assignment(&network_state, self.assignment_source)
+            .inspect_err(|_| {
+                metrics::MISSING_ASSIGNMENT_SOURCE.inc();
+            })?;
         let assignment_id = selected.id.clone();
-        let assignment_url = selected
-            .fb_url_v1
-            .clone()
-            .ok_or(anyhow!("Missing assignment URL"))?;
         let effective_from = selected.effective_from;
         let latest = self.latest_assignment_id.read().clone();
         if latest.as_deref() == Some(assignment_id.as_str()) {
@@ -507,6 +500,27 @@ fn accumulate_range(
     }
 }
 
+/// The descriptor `source` names together with its download url, or why it yielded nothing this
+/// poll.
+///
+/// A descriptor that is absent and one that carries no `fb_url_v1` are the same event to an
+/// operator — the configured source is unusable — so they share a counter at the call site while
+/// keeping messages that say which it was. The second shape is not hypothetical: `fb_url_v1` has
+/// no `skip_serializing_if`, so a publisher serializing a descriptor that still only has the
+/// deprecated urls writes it out as an explicit null.
+fn usable_assignment(
+    network_state: &sqd_assignments::NetworkState,
+    source: AssignmentSource,
+) -> anyhow::Result<(&NetworkAssignment, String)> {
+    let selected = select_assignment(network_state, source)
+        .ok_or_else(|| anyhow!("network state publishes no {source} assignment"))?;
+    let url = selected
+        .fb_url_v1
+        .clone()
+        .ok_or_else(|| anyhow!("the {source} assignment carries no fb_url_v1"))?;
+    Ok((selected, url))
+}
+
 /// The artifact descriptor `source` names, or `None` when the publisher hasn't included it.
 ///
 /// Every field of the network state is optional, because the migration walks it through three
@@ -570,6 +584,46 @@ mod tests {
 
         assert!(select_assignment(&legacy_only, AssignmentSource::Portal).is_none());
         assert!(select_assignment(&portal_only, AssignmentSource::Legacy).is_none());
+    }
+
+    #[allow(deprecated)]
+    fn assignment_without_url(id: &str) -> NetworkAssignment {
+        NetworkAssignment {
+            url: None,
+            fb_url: None,
+            fb_url_v1: None,
+            id: id.to_string(),
+            effective_from: 123,
+        }
+    }
+
+    #[test]
+    fn a_usable_source_yields_its_download_url() {
+        let state = network_state(true, false);
+
+        let (selected, url) = usable_assignment(&state, AssignmentSource::Legacy).unwrap();
+
+        assert_eq!(selected.id, "legacy");
+        assert_eq!(url, "https://example.test/legacy.fb.gz");
+    }
+
+    #[test]
+    fn a_source_carrying_no_v1_url_is_unusable() {
+        // Published but unfetchable is the same event as not published at all, and must reach
+        // the same counter -- an alert cannot tell the two apart and should not have to.
+        let mut state = network_state(true, true);
+        state.portal_assignment = Some(assignment_without_url("portal"));
+
+        assert!(usable_assignment(&state, AssignmentSource::Portal).is_err());
+        // ...and one source's defect says nothing about the other.
+        assert!(usable_assignment(&state, AssignmentSource::Legacy).is_ok());
+    }
+
+    #[test]
+    fn an_absent_source_is_unusable() {
+        let state = network_state(true, false);
+
+        assert!(usable_assignment(&state, AssignmentSource::Portal).is_err());
     }
 
     #[test]

--- a/src/network/storage.rs
+++ b/src/network/storage.rs
@@ -1,7 +1,8 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use anyhow::anyhow;
-use sqd_assignments::{Assignment, NetworkAssignment};
+use serde::Deserialize;
+use sqd_assignments::{Assignment, NetworkAssignment, PortalAssignment};
 use sqd_contract_client::{Network, PeerId};
 use sqd_primitives::BlockRef;
 use tracing::instrument;
@@ -13,31 +14,51 @@ use crate::{
     utils::RwLock,
 };
 
-/// The assignment currently held by the client: either the legacy shared format, or (under
-/// `mvcc-chunks`) the portal-oriented split format. See docs/assignment-wire-format.md in
-/// network-scheduler for the split rationale.
-enum ActiveAssignment {
-    Legacy(Assignment),
-    #[cfg(feature = "mvcc-chunks")]
-    Portal(sqd_assignments::PortalAssignment),
+/// Which of the published artifacts the portal routes from.
+///
+/// The scheduler publishes both throughout the migration, so this is an outright choice rather
+/// than a preference: only the selected artifact is ever consulted, and its absence is an error
+/// rather than a reason to serve the other one. That is what keeps [`Legacy`] usable as a kill
+/// switch and [`Portal`] verifiable as a canary.
+///
+/// [`Legacy`]: AssignmentSource::Legacy
+/// [`Portal`]: AssignmentSource::Portal
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, clap::ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum AssignmentSource {
+    /// `NetworkState::assignment`: the combined artifact served to workers and portals alike.
+    #[default]
+    Legacy,
+    /// `NetworkState::portal_assignment`: carries only what a portal reads.
+    Portal,
 }
 
-/// The last applied assignment. Carries its source because `portal_assignment` and the legacy
-/// `assignment` are independent sequences: ids only order within one of them.
-#[derive(Clone)]
-struct AppliedAssignment {
-    id: String,
-    is_portal_assignment: bool,
+impl std::fmt::Display for AssignmentSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Legacy => "legacy",
+            Self::Portal => "portal",
+        })
+    }
+}
+
+/// The assignment currently held by the client, in whichever wire format it was published in.
+/// See docs/assignment-wire-format.md in network-scheduler for the split rationale.
+enum ActiveAssignment {
+    Legacy(Assignment),
+    Portal(PortalAssignment),
 }
 
 pub struct StorageClient {
     assignment: RwLock<Option<ActiveAssignment>>,
     datasets_config: Arc<RwLock<Datasets>>,
-    latest_assignment: RwLock<Option<AppliedAssignment>>,
+    /// Id of the last applied assignment. Ids only order within a single source, but the source
+    /// is fixed for the process lifetime, so the id alone is enough to spot a regression.
+    latest_assignment_id: RwLock<Option<String>>,
     network_state_url: String,
     reqwest_client: reqwest::Client,
     ignore_deprecated_workers: bool,
-    prefer_portal_assignment: bool,
+    assignment_source: AssignmentSource,
 }
 
 #[derive(thiserror::Error, Debug, Clone)]
@@ -66,7 +87,7 @@ impl StorageClient {
         Self {
             assignment: RwLock::new(None, "StorageClient::assignment"),
             datasets_config,
-            latest_assignment: RwLock::new(None, "StorageClient::latest_assignment"),
+            latest_assignment_id: RwLock::new(None, "StorageClient::latest_assignment_id"),
             network_state_url,
             reqwest_client: reqwest::Client::builder()
                 .connect_timeout(Duration::from_secs(5))
@@ -75,7 +96,7 @@ impl StorageClient {
                 .build()
                 .unwrap(),
             ignore_deprecated_workers: false,
-            prefer_portal_assignment: true,
+            assignment_source: AssignmentSource::default(),
         }
     }
 
@@ -83,14 +104,13 @@ impl StorageClient {
         self.ignore_deprecated_workers = true;
     }
 
-    pub fn set_prefer_portal_assignment(&mut self, prefer: bool) {
-        self.prefer_portal_assignment = prefer;
+    pub fn set_assignment_source(&mut self, source: AssignmentSource) {
+        self.assignment_source = source;
     }
 
     pub fn num_workers(&self) -> usize {
         match self.assignment.read().as_ref() {
             Some(ActiveAssignment::Legacy(a)) => a.workers().len(),
-            #[cfg(feature = "mvcc-chunks")]
             Some(ActiveAssignment::Portal(a)) => a.workers().len(),
             None => 0,
         }
@@ -109,27 +129,34 @@ impl StorageClient {
     async fn update_assignment(&self) -> anyhow::Result<()> {
         tracing::debug!("Checking for new assignment");
         let network_state = self.fetch_network_state().await?;
-        let (visible_assignment, is_portal_assignment) =
-            visible_assignment(&network_state, self.prefer_portal_assignment);
-        let assignment_id = visible_assignment.id.clone();
-        let assignment_url = visible_assignment
+        let Some(selected) = select_assignment(&network_state, self.assignment_source) else {
+            // Never falls back to the other source: that would make a portal pinned to one format
+            // silently serve the other, defeating both the kill switch and the canary.
+            metrics::MISSING_ASSIGNMENT_SOURCE.inc();
+            return Err(anyhow!(
+                "network state publishes no {} assignment",
+                self.assignment_source
+            ));
+        };
+        let assignment_id = selected.id.clone();
+        let assignment_url = selected
             .fb_url_v1
             .clone()
             .ok_or(anyhow!("Missing assignment URL"))?;
-        let effective_from = visible_assignment.effective_from;
-        let latest = self.latest_assignment.read().clone();
-        if latest.as_ref().is_some_and(|l| l.id == assignment_id) {
+        let effective_from = selected.effective_from;
+        let latest = self.latest_assignment_id.read().clone();
+        if latest.as_deref() == Some(assignment_id.as_str()) {
             tracing::debug!("Assignment has not been changed");
             return Ok(());
         }
 
         if let Some(latest) = &latest {
-            if is_stale(latest, &assignment_id, is_portal_assignment) {
+            if is_stale(latest, &assignment_id) {
                 // Applying it would move the head backwards, dropping already-advertised chunks
                 // and opening a range no source covers. A later poll brings the newer one back.
                 tracing::warn!(
                     stale_id = %assignment_id,
-                    current_id = %latest.id,
+                    current_id = %latest,
                     "Rejected an assignment older than the current one"
                 );
                 metrics::STALE_ASSIGNMENTS_REJECTED.inc();
@@ -138,14 +165,14 @@ impl StorageClient {
         }
 
         let assignment = self
-            .fetch_assignment(&assignment_url, is_portal_assignment)
+            .fetch_assignment(&assignment_url, self.assignment_source)
             .await?;
 
         if latest.is_some() {
             sleep_until(effective_from).await;
         }
 
-        self.set_assignment(assignment, &assignment_id, is_portal_assignment);
+        self.set_assignment(assignment, &assignment_id);
 
         tracing::info!("Applied assignment \"{}\"", assignment_id);
         Ok(())
@@ -163,11 +190,10 @@ impl StorageClient {
     }
 
     #[instrument(skip(self, url))]
-    #[allow(unused_variables)]
     async fn fetch_assignment(
         &self,
         url: &str,
-        is_portal_assignment: bool,
+        source: AssignmentSource,
     ) -> anyhow::Result<ActiveAssignment> {
         use async_compression::tokio::bufread::GzipDecoder;
         use futures::TryStreamExt;
@@ -191,24 +217,19 @@ impl StorageClient {
 
         tracing::debug!("Downloaded assignment from {}", url);
 
-        #[cfg(feature = "mvcc-chunks")]
-        if is_portal_assignment {
-            return Ok(ActiveAssignment::Portal(
-                sqd_assignments::PortalAssignment::from_owned_unchecked(buf),
-            ));
-        }
-
-        Ok(ActiveAssignment::Legacy(Assignment::from_owned_unchecked(
-            buf,
-        )))
+        Ok(match source {
+            AssignmentSource::Legacy => {
+                ActiveAssignment::Legacy(Assignment::from_owned_unchecked(buf))
+            }
+            AssignmentSource::Portal => {
+                ActiveAssignment::Portal(PortalAssignment::from_owned_unchecked(buf))
+            }
+        })
     }
 
     #[instrument(skip_all)]
-    fn set_assignment(&self, assignment: ActiveAssignment, id: &str, is_portal_assignment: bool) {
-        *self.latest_assignment.write() = Some(AppliedAssignment {
-            id: id.to_owned(),
-            is_portal_assignment,
-        });
+    fn set_assignment(&self, assignment: ActiveAssignment, id: &str) {
+        *self.latest_assignment_id.write() = Some(id.to_owned());
 
         let prev = self.assignment.read();
         let workers_len = match &assignment {
@@ -227,7 +248,6 @@ impl StorageClient {
                 );
                 assignment.workers().len()
             }
-            #[cfg(feature = "mvcc-chunks")]
             ActiveAssignment::Portal(assignment) => {
                 self.update_datasets(
                     assignment
@@ -289,7 +309,6 @@ impl StorageClient {
             )?
             .id()
             .to_owned(),
-            #[cfg(feature = "mvcc-chunks")]
             ActiveAssignment::Portal(assignment) => find_chunk_with(
                 || assignment.find_chunk(dataset_url, block),
                 || assignment.get_dataset(dataset_url).unwrap().first_block(),
@@ -317,7 +336,6 @@ impl StorageClient {
             )?
             .id()
             .to_owned(),
-            #[cfg(feature = "mvcc-chunks")]
             ActiveAssignment::Portal(assignment) => find_chunk_with(
                 || assignment.find_chunk_by_timestamp(dataset_url, ts),
                 || assignment.get_dataset(dataset_url).unwrap().first_block(),
@@ -351,7 +369,6 @@ impl StorageClient {
                     }),
                 )
             }
-            #[cfg(feature = "mvcc-chunks")]
             ActiveAssignment::Portal(assignment) => {
                 let chunk = find_chunk_with(
                     || assignment.find_chunk(dataset_url, block),
@@ -400,7 +417,6 @@ impl StorageClient {
         let dataset_url = dataset.to_url();
         match self.assignment.read().as_ref()? {
             ActiveAssignment::Legacy(a) => Some(a.get_dataset(dataset_url)?.first_block()),
-            #[cfg(feature = "mvcc-chunks")]
             ActiveAssignment::Portal(a) => Some(a.get_dataset(dataset_url)?.first_block()),
         }
     }
@@ -415,7 +431,6 @@ impl StorageClient {
                     number: dataset.last_block(),
                 })
             }
-            #[cfg(feature = "mvcc-chunks")]
             ActiveAssignment::Portal(a) => {
                 let dataset = a.get_dataset(dataset_url)?;
                 dataset.last_block_hash().map(|hash| BlockRef {
@@ -433,7 +448,6 @@ impl StorageClient {
                 .iter()
                 .filter_map(|w| (*w.worker_id()).try_into().ok())
                 .collect(),
-            #[cfg(feature = "mvcc-chunks")]
             Some(ActiveAssignment::Portal(a)) => a
                 .workers()
                 .iter()
@@ -455,7 +469,6 @@ impl StorageClient {
                     });
                 }
             }
-            #[cfg(feature = "mvcc-chunks")]
             ActiveAssignment::Portal(assignment) => {
                 for c in assignment.get_dataset(dataset_url)?.chunks().iter() {
                     accumulate_range(&mut ranges, c.id(), c.worker_indexes().iter(), |idx| {
@@ -492,32 +505,20 @@ fn accumulate_range(
     }
 }
 
-/// Selects the assignment portals should use for routing, and reports whether it was the
-/// dedicated portal assignment (`true`) or the legacy shared assignment (`false`).
+/// The artifact descriptor `source` names, or `None` when the publisher hasn't included it.
 ///
-/// Under `mvcc-chunks`, portals prefer `portal_assignment` when `prefer_portal_assignment` is
-/// set (a runtime config flag, so it can be reverted without a rebuild), but fall back to the
-/// legacy assignment if it's disabled or the scheduler hasn't published `portal_assignment` yet.
-fn visible_assignment(
+/// Every field of the network state is optional, because the migration walks it through three
+/// shapes: legacy alone, both, then the split pair alone. Which of those a given network is in is
+/// the publisher's business -- the portal's is to serve the format it was configured for, or
+/// nothing at all.
+fn select_assignment(
     network_state: &sqd_assignments::NetworkState,
-    prefer_portal_assignment: bool,
-) -> (&NetworkAssignment, bool) {
-    #[cfg(feature = "mvcc-chunks")]
-    if prefer_portal_assignment {
-        match network_state.portal_assignment.as_ref() {
-            Some(assignment) => return (assignment, true),
-            None => {
-                tracing::warn!(
-                    "portal_assignment missing in network state; falling back to legacy assignment"
-                );
-            }
-        }
+    source: AssignmentSource,
+) -> Option<&NetworkAssignment> {
+    match source {
+        AssignmentSource::Legacy => network_state.assignment.as_ref(),
+        AssignmentSource::Portal => network_state.portal_assignment.as_ref(),
     }
-
-    #[cfg(not(feature = "mvcc-chunks"))]
-    let _ = prefer_portal_assignment;
-
-    (&network_state.assignment, false)
 }
 
 #[cfg(test)]
@@ -535,68 +536,71 @@ mod tests {
         }
     }
 
-    fn network_state() -> sqd_assignments::NetworkState {
+    /// A state publishing exactly the artifacts named, so a test can spell out which of the three
+    /// migration shapes it is in.
+    fn network_state(legacy: bool, portal: bool) -> sqd_assignments::NetworkState {
         sqd_assignments::NetworkState {
             network: "testnet".to_string(),
-            assignment: assignment("legacy"),
-            #[cfg(feature = "mvcc-chunks")]
+            assignment: legacy.then(|| assignment("legacy")),
             worker_assignment: None,
-            #[cfg(feature = "mvcc-chunks")]
-            portal_assignment: None,
+            portal_assignment: portal.then(|| assignment("portal")),
+            schema_bundle: None,
         }
     }
 
     #[test]
-    fn visible_assignment_uses_legacy_assignment() {
-        let state = network_state();
+    fn each_source_selects_its_own_artifact() {
+        let state = network_state(true, true);
 
-        let (visible, is_portal) = visible_assignment(&state, true);
-        assert_eq!(visible.id, "legacy");
-        assert!(!is_portal);
+        let legacy = select_assignment(&state, AssignmentSource::Legacy);
+        let portal = select_assignment(&state, AssignmentSource::Portal);
+
+        assert_eq!(legacy.map(|a| a.id.as_str()), Some("legacy"));
+        assert_eq!(portal.map(|a| a.id.as_str()), Some("portal"));
     }
 
-    #[cfg(feature = "mvcc-chunks")]
     #[test]
-    fn visible_assignment_prefers_portal_assignment() {
-        let mut state = network_state();
-        state.portal_assignment = Some(assignment("portal"));
+    fn a_missing_source_never_falls_back_to_the_other() {
+        // The whole point of the selector: pinning to one format must not silently serve the
+        // other, in either direction or in either of the one-sided migration shapes.
+        let legacy_only = network_state(true, false);
+        let portal_only = network_state(false, true);
 
-        let (visible, is_portal) = visible_assignment(&state, true);
-        assert_eq!(visible.id, "portal");
-        assert!(is_portal);
+        assert!(select_assignment(&legacy_only, AssignmentSource::Portal).is_none());
+        assert!(select_assignment(&portal_only, AssignmentSource::Legacy).is_none());
     }
 
-    fn applied(id: &str) -> AppliedAssignment {
-        AppliedAssignment {
-            id: id.to_string(),
-            is_portal_assignment: true,
-        }
+    #[test]
+    fn no_published_artifact_selects_nothing() {
+        let state = network_state(false, false);
+
+        assert!(select_assignment(&state, AssignmentSource::Legacy).is_none());
+        assert!(select_assignment(&state, AssignmentSource::Portal).is_none());
     }
 
     #[test]
     fn older_assignment_is_stale() {
-        let current = applied("2026-08-07T19:21:53_AAAA");
-        assert!(is_stale(&current, "2026-08-07T19:02:21_BBBB", true));
+        assert!(is_stale(
+            "2026-08-07T19:21:53_AAAA",
+            "2026-08-07T19:02:21_BBBB"
+        ));
     }
 
     #[test]
     fn newer_assignment_is_not_stale() {
-        let current = applied("2026-08-07T19:02:21_AAAA");
-        assert!(!is_stale(&current, "2026-08-07T19:21:53_BBBB", true));
+        assert!(!is_stale(
+            "2026-08-07T19:02:21_AAAA",
+            "2026-08-07T19:21:53_BBBB"
+        ));
     }
 
     #[test]
     fn same_timestamp_is_not_stale() {
         // Only the timestamp orders, so a differing hash must still apply.
-        let current = applied("2026-08-07T19:21:53_AAAA");
-        assert!(!is_stale(&current, "2026-08-07T19:21:53_BBBB", true));
-    }
-
-    #[test]
-    fn assignment_from_the_other_source_is_never_stale() {
-        // Otherwise a fallback between the two sources would look like a regression.
-        let current = applied("2026-08-07T19:21:53_AAAA");
-        assert!(!is_stale(&current, "2026-08-07T19:02:21_BBBB", false));
+        assert!(!is_stale(
+            "2026-08-07T19:21:53_AAAA",
+            "2026-08-07T19:21:53_BBBB"
+        ));
     }
 
     #[test]
@@ -608,29 +612,17 @@ mod tests {
             ("2026-08-07T19:21:53_", "2020-01-01T00:00:00_B"),
         ];
         for (current, candidate) in cases {
-            assert!(
-                !is_stale(&applied(current), candidate, true),
-                "{current} / {candidate}"
-            );
+            assert!(!is_stale(current, candidate), "{current} / {candidate}");
         }
     }
 
     #[test]
     fn ids_from_different_timestamp_formats_are_never_stale() {
         // A format change must not make every subsequent assignment look older.
-        let current = applied("2026-08-07T19:21:53_AAAA");
-        assert!(!is_stale(&current, "20260807T192153_BBBB", true));
-    }
-
-    #[cfg(feature = "mvcc-chunks")]
-    #[test]
-    fn visible_assignment_can_be_reverted_to_legacy_via_config() {
-        let mut state = network_state();
-        state.portal_assignment = Some(assignment("portal"));
-
-        let (visible, is_portal) = visible_assignment(&state, false);
-        assert_eq!(visible.id, "legacy");
-        assert!(!is_portal);
+        assert!(!is_stale(
+            "2026-08-07T19:21:53_AAAA",
+            "20260807T192153_BBBB"
+        ));
     }
 }
 
@@ -662,13 +654,13 @@ fn convert_chunk_not_found(
 /// Ids are `<timestamp>_<hash>` with a fixed-width timestamp, so prefixes order lexicographically.
 /// The hash is excluded: it carries no ordering, and would order same-second ids arbitrarily.
 ///
+/// Both ids always come from the same source, which is fixed for the process lifetime, so they are
+/// always drawn from one sequence and directly comparable.
+///
 /// Every uncertain case returns false. Wrongly accepting costs one poll; wrongly rejecting freezes
 /// the head until restart.
-fn is_stale(applied: &AppliedAssignment, candidate: &str, candidate_is_portal: bool) -> bool {
-    if applied.is_portal_assignment != candidate_is_portal {
-        return false;
-    }
-    let (Some(current), Some(new)) = (timestamp_prefix(&applied.id), timestamp_prefix(candidate))
+fn is_stale(applied_id: &str, candidate: &str) -> bool {
+    let (Some(current), Some(new)) = (timestamp_prefix(applied_id), timestamp_prefix(candidate))
     else {
         return false;
     };

--- a/src/network/storage.rs
+++ b/src/network/storage.rs
@@ -26,10 +26,12 @@ use crate::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum AssignmentSource {
-    /// `NetworkState::assignment`: the combined artifact served to workers and portals alike.
+    // Kept short and free of Rust paths: clap renders these verbatim as the `--help` text for
+    // each possible value.
+    /// The combined assignment, served to workers and portals alike.
     #[default]
     Legacy,
-    /// `NetworkState::portal_assignment`: carries only what a portal reads.
+    /// The dedicated portal assignment, carrying only what a portal reads.
     Portal,
 }
 


### PR DESCRIPTION
# What is this PR about?

`assignment_source: legacy | portal` picks which published artifact routing reads. Config key, overridable with `--assignment-source` / `ASSIGNMENT_SOURCE`. Defaults to `legacy`.

## Selection is absolute

|                    | legacy only | both   | portal only | neither |
|--------------------|-------------|--------|-------------|---------|
| `legacy` (default) | legacy      | legacy | error       | error   |
| `portal`           | error       | portal | portal      | error   |

error = log + `missing_assignment_source`, apply nothing, keep serving the current assignment. At startup there is none, so `/ready` stays false.

No fallback in either direction, which is the point of the change: `prefer_portal_assignment` fell back silently, so a canary that never ran was indistinguishable from one that passed. `ct1_smoke` now runs against both artifacts and asserts the configured one was fetched *and* the other never was.

## Removals

`mvcc-chunks` — sqd-network dropped its own, and every gate here duplicated the `ActiveAssignment` enum that already switched at runtime. The source is then fixed for the process lifetime, making `AppliedAssignment.is_portal_assignment` and the cross-source branch of `is_stale` unreachable; both removed with it.

`prefer_portal_assignment` — removed outright, no shim. **An unknown top-level config key is fatal without an `auth:` block, so a config still setting it refuses to start.** It was inert in every released build (the portal path sat behind a non-default feature and release images build without `--features`) and is judged unused, but that is a deployment-side claim, not a code one.

## Dependency bump

sqd-network `e9a3434`/`360bbd4` → `67f54cc`. The span crosses `541684c`, which moved the libp2p fork to `fac3b0c9`. That fork builds against an in-tree `libp2p-identity` while `multiaddr` pulls the crates.io one, so without `[patch.crates-io]` both land in the graph and `libp2p-swarm` fails on mismatched `PeerId` types. sqd-network patches this in its own root manifest, but Cargo only honours `[patch]` from the workspace root, so consumers must repeat it.

The same span carries `c4b85c1`, which hands raw protobuf to the transport consumer — the harness worker stub now decodes/encodes itself. The harness is a separate workspace, so it needs its own patch plus `=0.2.12` on `libp2p-identity`: its lock held `0.2.14` and preferred it over the patch. The root manifest is still a caret and works only because its lock holds `0.2.12` — same trap after an unconstrained `cargo update`.

`query_engine`/`output_format` are set to protocol defaults. `msg_to_sign` only appends them when non-zero, so signatures stay byte-identical for workers predating the fields.

## Known gaps

- No e2e test of the absent-artifact path — unit-tested only, though it is the behaviour the design turns on.
- `ct2_worker_faults` and `ct10_authorization` run legacy only.
- `missing_assignment_source` does not count a descriptor published *without* `fb_url_v1`, so an alert on it has a hole.
- Mid-life loss of the artifact keeps `/ready` at 200 — needs an alert, not a dashboard.
- Both parse paths use `from_owned_unchecked`; nothing verifies the blob at a URL is the format configured for it. Pre-existing (GAP-1), but the split doubles the ways to mismatch.
- `schema_bundle` / `read_schema_id` out of scope — no bundle format is defined upstream yet.