### PR TITLE
fix(network): reroute a worker's stale-envelope verdict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7836,7 +7836,7 @@ dependencies = [
 
 [[package]]
 name = "sqd-portal"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqd-portal"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 default-run = "sqd-portal"
 

--- a/harness/src/stubs/worker.rs
+++ b/harness/src/stubs/worker.rs
@@ -45,6 +45,8 @@ pub enum WorkerFault {
     /// Answer "chunk not found" — the worker is still downloading it. Same
     /// DC-1 row as ServerError, but the portal treats it as retriable.
     NotFound(String),
+    /// Refuse for clock skew: a bad-request verdict that must still reroute.
+    StaleEnvelope,
     /// Refuse for capacity: the rate-limit verdict.
     TooManyRequests,
     /// Refuse for capacity: the overload verdict. One DC-1 row with the above.
@@ -181,6 +183,13 @@ fn answer(
         }
         Some(WorkerFault::NotFound(m)) => {
             return verdict_result(query, keypair, query_error::Err::NotFound(m.clone()))
+        }
+        Some(WorkerFault::StaleEnvelope) => {
+            return verdict_result(
+                query,
+                keypair,
+                query_error::Err::BadRequest("timestamp out of allowed range".to_owned()),
+            )
         }
         Some(WorkerFault::TooManyRequests) => {
             return verdict_result(query, keypair, query_error::Err::TooManyRequests(()))

--- a/harness/tests/ct2_worker_faults.rs
+++ b/harness/tests/ct2_worker_faults.rs
@@ -144,6 +144,7 @@ async fn run(fx: &mut Fixture) -> anyhow::Result<()> {
             "not-found",
             WorkerFault::NotFound("still downloading".into()),
         ),
+        ("stale-envelope", WorkerFault::StaleEnvelope),
         ("too-many-requests", WorkerFault::TooManyRequests),
         ("server-overloaded", WorkerFault::ServerOverloaded),
         ("server-error", WorkerFault::ServerError("scripted".into())),

--- a/spec/05-dependencies.md
+++ b/spec/05-dependencies.md
@@ -27,6 +27,7 @@ alternatives exist.
 | Worker fault | Own class / action |
 |---|---|
 | invalid-query verdict | BAD-REQUEST (terminal for the request) |
+| stale-envelope verdict (the worker's clock disagrees with ours beyond the protocol's freshness window) | reroute; cooldown P-WORKER-ERROR-COOLDOWN; exhausted ⇒ RETRIES-EXHAUSTED. Never BAD-REQUEST: the query is well-formed and the next worker may accept it unchanged |
 | result exceeds size cap | BAD-REQUEST advising a narrower query |
 | parent-hash mismatch verdict | CONFLICT (real-time mode only — finalized-mode queries carry no parent hash, REQ-3) |
 | server error / not found | reroute; cooldown P-WORKER-ERROR-COOLDOWN; exhausted ⇒ RETRIES-EXHAUSTED |

--- a/spec/09-failure-model.md
+++ b/spec/09-failure-model.md
@@ -40,6 +40,7 @@ requests only; the publisher ⇒ freshness only; chain RPC ⇒ status only (REQ-
 | Slow (past adaptive estimate) | mask — speculative parallel attempt (FV-2) |
 | Timeout | mask via reroute + cooldown P-WORKER-TIMEOUT-COOLDOWN; congestion signal |
 | Erroring | mask via reroute + cooldown P-WORKER-ERROR-COOLDOWN |
+| Clock skew (rejects the query envelope as stale) | mask via reroute + cooldown P-WORKER-ERROR-COOLDOWN; a skew on *our* side hits every candidate ⇒ fail-safe RETRIES-EXHAUSTED, never BAD-REQUEST |
 | Rate-limiting | mask via backoff honor; all-candidates-limited ⇒ fail-safe OVERLOADED |
 | Oversized response | fail-safe BAD-REQUEST (advise narrower query) |
 | Equivocating (bad signature / wrong-range data) | integrity: discard, reroute, count (REQ-43); never delivered; all attempts equivocating ⇒ fail-safe WORKER-FAILURE (pages); equivocation mixed with transient failures ⇒ fail-safe RETRIES-EXHAUSTED, the equivocation still counted and alarmed (DC-1) |

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -114,6 +114,9 @@ enum Health {
     Error,
 }
 
+/// Matched verbatim: the wire carries no code for this verdict (GAP-25).
+const STALE_ENVELOPE: &str = "timestamp out of allowed range";
+
 /// One DC-1 row: how a worker verdict is classified, counted, and charged. The three
 /// were chosen independently in each match arm — eight arms times three decisions — and
 /// they drifted: the two capacity refusals shared a row in the spec while disagreeing
@@ -135,6 +138,10 @@ impl Verdict {
             backs_off,
         };
         match err {
+            // Clock skew, not a bad query: another worker may accept the same bytes.
+            Err::BadRequest(s) if s == STALE_ENVELOPE => {
+                row(QueryError::Retriable(s), "clock_skew", Health::Error, false)
+            }
             Err::BadRequest(s) => row(
                 QueryError::BadRequest(format!("couldn't parse request: {s}")),
                 "bad_request",
@@ -1216,5 +1223,24 @@ mod tests {
     fn parse_base_block_mismatch_malformed_no_number() {
         let msg = "unexpected base block: expected 0xabc, but got #0xdef";
         assert!(parse_base_block_mismatch(msg).is_none());
+    }
+
+    #[test]
+    fn stale_envelope_reroutes() {
+        let verdict = Verdict::of(query_error::Err::BadRequest(STALE_ENVELOPE.to_owned()));
+        assert!(matches!(verdict.error, QueryError::Retriable(_)));
+        assert!(matches!(verdict.health, Health::Error));
+        assert_eq!(verdict.label, "clock_skew");
+        assert!(!verdict.backs_off);
+    }
+
+    #[test]
+    fn other_bad_requests_stay_terminal() {
+        let verdict = Verdict::of(query_error::Err::BadRequest(
+            "invalid query signature".to_owned(),
+        ));
+        assert!(matches!(verdict.error, QueryError::BadRequest(_)));
+        assert!(matches!(verdict.health, Health::Ok));
+        assert_eq!(verdict.label, "bad_request");
     }
 }


### PR DESCRIPTION
A worker rejects a query whose signed envelope falls outside the protocol's freshness window (`"timestamp out of allowed range"`). That verdict says the worker's clock and ours disagree — it says nothing about the query, which is well-formed and which the next worker may accept unchanged.

It shared a row with the invalid-query verdicts, so the outcome was:

- terminal `400 malformed_request` to the client, wrapped as `couldn't parse request: …`, for something the client cannot fix;
- no reroute, even with healthy candidates left;
- `Health::Ok`, so the skewed worker kept its place in the pool and kept failing requests.

Now it is `Retriable` + `Health::Error`: the attempt reroutes, the worker draws the error cooldown, and the metric label is `clock_skew` rather than `bad_request`, so a divergence is attributable per worker. When the skew is on the portal's side every candidate rejects and the request ends as retries-exhausted — a transient class the client can act on — instead of blaming the query.

Spec: adds the row to the DC-1 error mapping (`spec/05-dependencies.md`) and to the worker-fault table (`spec/09-failure-model.md`), which both stated that every bad-request verdict is terminal.

## Caveat

The verdict is matched by exact string, because the wire carries no code for it. This is the GAP-25 fragility with one more caller: a reworded worker message silently restores the old behavior. The fix is a stable verdict surface on the worker side; this change does not create the dependency, it joins it.

## Testing

- Unit: the stale-envelope verdict reroutes; every other bad-request verdict stays terminal.
- CT-2 (`ct2_worker_faults`): new `WorkerFault::StaleEnvelope` makes a stub worker answer with the real verdict; the response must be byte-identical to the unfaulted baseline.
- Verified the e2e case is load-bearing — with the match disabled, CT-2 fails and the log shows the old terminal path.
- Full suite green: 282 unit tests, CT-2, clippy clean of new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)