### PR TITLE
fix(network): sign worker queries after congestion-permit acquisition

### DIFF
--- a/harness/src/fixture.rs
+++ b/harness/src/fixture.rs
@@ -11,7 +11,7 @@ use anyhow::Context;
 use tempfile::TempDir;
 
 use crate::artifact::AssignmentSource;
-use crate::portal::{Auth, Endpoints, PortalProcess};
+use crate::portal::{Auth, Endpoints, PortalProcess, Tuning};
 use crate::stubs::control_plane::ControlPlane;
 use crate::stubs::worker::{WorkerFaults, WorkerStub};
 use crate::{artifact, driver, dummy_chain, keys, portal, stubs, ToyWorld};
@@ -55,7 +55,7 @@ impl Fixture {
     /// 1 + retries distinct workers per chunk, so two is the minimum that lets
     /// a reroute actually find somewhere to go.
     pub async fn start(world: ToyWorld, workers: usize) -> anyhow::Result<Self> {
-        Self::start_with(world, workers, None, Assignments::default()).await
+        Self::start_with(world, workers, None, Assignments::default(), None).await
     }
 
     /// The same world with an `auth:` block and the DC-8 stub behind it.
@@ -66,7 +66,7 @@ impl Fixture {
         workers: usize,
         auth: Auth,
     ) -> anyhow::Result<Self> {
-        Self::start_with(world, workers, Some(auth), Assignments::default()).await
+        Self::start_with(world, workers, Some(auth), Assignments::default(), None).await
     }
 
     /// A fixture whose publisher shape and configured source are set by the caller — the DC-2
@@ -77,7 +77,18 @@ impl Fixture {
         workers: usize,
         assignments: Assignments,
     ) -> anyhow::Result<Self> {
-        Self::start_with(world, workers, None, assignments).await
+        Self::start_with(world, workers, None, assignments, None).await
+    }
+
+    /// The same world with portal tuning (congestion window, transport timeout).
+    /// Used by the stale-timestamp class, whose property depends on how the
+    /// congestion scheduler queues a signed query rather than on the request.
+    pub async fn start_tuned(
+        world: ToyWorld,
+        workers: usize,
+        tuning: Tuning,
+    ) -> anyhow::Result<Self> {
+        Self::start_with(world, workers, None, Assignments::default(), Some(tuning)).await
     }
 
     async fn start_with(
@@ -85,6 +96,7 @@ impl Fixture {
         workers: usize,
         auth: Option<Auth>,
         assignments: Assignments,
+        tuning: Option<Tuning>,
     ) -> anyhow::Result<Self> {
         anyhow::ensure!(workers >= 1, "need at least one worker");
         // Loopback p2p addresses are filtered as unreachable unless this is set.
@@ -181,6 +193,7 @@ impl Fixture {
             &endpoints,
             auth.as_ref(),
             assignments.source,
+            tuning.as_ref(),
         )?;
         let portal = portal::spawn(
             &scratch,

--- a/harness/src/portal.rs
+++ b/harness/src/portal.rs
@@ -35,6 +35,58 @@ pub struct Auth {
 /// Where the fixture writes the dedicated key and where `auth.key_path` points.
 pub const AUTH_KEY_FILE: &str = "auth.key";
 
+/// Optional portal tuning a test threads through the fixture, for classes whose
+/// property depends on configuration rather than on the request (like CT-10's
+/// `auth:` block). Absent, the smoke's defaults hold; present, it can pin the
+/// congestion window and lengthen the transport timeout so a slow worker read
+/// holds a scheduler slot past the worker's 60s freshness bound.
+#[derive(Clone)]
+pub struct Tuning {
+    /// The portal's per-request transport timeout. Must exceed a stall a test
+    /// wants a worker to hold, or the portal tears the query down first.
+    pub transport_timeout_sec: u64,
+    /// `Some` writes a `congestion:` block; `None` leaves the portal's default
+    /// (an AIMD window seeded at 10..=500).
+    pub congestion: Option<Congestion>,
+}
+
+/// The subset of `CongestionConfig` (src/config.rs) a test pins. Field names
+/// match the portal struct; the rest keep their `#[serde(default)]` values.
+#[derive(Clone)]
+pub struct Congestion {
+    pub enabled: bool,
+    pub min_window: u32,
+    pub max_window: u32,
+    /// Per-read deadline inside `read_response_with_permits`; a stalled body read
+    /// holds its scheduler slot up to this long.
+    pub read_timeout_sec: u64,
+}
+
+impl Default for Tuning {
+    fn default() -> Self {
+        Self {
+            transport_timeout_sec: 10,
+            congestion: None,
+        }
+    }
+}
+
+impl Tuning {
+    /// A single-slot congestion window (`min = max = 1`) with a transport timeout
+    /// and read timeout long enough to hold that slot across a multi-second stall.
+    pub fn single_slot_congestion(transport_timeout_sec: u64, read_timeout_sec: u64) -> Self {
+        Self {
+            transport_timeout_sec,
+            congestion: Some(Congestion {
+                enabled: true,
+                min_window: 1,
+                max_window: 1,
+                read_timeout_sec,
+            }),
+        }
+    }
+}
+
 impl Auth {
     pub fn new(portal_id: impl Into<String>) -> Self {
         Self {
@@ -67,6 +119,7 @@ pub fn write_config(
     e: &Endpoints,
     auth: Option<&Auth>,
     assignment_source: AssignmentSource,
+    tuning: Option<&Tuning>,
 ) -> anyhow::Result<PathBuf> {
     let mut datasets = String::new();
     for ds in &world.datasets {
@@ -110,10 +163,27 @@ pub fn write_config(
         _ => String::new(),
     };
 
+    let default_tuning = Tuning::default();
+    let tuning = tuning.unwrap_or(&default_tuning);
+    let congestion_block = match &tuning.congestion {
+        Some(c) => format!(
+            "congestion:\n  \
+             enabled: {enabled}\n  \
+             min_window: {min}\n  \
+             max_window: {max}\n  \
+             read_timeout_sec: {read}\n",
+            enabled = c.enabled,
+            min = c.min_window,
+            max = c.max_window,
+            read = c.read_timeout_sec,
+        ),
+        None => String::new(),
+    };
+
     let config = format!(
         r#"hostname: http://127.0.0.1:{http}
 max_parallel_streams: 64
-transport_timeout_sec: 10
+transport_timeout_sec: {transport_timeout}
 pre_drain_grace_period_sec: 1
 drain_timeout_sec: 2
 assignments_url: http://127.0.0.1:{publisher}
@@ -124,7 +194,7 @@ chain_update_interval_sec: 60
 send_logs: false
 sentry_is_enabled: false
 verify_worker_responses: true
-# Fast penalty decay: an early dial race must not wedge the tiny toy pool for
+{congestion_block}# Fast penalty decay: an early dial race must not wedge the tiny toy pool for
 # minutes. Penalty behavior itself is CT-2's subject, not the smoke's.
 priorities:
   max_queries_per_worker: 1
@@ -142,6 +212,8 @@ datasets:
         registry = e.registry_port,
         datasets = datasets,
         auth_block = auth_block,
+        transport_timeout = tuning.transport_timeout_sec,
+        congestion_block = congestion_block,
     );
     let path = scratch.join("portal.config.yml");
     std::fs::write(&path, config)?;

--- a/harness/src/stubs/worker.rs
+++ b/harness/src/stubs/worker.rs
@@ -24,10 +24,11 @@ use sqd_network_transport::{
 use super::Ledger;
 use crate::world::ToyWorld;
 
-/// The real worker's admission-time freshness bound (`protocol::MAX_TIME_LAG`,
-/// 60s in worker-rs). A signed query whose `timestamp_ms` is further than this
-/// from the worker's clock is rejected with `BadRequest`.
-const MAX_TIME_LAG_MS: u64 = 60_000;
+/// The real worker's admission-time freshness bound: a signed query whose
+/// `timestamp_ms` is further than this from the worker's clock is rejected
+/// with `BadRequest`. Derived from the shared protocol constant worker-rs
+/// validates against, so the stub keeps mirroring workers if the bound moves.
+const MAX_TIME_LAG_MS: u64 = sqd_network_transport::protocol::MAX_TIME_LAG.as_millis() as u64;
 
 fn now_ms() -> u64 {
     SystemTime::now()
@@ -178,14 +179,14 @@ pub async fn start(
                     query,
                     resp_chan,
                 } => {
-                    let lag = query.timestamp_ms.abs_diff(now_ms());
-                    // Freshness wins before the fault queue is touched: a naturally
-                    // stale query is rejected at admission and must not consume (and
-                    // silently swallow) the next scripted fault, or every scenario
-                    // queued behind it would shift. `answer` re-checks on its own
-                    // clock read; test staleness margins are seconds, so the two
-                    // reads cannot disagree in practice.
-                    let fault = if lag > MAX_TIME_LAG_MS {
+                    // One clock read decides admission for both the fault dequeue
+                    // and the answer: freshness wins before the fault queue is
+                    // touched — a naturally stale query is rejected at admission
+                    // and must not consume (and silently swallow) the next scripted
+                    // fault — and `answer` receives the same lag, so the decision
+                    // cannot flip between the two.
+                    let lag_ms = query.timestamp_ms.abs_diff(now_ms());
+                    let fault = if lag_ms > MAX_TIME_LAG_MS {
                         None
                     } else {
                         faults.next()
@@ -195,7 +196,7 @@ pub async fn start(
                         chunk = %query.chunk_id,
                         ?fault,
                         signed_ts = query.timestamp_ms,
-                        lag_ms = lag,
+                        lag_ms,
                         "stub worker query"
                     );
                     // A `Stall` defers the send; every other verdict is built now.
@@ -203,7 +204,7 @@ pub async fn start(
                         Some(WorkerFault::Stall(d)) => Some(*d),
                         _ => None,
                     };
-                    let result = answer(&world, &signing_keypair, &query, &ledger2, fault);
+                    let result = answer(&world, &signing_keypair, &query, &ledger2, fault, lag_ms);
                     match stall {
                         Some(dur) => {
                             let handle = handle.clone();
@@ -229,17 +230,20 @@ pub async fn start(
     Ok(WorkerStub { ledger })
 }
 
+/// `lag_ms` is the admission lag the event loop measured with the same clock
+/// read that decided whether to dequeue a fault — passed in rather than
+/// re-measured, so the freshness decision cannot flip between the two.
 fn answer(
     world: &ToyWorld,
     keypair: &Keypair,
     query: &sqd_messages::Query,
     ledger: &Ledger,
     fault: Option<WorkerFault>,
+    lag_ms: u64,
 ) -> sqd_messages::QueryResult {
     let range = query
         .block_range
         .unwrap_or(sqd_messages::Range { begin: 0, end: 0 });
-    let lag_ms = query.timestamp_ms.abs_diff(now_ms());
     ledger.push(format!(
         "query chunk={} range={}-{} dataset={} lag_ms={} fault={}",
         query.chunk_id,

--- a/harness/src/stubs/worker.rs
+++ b/harness/src/stubs/worker.rs
@@ -9,6 +9,7 @@ use std::collections::VecDeque;
 use std::io::Write;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::Context;
 use clap::Parser;
@@ -22,6 +23,18 @@ use sqd_network_transport::{
 
 use super::Ledger;
 use crate::world::ToyWorld;
+
+/// The real worker's admission-time freshness bound (`protocol::MAX_TIME_LAG`,
+/// 60s in worker-rs). A signed query whose `timestamp_ms` is further than this
+/// from the worker's clock is rejected with `BadRequest`.
+const MAX_TIME_LAG_MS: u64 = 60_000;
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("after 1970")
+        .as_millis() as u64
+}
 
 #[derive(Parser)]
 struct StubCli {
@@ -51,6 +64,11 @@ pub enum WorkerFault {
     TooManyRequests,
     /// Refuse for capacity: the overload verdict. One DC-1 row with the above.
     ServerOverloaded,
+    /// Hold the response (send no bytes) for the duration, then answer normally.
+    /// Models a worker that received the query fresh (so it passes the
+    /// admission-time timestamp check) but is slow to produce the body.
+    /// Deferred send so the stub's event loop keeps serving other queries.
+    Stall(Duration),
 }
 
 /// A fault queue shared by every stub worker in a test, so a single queued
@@ -136,8 +154,16 @@ pub async fn start(
     let builder = P2PTransportBuilder::from_cli(cli.transport, agent)
         .await
         .context("transport builder")?;
+    // The worker's own request_response uses `query_execution_timeout` as the
+    // per-request deadline; the default (20s) would tear a `Stall` down before a
+    // >60s congestion delay could elapse. Raise it so the stub can hold a
+    // response as long as a test needs.
+    let worker_config = WorkerConfig {
+        query_execution_timeout: Duration::from_secs(300),
+        ..WorkerConfig::default()
+    };
     let (events, handle) = builder
-        .build_worker(WorkerConfig::default())
+        .build_worker(worker_config)
         .await
         .context("build worker")?;
 
@@ -152,11 +178,47 @@ pub async fn start(
                     query,
                     resp_chan,
                 } => {
-                    let fault = faults.next();
-                    tracing::info!(%peer_id, chunk = %query.chunk_id, ?fault, "stub worker query");
+                    let lag = query.timestamp_ms.abs_diff(now_ms());
+                    // Freshness wins before the fault queue is touched: a naturally
+                    // stale query is rejected at admission and must not consume (and
+                    // silently swallow) the next scripted fault, or every scenario
+                    // queued behind it would shift. `answer` re-checks on its own
+                    // clock read; test staleness margins are seconds, so the two
+                    // reads cannot disagree in practice.
+                    let fault = if lag > MAX_TIME_LAG_MS {
+                        None
+                    } else {
+                        faults.next()
+                    };
+                    tracing::info!(
+                        %peer_id,
+                        chunk = %query.chunk_id,
+                        ?fault,
+                        signed_ts = query.timestamp_ms,
+                        lag_ms = lag,
+                        "stub worker query"
+                    );
+                    // A `Stall` defers the send; every other verdict is built now.
+                    let stall = match &fault {
+                        Some(WorkerFault::Stall(d)) => Some(*d),
+                        _ => None,
+                    };
                     let result = answer(&world, &signing_keypair, &query, &ledger2, fault);
-                    if handle.send_query_result(result, resp_chan).is_err() {
-                        tracing::warn!("query result queue full");
+                    match stall {
+                        Some(dur) => {
+                            let handle = handle.clone();
+                            tokio::spawn(async move {
+                                tokio::time::sleep(dur).await;
+                                if handle.send_query_result(result, resp_chan).is_err() {
+                                    tracing::warn!("query result queue full (after stall)");
+                                }
+                            });
+                        }
+                        None => {
+                            if handle.send_query_result(result, resp_chan).is_err() {
+                                tracing::warn!("query result queue full");
+                            }
+                        }
                     }
                 }
                 other => tracing::debug!("ignoring worker event: {other:?}"),
@@ -177,16 +239,32 @@ fn answer(
     let range = query
         .block_range
         .unwrap_or(sqd_messages::Range { begin: 0, end: 0 });
+    let lag_ms = query.timestamp_ms.abs_diff(now_ms());
     ledger.push(format!(
-        "query chunk={} range={}-{} dataset={} fault={}",
+        "query chunk={} range={}-{} dataset={} lag_ms={} fault={}",
         query.chunk_id,
         range.begin,
         range.end,
         query.dataset,
+        lag_ms,
         fault
             .as_ref()
             .map_or("none".to_owned(), |f| format!("{f:?}")),
     ));
+
+    // Admission-time freshness check, exactly as the real worker's `validate_query`
+    // does it (worker-rs src/controller/p2p.rs): a signed timestamp more than
+    // MAX_TIME_LAG from the worker's clock is rejected. Unconditional — it mimics
+    // the real worker rather than being an injectable fault (`StaleEnvelope` is the
+    // injectable variant) — and it runs first, because the real worker validates
+    // before it does anything else with a query.
+    if lag_ms > MAX_TIME_LAG_MS {
+        return verdict_result(
+            query,
+            keypair,
+            query_error::Err::BadRequest("timestamp out of allowed range".to_owned()),
+        );
+    }
 
     match &fault {
         Some(WorkerFault::ServerError(m)) => {

--- a/harness/tests/ct1_smoke.rs
+++ b/harness/tests/ct1_smoke.rs
@@ -161,7 +161,7 @@ async fn smoke(assignment_source: AssignmentSource) -> anyhow::Result<()> {
         .map(|(id, port)| format!("{} /ip4/127.0.0.1/udp/{port}/quic-v1", id.peer_id))
         .collect::<Vec<_>>()
         .join(",");
-    let config = portal::write_config(&scratch, &world, &endpoints, None, assignment_source)?;
+    let config = portal::write_config(&scratch, &world, &endpoints, None, assignment_source, None)?;
     let mut portal_proc = portal::spawn(
         &scratch,
         &config,

--- a/harness/tests/ct_stale_timestamp.rs
+++ b/harness/tests/ct_stale_timestamp.rs
@@ -1,32 +1,36 @@
 //! Stale-signed-timestamp rejection — the class for the 2026 production
 //! incident where a portal returned hard, non-retriable `400`s for specific
-//! chunk ranges, and for the fix that removed it.
+//! chunk ranges.
 //!
-//! ## The defect (reproduced first, then fixed on this branch)
+//! ## The defect
 //!
 //! `prepare_query` (src/network/client.rs) stamps `timestamp_ms = now` and
 //! signs the worker query; a worker validates that signed timestamp at
 //! admission against `MAX_TIME_LAG = 60s` (worker-rs `validate_query`) and
-//! answers `BadRequest("timestamp out of allowed range")` when it is exceeded —
-//! a rejection that can carry a `retry_after` hint. Two things compounded:
+//! answers `BadRequest("timestamp out of allowed range")` when it is exceeded.
+//! Two things compounded:
 //!
 //! 1. The query was signed *before* `send_to_transport` awaited its
 //!    congestion-scheduler permit, so under load the signature aged in the
 //!    portal's own queue.
 //! 2. The verdict table (`Verdict::of`) mapped *any* worker `BadRequest` — the
-//!    anti-replay rejection included — to a non-retriable client `400`
+//!    stale-envelope rejection included — to a non-retriable client `400`
 //!    (`invalid_request_error` / `malformed_request`), no reroute, no failover.
 //!
-//! ## The fix these tests pin
+//! ## What these tests pin
 //!
-//! - The stale-timestamp rejection is classified retriable: the portal
-//!   reroutes with a freshly signed attempt and the client sees a `200`
-//!   ([`ct_stale_timestamp_is_retried`]). The worker that correctly rejected
-//!   the stale query is not penalized.
-//! - The send permit is acquired *before* the query is stamped and signed
-//!   (`query_worker`), so queue time can no longer age a signature
-//!   ([`ct_stale_timestamp_congestion_queue_boundary`] documents the permit
-//!   lifetimes that make the >60s queue itself unreachable in this harness).
+//! - The verdict side (landed on master as the `clock_skew` row): the
+//!   stale-envelope rejection reroutes on the error cooldown, so the client
+//!   sees a `200` served by another worker, and the rejecting worker's cooldown
+//!   decays instead of latching ([`ct_stale_timestamp_is_retried`] drives the
+//!   genuine wire rejection end to end, plus the stub now applies the real
+//!   admission-time freshness check unconditionally).
+//! - The signing side (this branch): the send permit is acquired *before* the
+//!   query is stamped and signed (`query_worker`), so queue time can no longer
+//!   age a signature ([`ct_stale_timestamp_congestion_queue_boundary`]
+//!   documents the permit lifetimes that make the >60s queue itself
+//!   unreachable in this harness; the ordering is pinned at unit level on the
+//!   `acquire_permit_then_timestamp` seam).
 
 use std::time::{Duration, Instant};
 
@@ -69,9 +73,10 @@ fn is_stale_timestamp_400(d: &Decoded) -> bool {
             .contains("timestamp out of allowed range")
 }
 
-/// A worker's stale-timestamp rejection is transient: the portal must reroute
+/// A worker's stale-envelope rejection is transient: the portal must reroute
 /// with a freshly signed attempt and deliver a `200`, never the pre-fix
-/// terminal `400`.
+/// terminal `400` — and the rejecting worker's error cooldown must decay
+/// rather than latch.
 #[tokio::test(flavor = "multi_thread")]
 async fn ct_stale_timestamp_is_retried() -> anyhow::Result<()> {
     // Two workers, so the reroute has somewhere to go.
@@ -105,7 +110,7 @@ async fn run_retry(fx: &mut Fixture) -> anyhow::Result<()> {
     // The genuine wire rejection: whichever worker the portal picks first
     // answers `BadRequest("timestamp out of allowed range")`, exactly as a real
     // worker does when a signed timestamp is stale at admission.
-    fx.worker_faults.queue(WorkerFault::BadTimestamp, 1);
+    fx.worker_faults.queue(WorkerFault::StaleEnvelope, 1);
     let before = fx.queries_answered();
     let d = driver::stream(
         &http,
@@ -149,10 +154,14 @@ async fn run_retry(fx: &mut Fixture) -> anyhow::Result<()> {
         "a rejected attempt must be rerouted; only {sent} worker query was answered"
     );
 
-    // The rejecting worker was never the problem, so the pool stays healthy:
-    // the very next request serves without cooldown. Issued immediately — the
-    // harness config decays worker penalties after 1s, so a wrongly cooled-down
-    // worker would still be inside its penalty window here.
+    // The rejection draws the DC-1 error cooldown (spec/05: "reroute; cooldown
+    // P-WORKER-ERROR-COOLDOWN") — but the cooldown must decay, never latch. The
+    // pool keeps serving through it via the other worker, and once the harness's
+    // 1s penalty window passes, the rejecting worker itself serves fresh queries
+    // again. Its selection after decay is deterministic: Best-group workers rank
+    // by measured throughput with "no data yet" ahead of any measurement, and
+    // the rejector — whose only interaction was the rejection — is the one
+    // worker without a throughput sample.
     fx.worker_faults.clear();
     let rejecting = rejecting_worker(fx)?;
     let served_before = fresh_serves(&fx.worker_ledgers[rejecting]);
@@ -167,7 +176,7 @@ async fn run_retry(fx: &mut Fixture) -> anyhow::Result<()> {
     .await?;
     ensure!(
         after.status == 200,
-        "the pool must serve right after the rejection, got {} — {}",
+        "the pool must serve right through the rejector's cooldown, got {} — {}",
         after.status,
         String::from_utf8_lossy(&after.body),
     );
@@ -175,27 +184,39 @@ async fn run_retry(fx: &mut Fixture) -> anyhow::Result<()> {
         after.body == baseline.body,
         "follow-up response differs from the unfaulted baseline"
     );
-    // A pool-level 200 alone cannot tell a healthy pool from one that quietly
-    // benched the rejecting worker — the other worker could have served it. The
-    // worker that answered `BadTimestamp` must itself serve the follow-up. That
-    // routing is deterministic, not luck: the pool ranks Best-group workers by
-    // measured throughput with "no data yet" ahead of any measurement, and the
-    // rejecting worker — whose only interaction was the rejection — is the one
-    // worker without a throughput sample, so a healthy pool picks it first. A
-    // cooled-down worker would instead sit in the Unavailable group and the
-    // request would route around it.
-    ensure!(
-        fresh_serves(&fx.worker_ledgers[rejecting]) > served_before,
-        "the rejecting worker was not selected for the follow-up request — it was \
-         cooled down for correctly rejecting a stale query; its ledger: {:?}",
-        fx.worker_ledgers[rejecting].entries(),
-    );
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let mut probes = 0usize;
+    while fresh_serves(&fx.worker_ledgers[rejecting]) == served_before {
+        ensure!(
+            std::time::Instant::now() < deadline,
+            "the rejecting worker never served again after {probes} probes — its \
+             error cooldown latched instead of decaying; ledger: {:?}",
+            fx.worker_ledgers[rejecting].entries(),
+        );
+        probes += 1;
+        let probe = driver::stream(
+            &http,
+            &base,
+            "toy",
+            "finalized-stream",
+            &query(FROM, TO),
+            &format!("stale-recovery-{probes}"),
+        )
+        .await?;
+        ensure!(
+            probe.status == 200,
+            "recovery probe {probes} failed with {} — {}",
+            probe.status,
+            String::from_utf8_lossy(&probe.body),
+        );
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
 
     Ok(())
 }
 
-/// Index of the (single) worker whose ledger recorded the `BadTimestamp`
-/// rejection.
+/// Index of the (single) worker whose ledger recorded the injected
+/// `StaleEnvelope` rejection.
 fn rejecting_worker(fx: &Fixture) -> anyhow::Result<usize> {
     let hits: Vec<usize> = fx
         .worker_ledgers
@@ -204,13 +225,13 @@ fn rejecting_worker(fx: &Fixture) -> anyhow::Result<usize> {
         .filter(|(_, l)| {
             l.entries()
                 .iter()
-                .any(|e| e.starts_with("query ") && e.contains("fault=BadTimestamp"))
+                .any(|e| e.starts_with("query ") && e.contains("fault=StaleEnvelope"))
         })
         .map(|(i, _)| i)
         .collect();
     anyhow::ensure!(
         hits.len() == 1,
-        "exactly one worker must have recorded the BadTimestamp rejection, found {}",
+        "exactly one worker must have recorded the StaleEnvelope rejection, found {}",
         hits.len()
     );
     Ok(hits[0])

--- a/harness/tests/ct_stale_timestamp.rs
+++ b/harness/tests/ct_stale_timestamp.rs
@@ -302,9 +302,10 @@ async fn run_congestion(fx: &mut Fixture) -> anyhow::Result<()> {
     // fix, still yields a fresh signature at send.
     let stall = Duration::from_secs(66);
 
-    // Stream A holds a worker's response for `stall`, occupying whatever
-    // scheduler slot it lands on. It queries chunk 1 (blocks 0..=39), off B's
-    // range.
+    // Stream A's first attempt gets its response withheld for `stall`, parking
+    // the portal in the (permit-free) first-byte wait — per the contract under
+    // test it holds NO scheduler slot while it waits. It queries chunk 1
+    // (blocks 0..=39), off B's range.
     fx.worker_faults.queue(WorkerFault::Stall(stall), 1);
     let base_a = base.clone();
     let http_a = http.clone();
@@ -375,12 +376,26 @@ async fn run_congestion(fx: &mut Fixture) -> anyhow::Result<()> {
         b.status,
         String::from_utf8_lossy(&b.body),
     );
+    // Wire-level freshness evidence from the real path: the stub logs the
+    // admission lag of every query it receives, so B's served entry proves the
+    // transmitted timestamp was stamped moments before the send — not at some
+    // earlier enqueue time.
+    let b_entry = fx
+        .worker_ledgers
+        .iter()
+        .flat_map(|l| l.entries())
+        .find(|e| e.contains("range=40-79") && e.contains("fault=none"))
+        .context("no worker ledger shows B's query being served")?;
+    let b_lag_ms: u64 = b_entry
+        .split("lag_ms=")
+        .nth(1)
+        .and_then(|s| s.split_whitespace().next())
+        .and_then(|s| s.parse().ok())
+        .context("B's ledger entry carries no parsable lag_ms")?;
     ensure!(
-        fx.worker_ledgers.iter().any(|l| l
-            .entries()
-            .iter()
-            .any(|e| e.contains("range=40-79") && e.contains("fault=none"))),
-        "no worker ledger shows B's query being served"
+        b_lag_ms < 5_000,
+        "B's query arrived at the worker with a {b_lag_ms}ms-old signature — \
+         the wire timestamp was not stamped at send time: {b_entry}"
     );
     // The boundary: a stall does not hold the single slot (see the doc
     // comment), so B's acquire is granted immediately and it serves promptly.

--- a/harness/tests/ct_stale_timestamp.rs
+++ b/harness/tests/ct_stale_timestamp.rs
@@ -271,25 +271,25 @@ fn fresh_serves(ledger: &harness::stubs::Ledger) -> usize {
 ///    and the worker actor answers atomically via a `ResponseChannel` — there
 ///    is no "first byte then stall", so body reads are one fast pass on
 ///    loopback.
-/// 3. **The tiny pool fails closed first.** With `max_queries_per_worker: 1`, a
-///    stalled worker's lease exhausts the two-worker pool, so a concurrent
-///    request fails at worker selection with a retriable `no_workers` (503)
-///    long before any congestion permit is involved.
-/// 4. **The stall is bypassed anyway.** The default `retries: 1` plus the 1s
+/// 3. **The stall is bypassed anyway.** The default `retries: 1` plus the 1s
 ///    request-timeout floor fire a speculative retry that gets a fresh answer.
 ///
 /// So this test pins the boundary: under a pinned single-slot window and a
-/// >60s stall, a second request resolves promptly and the stale-timestamp 400
-/// never appears. If a change to the permit lifetimes ever lets a stall hold
-/// the slot, the latency guard flips — the cue to re-examine the sign-after-
-/// acquire ordering end to end.
+/// >60s stall, a second request must still *reach a worker through the
+/// scheduler* and serve promptly. Four workers, because with
+/// `max_queries_per_worker: 1` and `retries: 1` stream A pre-leases two — on a
+/// two-worker pool B would die at worker selection with `no_workers` before
+/// ever calling `acquire`, and the latency guard would pass vacuously. If a
+/// change to the permit lifetimes ever lets a stall hold the slot, B's acquire
+/// blocks for the stall and the guard flips — the cue to re-examine the
+/// sign-after-acquire ordering end to end.
 #[tokio::test(flavor = "multi_thread")]
 async fn ct_stale_timestamp_congestion_queue_boundary() -> anyhow::Result<()> {
     // Single-slot window; transport + read timeouts long enough that, if a stall
     // *did* hold the slot, it would hold it well past 60s rather than being torn
     // down early.
     let tuning = Tuning::single_slot_congestion(120, 120);
-    let mut fx = Fixture::start_tuned(ToyWorld::standard(), 2, tuning).await?;
+    let mut fx = Fixture::start_tuned(ToyWorld::standard(), 4, tuning).await?;
     let result = run_congestion(&mut fx).await;
     fx.finish(result)
 }
@@ -366,19 +366,32 @@ async fn run_congestion(fx: &mut Fixture) -> anyhow::Result<()> {
         stall.as_secs(),
     );
 
-    // The boundary: a stall does not hold the single slot (see the doc
-    // comment), so B resolves promptly — as a fast availability failure or a
-    // served response.
+    // B must have gone through the whole path — sign, acquire, send, serve —
+    // not died early at worker selection: a `no_workers` here would pass the
+    // latency guard without ever touching the scheduler, proving nothing.
     ensure!(
-        b_latency < Duration::from_secs(30),
-        "B resolved in {b_latency:?}; a stall is not expected to hold the congestion slot. \
-         If this now exceeds 60s the permit lifetimes changed — re-examine the \
-         sign-after-acquire ordering (status was {}, body {})",
+        b.status == 200,
+        "B must reach a worker through the scheduler and serve, got {} — {}",
         b.status,
         String::from_utf8_lossy(&b.body),
     );
+    ensure!(
+        fx.worker_ledgers.iter().any(|l| l
+            .entries()
+            .iter()
+            .any(|e| e.contains("range=40-79") && e.contains("fault=none"))),
+        "no worker ledger shows B's query being served"
+    );
+    // The boundary: a stall does not hold the single slot (see the doc
+    // comment), so B's acquire is granted immediately and it serves promptly.
+    ensure!(
+        b_latency < Duration::from_secs(30),
+        "B took {b_latency:?}; a stall is not expected to hold the congestion slot. \
+         If this approaches the stall duration the permit lifetimes changed — \
+         re-examine the sign-after-acquire ordering",
+    );
     // And in no case may the anti-replay rejection surface as the pre-fix
-    // terminal 400 — retriable classification plus sign-after-acquire both
+    // terminal 400 — the clock_skew reroute plus sign-after-acquire both
     // stand in the way.
     ensure!(
         !is_stale_timestamp_400(&b),

--- a/harness/tests/ct_stale_timestamp.rs
+++ b/harness/tests/ct_stale_timestamp.rs
@@ -1,0 +1,368 @@
+//! Stale-signed-timestamp rejection — the class for the 2026 production
+//! incident where a portal returned hard, non-retriable `400`s for specific
+//! chunk ranges, and for the fix that removed it.
+//!
+//! ## The defect (reproduced first, then fixed on this branch)
+//!
+//! `prepare_query` (src/network/client.rs) stamps `timestamp_ms = now` and
+//! signs the worker query; a worker validates that signed timestamp at
+//! admission against `MAX_TIME_LAG = 60s` (worker-rs `validate_query`) and
+//! answers `BadRequest("timestamp out of allowed range")` when it is exceeded —
+//! a rejection that can carry a `retry_after` hint. Two things compounded:
+//!
+//! 1. The query was signed *before* `send_to_transport` awaited its
+//!    congestion-scheduler permit, so under load the signature aged in the
+//!    portal's own queue.
+//! 2. The verdict table (`Verdict::of`) mapped *any* worker `BadRequest` — the
+//!    anti-replay rejection included — to a non-retriable client `400`
+//!    (`invalid_request_error` / `malformed_request`), no reroute, no failover.
+//!
+//! ## The fix these tests pin
+//!
+//! - The stale-timestamp rejection is classified retriable: the portal
+//!   reroutes with a freshly signed attempt and the client sees a `200`
+//!   ([`ct_stale_timestamp_is_retried`]). The worker that correctly rejected
+//!   the stale query is not penalized.
+//! - The send permit is acquired *before* the query is stamped and signed
+//!   (`query_worker`), so queue time can no longer age a signature
+//!   ([`ct_stale_timestamp_congestion_queue_boundary`] documents the permit
+//!   lifetimes that make the >60s queue itself unreachable in this harness).
+
+use std::time::{Duration, Instant};
+
+use anyhow::{ensure, Context};
+use harness::driver::{self, Decoded};
+use harness::fixture::Fixture;
+use harness::portal::Tuning;
+use harness::stubs::worker::WorkerFault;
+use harness::ToyWorld;
+use serde_json::json;
+
+/// Chunk 2 of the toy world is blocks 40..=79 — a single-chunk range, so the
+/// per-attempt worker queries in the ledgers are unambiguous.
+const FROM: u64 = 40;
+const TO: u64 = 79;
+
+fn query(from: u64, to: u64) -> serde_json::Value {
+    json!({
+        "type": "evm",
+        "fromBlock": from,
+        "toBlock": to,
+        "includeAllBlocks": true,
+        "fields": { "block": { "number": true, "hash": true } },
+    })
+}
+
+/// The pre-fix production envelope: a terminal 400 carrying the worker's
+/// anti-replay reason. After the fix this must never reach a client.
+fn is_stale_timestamp_400(d: &Decoded) -> bool {
+    if d.status != 400 {
+        return false;
+    }
+    let Ok(body) = serde_json::from_slice::<serde_json::Value>(&d.body) else {
+        return false;
+    };
+    body["error"]["code"] == "malformed_request"
+        && body["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("timestamp out of allowed range")
+}
+
+/// A worker's stale-timestamp rejection is transient: the portal must reroute
+/// with a freshly signed attempt and deliver a `200`, never the pre-fix
+/// terminal `400`.
+#[tokio::test(flavor = "multi_thread")]
+async fn ct_stale_timestamp_is_retried() -> anyhow::Result<()> {
+    // Two workers, so the reroute has somewhere to go.
+    let mut fx = Fixture::start(ToyWorld::standard(), 2).await?;
+    let result = run_retry(&mut fx).await;
+    fx.finish(result)
+}
+
+async fn run_retry(fx: &mut Fixture) -> anyhow::Result<()> {
+    fx.wait_ready(Duration::from_secs(60)).await?;
+    let (base, http) = (fx.base.clone(), fx.http.clone());
+
+    // Baseline: the range is servable, so any later deviation is attributable
+    // to the injected rejection and not to the world.
+    let baseline = driver::stream(
+        &http,
+        &base,
+        "toy",
+        "finalized-stream",
+        &query(FROM, TO),
+        "stale-baseline",
+    )
+    .await?;
+    ensure!(
+        baseline.status == 200,
+        "baseline must serve, got {} — {}",
+        baseline.status,
+        String::from_utf8_lossy(&baseline.body),
+    );
+
+    // The genuine wire rejection: whichever worker the portal picks first
+    // answers `BadRequest("timestamp out of allowed range")`, exactly as a real
+    // worker does when a signed timestamp is stale at admission.
+    fx.worker_faults.queue(WorkerFault::BadTimestamp, 1);
+    let before = fx.queries_answered();
+    let d = driver::stream(
+        &http,
+        &base,
+        "toy",
+        "finalized-stream",
+        &query(FROM, TO),
+        "stale-retried",
+    )
+    .await?;
+
+    eprintln!(
+        "[ct_stale_timestamp] response after one stale rejection: status={} body-bytes={}",
+        d.status,
+        d.body.len(),
+    );
+
+    // The fixed behavior: the rejection is masked by a reroute, the client
+    // gets the data.
+    ensure!(
+        !is_stale_timestamp_400(&d),
+        "the worker's anti-replay rejection reached the client as the pre-fix terminal 400: {}",
+        String::from_utf8_lossy(&d.body),
+    );
+    ensure!(
+        d.status == 200,
+        "one stale rejection must be masked by a retry, got {} — {}",
+        d.status,
+        String::from_utf8_lossy(&d.body),
+    );
+    ensure!(
+        d.body == baseline.body,
+        "retried response differs from the unfaulted baseline"
+    );
+
+    // The retry is real: the rejected attempt plus at least one fresh attempt
+    // appear in the worker ledgers.
+    let sent = fx.queries_answered() - before;
+    ensure!(
+        sent >= 2,
+        "a rejected attempt must be rerouted; only {sent} worker query was answered"
+    );
+
+    // The rejecting worker was never the problem, so the pool stays healthy:
+    // the very next request serves without cooldown. Issued immediately — the
+    // harness config decays worker penalties after 1s, so a wrongly cooled-down
+    // worker would still be inside its penalty window here.
+    fx.worker_faults.clear();
+    let rejecting = rejecting_worker(fx)?;
+    let served_before = fresh_serves(&fx.worker_ledgers[rejecting]);
+    let after = driver::stream(
+        &http,
+        &base,
+        "toy",
+        "finalized-stream",
+        &query(FROM, TO),
+        "stale-after",
+    )
+    .await?;
+    ensure!(
+        after.status == 200,
+        "the pool must serve right after the rejection, got {} — {}",
+        after.status,
+        String::from_utf8_lossy(&after.body),
+    );
+    ensure!(
+        after.body == baseline.body,
+        "follow-up response differs from the unfaulted baseline"
+    );
+    // A pool-level 200 alone cannot tell a healthy pool from one that quietly
+    // benched the rejecting worker — the other worker could have served it. The
+    // worker that answered `BadTimestamp` must itself serve the follow-up. That
+    // routing is deterministic, not luck: the pool ranks Best-group workers by
+    // measured throughput with "no data yet" ahead of any measurement, and the
+    // rejecting worker — whose only interaction was the rejection — is the one
+    // worker without a throughput sample, so a healthy pool picks it first. A
+    // cooled-down worker would instead sit in the Unavailable group and the
+    // request would route around it.
+    ensure!(
+        fresh_serves(&fx.worker_ledgers[rejecting]) > served_before,
+        "the rejecting worker was not selected for the follow-up request — it was \
+         cooled down for correctly rejecting a stale query; its ledger: {:?}",
+        fx.worker_ledgers[rejecting].entries(),
+    );
+
+    Ok(())
+}
+
+/// Index of the (single) worker whose ledger recorded the `BadTimestamp`
+/// rejection.
+fn rejecting_worker(fx: &Fixture) -> anyhow::Result<usize> {
+    let hits: Vec<usize> = fx
+        .worker_ledgers
+        .iter()
+        .enumerate()
+        .filter(|(_, l)| {
+            l.entries()
+                .iter()
+                .any(|e| e.starts_with("query ") && e.contains("fault=BadTimestamp"))
+        })
+        .map(|(i, _)| i)
+        .collect();
+    anyhow::ensure!(
+        hits.len() == 1,
+        "exactly one worker must have recorded the BadTimestamp rejection, found {}",
+        hits.len()
+    );
+    Ok(hits[0])
+}
+
+/// Queries this worker answered normally: no scripted fault, and fresh enough
+/// to pass the admission check (the stub logs `lag_ms` per query).
+fn fresh_serves(ledger: &harness::stubs::Ledger) -> usize {
+    ledger
+        .entries()
+        .iter()
+        .filter(|e| e.starts_with("query ") && e.contains("fault=none"))
+        .count()
+}
+
+/// The timing side of the incident, documented at its honest boundary.
+///
+/// In production the >60s delay arose between signing a query and the worker
+/// admitting it, while the query waited for a congestion-scheduler slot. The
+/// fix moves the permit acquisition *ahead* of `prepare_query` (`query_worker`,
+/// client.rs), so however long `acquire` queues, the timestamp is stamped and
+/// signed only once a slot is granted — queue time can no longer age the
+/// signature. The permit still covers the transport send, exactly as before.
+///
+/// ## Why the >60s queue itself is not inducible in this harness
+///
+/// Reproducing the wait needs the single congestion slot held continuously for
+/// >60s while another query waits on it. The permit lifetimes make that
+/// unreachable with an atomic-response stub:
+///
+/// 1. **A stalled worker holds no slot.** The send permit is released once the
+///    query bytes are written; `receive_first_byte` is *intentionally not*
+///    permit-gated (an explicit comment in client.rs), so a worker that
+///    withholds bytes parks there while the window stays free.
+/// 2. **The download permit needs bytes in flight.** The only long-lived permit
+///    is held across an *in-progress* body read (`read_response_with_permits`),
+///    and the worker actor answers atomically via a `ResponseChannel` — there
+///    is no "first byte then stall", so body reads are one fast pass on
+///    loopback.
+/// 3. **The tiny pool fails closed first.** With `max_queries_per_worker: 1`, a
+///    stalled worker's lease exhausts the two-worker pool, so a concurrent
+///    request fails at worker selection with a retriable `no_workers` (503)
+///    long before any congestion permit is involved.
+/// 4. **The stall is bypassed anyway.** The default `retries: 1` plus the 1s
+///    request-timeout floor fire a speculative retry that gets a fresh answer.
+///
+/// So this test pins the boundary: under a pinned single-slot window and a
+/// >60s stall, a second request resolves promptly and the stale-timestamp 400
+/// never appears. If a change to the permit lifetimes ever lets a stall hold
+/// the slot, the latency guard flips — the cue to re-examine the sign-after-
+/// acquire ordering end to end.
+#[tokio::test(flavor = "multi_thread")]
+async fn ct_stale_timestamp_congestion_queue_boundary() -> anyhow::Result<()> {
+    // Single-slot window; transport + read timeouts long enough that, if a stall
+    // *did* hold the slot, it would hold it well past 60s rather than being torn
+    // down early.
+    let tuning = Tuning::single_slot_congestion(120, 120);
+    let mut fx = Fixture::start_tuned(ToyWorld::standard(), 2, tuning).await?;
+    let result = run_congestion(&mut fx).await;
+    fx.finish(result)
+}
+
+async fn run_congestion(fx: &mut Fixture) -> anyhow::Result<()> {
+    fx.wait_ready(Duration::from_secs(60)).await?;
+    let (base, http) = (fx.base.clone(), fx.http.clone());
+    // Longer than the 60s freshness bound: were the slot actually held for the
+    // stall, B would be queued past 60s before being stamped — which, after the
+    // fix, still yields a fresh signature at send.
+    let stall = Duration::from_secs(66);
+
+    // Stream A holds a worker's response for `stall`, occupying whatever
+    // scheduler slot it lands on. It queries chunk 1 (blocks 0..=39), off B's
+    // range.
+    fx.worker_faults.queue(WorkerFault::Stall(stall), 1);
+    let base_a = base.clone();
+    let http_a = http.clone();
+    let a = tokio::spawn(async move {
+        driver::stream(
+            &http_a,
+            &base_a,
+            "toy",
+            "finalized-stream",
+            &query(0, 39),
+            "congestion-A",
+        )
+        .await
+    });
+
+    // Issue B only once a worker ledger shows A consumed the Stall fault — a
+    // fixed sleep would race on a loaded runner, letting B dequeue the stall
+    // itself and quietly void the scenario.
+    tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            let consumed = fx
+                .worker_ledgers
+                .iter()
+                .any(|l| l.entries().iter().any(|e| e.contains("fault=Stall(")));
+            if consumed {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .map_err(|_| anyhow::anyhow!("stream A never consumed the Stall fault within 15s"))?;
+    // A brief settle so A's attempt is parked in its first-byte wait.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    let b_started_at = Instant::now();
+    let b = driver::stream(
+        &http,
+        &base,
+        "toy",
+        "finalized-stream",
+        &query(FROM, TO),
+        "congestion-B",
+    )
+    .await?;
+    let b_latency = b_started_at.elapsed();
+
+    eprintln!(
+        "[ct_stale_timestamp/congestion] B: status={} latency={:?} retry-after={:?} body={}",
+        b.status,
+        b_latency,
+        b.header("retry-after"),
+        String::from_utf8_lossy(&b.body),
+    );
+    let a_result = a.await.context("stream A join")??;
+    eprintln!(
+        "[ct_stale_timestamp/congestion] A: status={} body-bytes={} (stall was {}s)",
+        a_result.status,
+        a_result.body.len(),
+        stall.as_secs(),
+    );
+
+    // The boundary: a stall does not hold the single slot (see the doc
+    // comment), so B resolves promptly — as a fast availability failure or a
+    // served response.
+    ensure!(
+        b_latency < Duration::from_secs(30),
+        "B resolved in {b_latency:?}; a stall is not expected to hold the congestion slot. \
+         If this now exceeds 60s the permit lifetimes changed — re-examine the \
+         sign-after-acquire ordering (status was {}, body {})",
+        b.status,
+        String::from_utf8_lossy(&b.body),
+    );
+    // And in no case may the anti-replay rejection surface as the pre-fix
+    // terminal 400 — retriable classification plus sign-after-acquire both
+    // stand in the way.
+    ensure!(
+        !is_stale_timestamp_400(&b),
+        "B surfaced the stale-timestamp 400 the fix removes: {}",
+        String::from_utf8_lossy(&b.body),
+    );
+    Ok(())
+}

--- a/spec/05-dependencies.md
+++ b/spec/05-dependencies.md
@@ -13,7 +13,9 @@ observing it on a Portal without one is the same violation (REQ-56).
 ## DC-1 — Archival workers
 
 *Role.* Serve chunk queries; the archival path of OP-1/OP-5.
-*Call contract.* Signed query per attempt; request deadline P-TRANSPORT-TIMEOUT;
+*Call contract.* Signed query per attempt, stamped and signed only after the attempt's
+send permit (DEF-13) is granted — scheduler queue time must never age the signature
+against the worker's admission window; request deadline P-TRANSPORT-TIMEOUT;
 first-byte wait bounded by the same; body read in bounded reads of at most
 P-CONGESTION-READ-TIMEOUT each under a congestion permit (DEF-13); response size capped
 at P-RESULT-MAX-SIZE; at most P-MAX-QUERIES-PER-WORKER concurrent queries per worker.

--- a/spec/13-conformance.md
+++ b/spec/13-conformance.md
@@ -31,8 +31,19 @@ the fault rows of DC-8's error table as injectors. `ct10_authorization` drives f
 portals — enforcing, shadow, no `auth:` block, one whose exchange budget is small enough
 to saturate, and one signing with a dedicated key — because the properties differ by
 configuration rather than by request.
-Coverage outside those three classes is still inline unit tests.
-All three suites run on every pull request: the harness is a separate crate, so it needs a
+**The stale-timestamp class exists**: `ct_stale_timestamp` pins the DC-1 stale-envelope
+row (05 §DC-1, 09 §worker faults) end to end. The worker stub validates admission-time
+freshness unconditionally (mirroring the real worker's 60s anti-replay window) and gained
+a `Stall` injector plus configurable portal tuning (congestion window, transport
+timeout); `ct_stale_timestamp_is_retried` asserts one genuine wire rejection is masked by
+a reroute — client 200, rejected-plus-fresh attempts in the ledgers, and the rejecting
+worker's error cooldown decaying rather than latching — and
+`ct_stale_timestamp_congestion_queue_boundary` pins the permit lifetimes under a pinned
+single-slot congestion window, documenting why a >60s scheduler queue is not inducible
+with atomic-response stubs. The sign-after-permit ordering itself is pinned by unit tests
+on the extracted seam (`acquire_permit_then_timestamp` in the network client).
+Coverage outside those four classes is still inline unit tests.
+All four suites run on every pull request: the harness is a separate crate, so it needs a
 build of the portal and a job of its own — a status this document cites has to be one
 something re-checks.
 

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -26,7 +26,7 @@ use tracing::{debug_span, instrument, Instrument};
 use super::contracts_state::{ContractsState, Status};
 use super::priorities::NoWorker;
 use super::{ChunkNotFound, NetworkState, WorkerLease};
-use crate::controller::download_scheduler::{DownloadScheduler, Outcome, Priority};
+use crate::controller::download_scheduler::{DownloadPermit, DownloadScheduler, Outcome, Priority};
 use crate::datasets::{DatasetConfig, Datasets};
 use crate::types::api_types::{DatasetState, WorkerDebugInfo};
 use crate::types::{BlockNumber, BlockRange, ChunkId, Compression, DataChunk};
@@ -647,6 +647,17 @@ impl NetworkClient {
         tracing::trace!("Sending query {query_id} to {worker}");
 
         let _guard = QueryGuard::new();
+        // The send permit is acquired *before* the query is stamped and signed: under
+        // congestion `acquire` queues arbitrarily long, and a `timestamp_ms` stamped
+        // ahead of that wait ages against the worker's admission tolerance (60s) while
+        // the query sits in the portal's own queue — surfacing as the stale-envelope
+        // verdict for a query that was fresh when it was built. Signing under the
+        // permit costs microseconds of extra hold time and keeps the timestamp fresh
+        // at send. `prepare_query` consumes the timestamp the helper produced after
+        // the grant, so the ordering is pinned by
+        // `timestamp_is_stamped_after_permit_grant`.
+        let (send_permit, timestamp_ms) =
+            acquire_permit_then_timestamp(self.read_scheduler.as_ref(), priority).await;
         let query = self
             .prepare_query(
                 worker,
@@ -656,10 +667,11 @@ impl NetworkClient {
                 &block_range,
                 query,
                 compression,
+                timestamp_ms,
             )
             .await;
         let result = self
-            .execute_query(worker, query, &block_range, priority)
+            .execute_query(worker, query, &block_range, priority, send_permit)
             .await;
         result
     }
@@ -670,8 +682,9 @@ impl NetworkClient {
         query: Query,
         block_range: &BlockRange,
         priority: Option<u32>,
+        send_permit: Option<DownloadPermit>,
     ) -> QueryResult {
-        let mut stream = self.send_to_transport(worker, query, priority).await?;
+        let mut stream = self.send_to_transport(worker, query, send_permit).await?;
         let network_start = Instant::now();
         let mut buf = self.receive_first_byte(worker, &mut stream).await?;
         let ttfb = network_start.elapsed();
@@ -683,6 +696,12 @@ impl NetworkClient {
             .await
     }
 
+    /// Builds and signs the wire query. `timestamp_ms` is produced by
+    /// `acquire_permit_then_timestamp` *after* the send permit is granted — taking it
+    /// as a parameter rather than reading the clock here is what makes the
+    /// sign-after-permit ordering a property of one function instead of a convention
+    /// spread over two.
+    #[allow(clippy::too_many_arguments)]
     async fn prepare_query(
         &self,
         worker: PeerId,
@@ -692,6 +711,7 @@ impl NetworkClient {
         block_range: &BlockRange,
         query: String,
         compression: Compression,
+        timestamp_ms: u64,
     ) -> Query {
         let compression = match compression {
             Compression::Gzip => sqd_messages::Compression::Gzip,
@@ -707,7 +727,7 @@ impl NetworkClient {
                 end: *block_range.end(),
             }),
             chunk_id: chunk_id.chunk.to_string(),
-            timestamp_ms: timestamp_now_ms(),
+            timestamp_ms,
             signature: Default::default(),
             compression,
         };
@@ -725,20 +745,19 @@ impl NetworkClient {
         .unwrap()
     }
 
+    /// Sends the query over the transport. `send_permit` is the congestion slot the
+    /// caller acquired *before* stamping the query's timestamp (see `query_worker`);
+    /// it still covers the send itself and is released when this returns.
     async fn send_to_transport(
         &self,
         worker: PeerId,
         query: Query,
-        priority: Option<u32>,
+        send_permit: Option<DownloadPermit>,
     ) -> Result<ResponseStream, QueryError> {
         metrics::QUERIES_SENT
             .get_or_create(&vec![("worker".to_string(), worker.to_string())])
             .inc();
 
-        let send_permit = match (&self.read_scheduler, priority) {
-            (Some(sched), Some(prio)) => Some(sched.acquire(prio).await),
-            _ => None,
-        };
         match self
             .transport_handle
             .send_query_request(worker, query)
@@ -1062,6 +1081,22 @@ impl NetworkClient {
     }
 }
 
+/// Awaits the congestion send permit (when scheduling applies) and only then reads
+/// the clock for the query's `timestamp_ms`. Extracted so the ordering — permit
+/// first, timestamp second — is a unit-testable property rather than a convention:
+/// a timestamp taken before the wait ages against the worker's 60s admission bound
+/// for as long as the scheduler queues the attempt.
+async fn acquire_permit_then_timestamp(
+    scheduler: Option<&Arc<DownloadScheduler>>,
+    priority: Option<u32>,
+) -> (Option<DownloadPermit>, u64) {
+    let permit = match (scheduler, priority) {
+        (Some(sched), Some(prio)) => Some(sched.acquire(prio).await),
+        _ => None,
+    };
+    (permit, timestamp_now_ms())
+}
+
 fn is_congestion_failure(failure: &QueryFailure) -> bool {
     matches!(
         failure,
@@ -1242,5 +1277,60 @@ mod tests {
         assert!(matches!(verdict.error, QueryError::BadRequest(_)));
         assert!(matches!(verdict.health, Health::Ok));
         assert_eq!(verdict.label, "bad_request");
+    }
+
+    /// The sign-after-permit regression guard: with the single scheduler slot held,
+    /// a queued attempt's `timestamp_ms` must be read only once the permit is
+    /// granted — never at the moment the attempt started waiting. Under the old
+    /// sign-before-acquire ordering the stamped value would predate the release;
+    /// here it must not. `query_worker` feeds this helper's timestamp straight into
+    /// `prepare_query`, so pinning the helper pins the wire value.
+    #[tokio::test]
+    async fn timestamp_is_stamped_after_permit_grant() {
+        let config = crate::config::CongestionConfig {
+            min_window: 1,
+            max_window: 1,
+            ..Default::default()
+        };
+        let scheduler = Arc::new(DownloadScheduler::new(config));
+
+        // Occupy the only slot, then start an attempt that has to queue.
+        let blocker = scheduler.acquire(0).await;
+        let waiter = tokio::spawn({
+            let scheduler = Arc::clone(&scheduler);
+            async move { acquire_permit_then_timestamp(Some(&scheduler), Some(1)).await }
+        });
+
+        // Let the attempt sit in the queue long enough that a stamp taken at
+        // enqueue time is measurably older than the release.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        let released_at = timestamp_now_ms();
+        drop(blocker);
+
+        let (permit, stamped) = waiter.await.expect("waiter task");
+        assert!(
+            permit.is_some(),
+            "scheduling applied, so a permit is granted"
+        );
+        assert!(
+            stamped >= released_at,
+            "timestamp {stamped} was stamped before the permit was released at \
+             {released_at} — the query would age in the scheduler queue"
+        );
+    }
+
+    /// With the scheduler disabled or no priority given, no permit exists and the
+    /// timestamp is simply the current clock — the unscheduled path is unchanged.
+    #[tokio::test]
+    async fn no_scheduler_means_no_permit_and_a_fresh_timestamp() {
+        let before = timestamp_now_ms();
+        let (permit, stamped) = acquire_permit_then_timestamp(None, Some(1)).await;
+        assert!(permit.is_none());
+        assert!(stamped >= before);
+
+        let config = crate::config::CongestionConfig::default();
+        let scheduler = Arc::new(DownloadScheduler::new(config));
+        let (permit, _) = acquire_permit_then_timestamp(Some(&scheduler), None).await;
+        assert!(permit.is_none(), "no priority, no permit — same as before");
     }
 }


### PR DESCRIPTION
## Problem

Workers enforce an anti-replay guard at query admission: the signed `timestamp_ms` must be within 60s (`MAX_TIME_LAG`) of the worker's clock, otherwise the query is rejected with `BadRequest("timestamp out of allowed range")`.

Master (38d661c, v0.13.2) already reclassifies that verdict: it reroutes on the error cooldown instead of surfacing a terminal client 400. That covers the *response* side. This PR covers the *cause* the incident actually had: the portal stamped and signed each query in `prepare_query` **before** `send_to_transport` awaited its congestion-scheduler permit. Under load, `acquire` queues a query arbitrarily long, so the portal's own queue aged signatures past the worker's admission window — manufacturing stale-envelope rejections for queries that were fresh when they were built. A production deployment under high-concurrency streaming load saw load-correlated rejection rates with exactly this envelope; throttling client concurrency eliminated them.

## Fix

**Sign after the permit, not before** (`src/network/client.rs`). `query_worker` acquires the congestion send permit first and threads it through `execute_query` into `send_to_transport` (which no longer acquires). The timestamp is read by a small extracted seam, `acquire_permit_then_timestamp`, only once the permit is granted, and `prepare_query` takes it as a parameter — the sign-after-permit ordering is the property of one function rather than a convention spread over two. The permit still covers the transport send exactly as before; behavior is unchanged when the scheduler is disabled or no priority is given; the download-permit path is untouched. spec/05's DC-1 call contract now states the ordering.

With this in place, a stale-envelope rejection can only mean genuine clock disagreement — which is precisely the case 38d661c's `clock_skew` reroute-with-cooldown row is built for.

## Tests

- Unit: `timestamp_is_stamped_after_permit_grant` holds the single scheduler slot, queues an attempt, and asserts the stamp postdates the permit release (fails under the old ordering); `no_scheduler_means_no_permit_and_a_fresh_timestamp` pins the unscheduled path.
- Harness (new conformance class, registered in spec/13):
  - The worker stub now applies the real admission-time freshness check unconditionally (mirroring worker-rs `validate_query`), checked before the fault queue is touched so a naturally stale query cannot swallow a scripted fault; it gained a `Stall` (deferred send) injector and a raised worker-side execution timeout so long stalls survive the transport.
  - `ct_stale_timestamp_is_retried` drives the genuine wire rejection end to end: client 200 identical to the unfaulted baseline, rejected-plus-fresh attempts visible in the ledgers, and the rejecting worker's error cooldown decaying rather than latching.
  - `ct_stale_timestamp_congestion_queue_boundary` pins the permit lifetimes under a pinned single-slot congestion window and documents why a >60s scheduler queue is not inducible with atomic-response stubs.
- Full sweep green: portal unit tests, harness ct1 / ct2 (both) / ct10 / this class; fmt and clippy clean.

## Notes

- This branch originally carried the verdict reclassification too; that half landed on master independently as 38d661c while this PR was in review, so the branch was rebased to contribute only the signing-order fix and the conformance class. Earlier review-round comments referring to a `stale_timestamp`/`Health::Ok` verdict arm describe the superseded version; the class now pins master's `clock_skew` cooldown semantics.
- Worker errors remain string-matched (GAP-25); when structured errors land, the match moves with the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ESmW6qzFXYky1WHi3WEsm
