### PR TITLE
feat(network): Adopt columnar portal assignments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3871,7 +3871,7 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 [[package]]
 name = "libp2p"
 version = "0.56.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "bytes 1.11.1",
  "either",
@@ -3904,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.6.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -3914,7 +3914,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.15.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -3938,7 +3938,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.6.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -3948,7 +3948,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.43.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "either",
  "fnv",
@@ -3972,7 +3972,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.44.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -3987,7 +3987,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.50.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -4017,7 +4017,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.47.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -4037,8 +4037,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identity"
 version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3104e13b51e4711ff5738caa1fb54467c8604c2e94d607e27745bcf709068774"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -4056,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.49.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.11.1",
@@ -4083,7 +4082,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.48.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures 0.3.31",
  "hickory-proto",
@@ -4101,7 +4100,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.17.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures 0.3.31",
  "libp2p-core",
@@ -4118,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.47.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -4133,7 +4132,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.13.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -4154,7 +4153,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.29.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -4170,7 +4169,7 @@ dependencies = [
 [[package]]
 name = "libp2p-stream"
 version = "0.4.0-alpha"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures 0.3.31",
  "libp2p-core",
@@ -4183,7 +4182,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.47.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "either",
  "fnv",
@@ -4203,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -4213,7 +4212,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.44.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -4228,7 +4227,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.6.2"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures 0.3.31",
  "futures-rustls",
@@ -4246,7 +4245,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.5.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -4604,7 +4603,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "bytes 1.11.1",
  "futures 0.3.31",
@@ -6326,7 +6325,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.11.1",
@@ -7040,7 +7039,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures 0.3.31",
  "pin-project",
@@ -7735,7 +7734,7 @@ dependencies = [
 [[package]]
 name = "sqd-assignments"
 version = "0.3.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=4939971#49399718778160b4187715b075762aa9620c3008"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=d1ee014#d1ee0146a0a238ee87f10e20f3cc8905abf656e8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7765,7 +7764,7 @@ dependencies = [
 [[package]]
 name = "sqd-contract-client"
 version = "1.3.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=e9a3434#e9a34341035ac7745b71eb87dabc8501aa434376"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=d1ee014#d1ee0146a0a238ee87f10e20f3cc8905abf656e8"
 dependencies = [
  "async-trait",
  "clap",
@@ -7774,6 +7773,7 @@ dependencies = [
  "libp2p",
  "log",
  "num-rational",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -7784,10 +7784,11 @@ dependencies = [
 
 [[package]]
 name = "sqd-messages"
-version = "2.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=e9a3434#e9a34341035ac7745b71eb87dabc8501aa434376"
+version = "3.1.0"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=d1ee014#d1ee0146a0a238ee87f10e20f3cc8905abf656e8"
 dependencies = [
  "bytemuck",
+ "bytes 1.11.1",
  "flate2",
  "hex",
  "libp2p-identity",
@@ -7801,7 +7802,7 @@ dependencies = [
 [[package]]
 name = "sqd-network-transport"
 version = "3.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=e9a3434#e9a34341035ac7745b71eb87dabc8501aa434376"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=d1ee014#d1ee0146a0a238ee87f10e20f3cc8905abf656e8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7735,7 +7735,7 @@ dependencies = [
 [[package]]
 name = "sqd-assignments"
 version = "0.3.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=625de07#625de07388d90c29799fe3f73f7f65a2bcd64853"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=4939971#49399718778160b4187715b075762aa9620c3008"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7732,18 +7732,23 @@ dependencies = [
 
 [[package]]
 name = "sqd-assignments"
-version = "0.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=67f54cc#67f54ccec1e82a80ef95bd419af2fc20bb942129"
+version = "0.3.0"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=339a0d7#339a0d7ed961f2698d65215f37344c1f61024589"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "crypto_box",
+ "curve25519-dalek",
  "flatbuffers",
+ "hmac",
  "libp2p-identity",
  "ouroboros",
  "serde",
  "serde_json",
  "sha2",
+ "thiserror 2.0.17",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,6 +559,8 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio 1.48.0",
+ "zstd 0.13.3",
+ "zstd-safe 7.2.4",
 ]
 
 [[package]]
@@ -7733,7 +7735,7 @@ dependencies = [
 [[package]]
 name = "sqd-assignments"
 version = "0.3.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=339a0d7#339a0d7ed961f2698d65215f37344c1f61024589"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=625de07#625de07388d90c29799fe3f73f7f65a2bcd64853"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7749,6 +7751,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tracing",
  "url",
+ "zstd 0.13.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ uuid = { version = "1", features = ["v4", "fast-rng"] }
 reqwest-retry = "0.7"
 reqwest-middleware = "0.4"
 
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "625de07", features = ["reader"] }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "4939971", features = ["reader"] }
 sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "1.3.0" }
 sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "2.1.0", features = ["semver", "bitstring"] }
 sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "3.1.0", features = ["portal", "metrics"] }
@@ -92,7 +92,7 @@ tower = { version = "0.5", features = ["util"] }
 proptest_async = { version = "0.2.1", default-features = false, features = ["tokio"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "test-util"] }
 tempfile = "3"
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "625de07", features = ["builder", "reader"] }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "4939971", features = ["builder", "reader"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", features = ["profiling"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,12 +92,7 @@ tower = { version = "0.5", features = ["util"] }
 proptest_async = { version = "0.2.1", default-features = false, features = ["tokio"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "test-util"] }
 tempfile = "3"
-# Reading an assignment is all the portal does; building one is how a test states the shape it
-# reads -- a gap between chunks has no other way to exist here.
 sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "339a0d7", features = ["builder", "reader"] }
 
-# Keep this table to what is genuinely platform-specific -- jemalloc, which has no msvc build.
-# Anything appended below the header is silently gated too, which is how the sqd-* crates ended
-# up here and made an msvc build fail on missing crates rather than on missing jemalloc.
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", features = ["profiling"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,11 +82,14 @@ tower = { version = "0.5", features = ["util"] }
 proptest_async = { version = "0.2.1", default-features = false, features = ["tokio"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "test-util"] }
 tempfile = "3"
+# Reading an assignment is all the portal does; building one is how a test states the shape it
+# reads -- a gap between chunks has no other way to exist here.
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "339a0d7", features = ["builder", "reader"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", features = ["profiling"] }
 
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "67f54cc", features = ["reader"] }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "339a0d7", features = ["reader"] }
 sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "1.3.0" }
 sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "2.1.0", features = ["semver", "bitstring"] }
 sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "3.1.0", features = ["portal", "metrics"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ sql = ["dep:once_cell", "dep:substrait", "dep:sql_query_plan"]
 
 [dependencies]
 anyhow = "1"
-async-compression = { version = "0.4.20", features = ["tokio", "gzip"] }
+async-compression = { version = "0.4.20", features = ["tokio", "gzip", "zstd"] }
 async-stream = "0.3.5"
 atomic_enum = { version = "0.3.0", features = ["cas"] }
 axum = { version = "0.7", features = ["http2"] }
@@ -76,7 +76,7 @@ uuid = { version = "1", features = ["v4", "fast-rng"] }
 reqwest-retry = "0.7"
 reqwest-middleware = "0.4"
 
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "339a0d7", features = ["reader"] }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "625de07", features = ["reader"] }
 sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "1.3.0" }
 sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "2.1.0", features = ["semver", "bitstring"] }
 sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "3.1.0", features = ["portal", "metrics"] }
@@ -92,7 +92,7 @@ tower = { version = "0.5", features = ["util"] }
 proptest_async = { version = "0.2.1", default-features = false, features = ["tokio"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "test-util"] }
 tempfile = "3"
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "339a0d7", features = ["builder", "reader"] }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "625de07", features = ["builder", "reader"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", features = ["profiling"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,16 @@ uuid = { version = "1", features = ["v4", "fast-rng"] }
 reqwest-retry = "0.7"
 reqwest-middleware = "0.4"
 
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "339a0d7", features = ["reader"] }
+sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "1.3.0" }
+sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "2.1.0", features = ["semver", "bitstring"] }
+sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "3.1.0", features = ["portal", "metrics"] }
+
+sqd-primitives = { git = "https://github.com/subsquid/data.git", rev = "eaa9f86", features = ["serde"] }
+sqd-query = { git = "https://github.com/subsquid/data.git", rev = "eaa9f86" }
+
+sql_query_plan = { git = "https://github.com/subsquid/qplan.git", rev = "2e61b51", optional = true }
+
 [dev-dependencies]
 proptest = "1.4.0"
 tower = { version = "0.5", features = ["util"] }
@@ -86,15 +96,8 @@ tempfile = "3"
 # reads -- a gap between chunks has no other way to exist here.
 sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "339a0d7", features = ["builder", "reader"] }
 
+# Keep this table to what is genuinely platform-specific -- jemalloc, which has no msvc build.
+# Anything appended below the header is silently gated too, which is how the sqd-* crates ended
+# up here and made an msvc build fail on missing crates rather than on missing jemalloc.
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", features = ["profiling"] }
-
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "339a0d7", features = ["reader"] }
-sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "1.3.0" }
-sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "2.1.0", features = ["semver", "bitstring"] }
-sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "3.1.0", features = ["portal", "metrics"] }
-
-sqd-primitives = { git = "https://github.com/subsquid/data.git", rev = "eaa9f86", features = ["serde"] }
-sqd-query = { git = "https://github.com/subsquid/data.git", rev = "eaa9f86" }
-
-sql_query_plan = { git = "https://github.com/subsquid/qplan.git", rev = "2e61b51", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,10 +76,10 @@ uuid = { version = "1", features = ["v4", "fast-rng"] }
 reqwest-retry = "0.7"
 reqwest-middleware = "0.4"
 
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "4939971", features = ["reader"] }
-sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "1.3.0" }
-sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "2.1.0", features = ["semver", "bitstring"] }
-sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", version = "3.1.0", features = ["portal", "metrics"] }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "d1ee014", features = ["reader"] }
+sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "d1ee014", version = "1.3.0" }
+sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "d1ee014", version = "3.1.0", features = ["semver", "bitstring"] }
+sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "d1ee014", version = "3.1.0", features = ["portal", "metrics"] }
 
 sqd-primitives = { git = "https://github.com/subsquid/data.git", rev = "eaa9f86", features = ["serde"] }
 sqd-query = { git = "https://github.com/subsquid/data.git", rev = "eaa9f86" }
@@ -92,7 +92,10 @@ tower = { version = "0.5", features = ["util"] }
 proptest_async = { version = "0.2.1", default-features = false, features = ["tokio"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "test-util"] }
 tempfile = "3"
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "4939971", features = ["builder", "reader"] }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "d1ee014", features = ["builder", "reader"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", features = ["profiling"] }
+
+[patch.crates-io]
+libp2p-identity = { git = "https://github.com/kalabukdima/rust-libp2p.git", rev = "fac3b0c9" }

--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -2655,7 +2655,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "libp2p"
 version = "0.56.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "bytes",
  "either",
@@ -2688,7 +2688,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.6.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -2698,7 +2698,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.15.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -2722,7 +2722,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.6.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -2732,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.43.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "either",
  "fnv",
@@ -2756,7 +2756,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.44.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "async-trait",
  "futures",
@@ -2771,7 +2771,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.50.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -2801,7 +2801,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.47.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -2820,15 +2820,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
+version = "0.2.12"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "bs58",
  "ed25519-dalek",
  "hkdf",
  "multihash",
- "prost 0.14.4",
+ "quick-protobuf",
  "rand 0.8.7",
  "serde",
  "sha2",
@@ -2840,7 +2839,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.49.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -2867,7 +2866,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.48.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -2885,7 +2884,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.17.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -2902,7 +2901,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.47.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2917,7 +2916,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.13.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2938,7 +2937,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.29.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "async-trait",
  "futures",
@@ -2954,7 +2953,7 @@ dependencies = [
 [[package]]
 name = "libp2p-stream"
 version = "0.4.0-alpha"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -2967,7 +2966,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.47.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "either",
  "fnv",
@@ -2987,7 +2986,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -2997,7 +2996,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.44.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3012,7 +3011,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.6.2"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -3030,7 +3029,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.5.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3235,7 +3234,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "bytes",
  "futures",
@@ -3899,16 +3898,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
-dependencies = [
- "bytes",
- "prost-derive 0.14.4",
-]
-
-[[package]]
 name = "prost-build"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3956,19 +3945,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-derive"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "prost-types"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3989,7 +3965,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4543,7 +4519,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=c0ed330#c0ed3308db3a7deda74a688e13b69007942c41ab"
+source = "git+https://github.com/kalabukdima/rust-libp2p.git?rev=fac3b0c9#fac3b0c97757d6d8d6042f5423d9467a94ea80b0"
 dependencies = [
  "futures",
  "pin-project",
@@ -4900,7 +4876,7 @@ dependencies = [
 [[package]]
 name = "sqd-assignments"
 version = "0.3.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=4939971#49399718778160b4187715b075762aa9620c3008"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=d1ee014#d1ee0146a0a238ee87f10e20f3cc8905abf656e8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4922,7 +4898,7 @@ dependencies = [
 [[package]]
 name = "sqd-contract-client"
 version = "1.3.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=e9a3434#e9a34341035ac7745b71eb87dabc8501aa434376"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=d1ee014#d1ee0146a0a238ee87f10e20f3cc8905abf656e8"
 dependencies = [
  "async-trait",
  "clap",
@@ -4931,6 +4907,7 @@ dependencies = [
  "libp2p",
  "log",
  "num-rational",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -4941,9 +4918,10 @@ dependencies = [
 
 [[package]]
 name = "sqd-messages"
-version = "2.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=e9a3434#e9a34341035ac7745b71eb87dabc8501aa434376"
+version = "3.1.0"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=d1ee014#d1ee0146a0a238ee87f10e20f3cc8905abf656e8"
 dependencies = [
+ "bytes",
  "hex",
  "libp2p-identity",
  "prost 0.13.5",
@@ -4956,7 +4934,7 @@ dependencies = [
 [[package]]
 name = "sqd-network-transport"
 version = "3.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=e9a3434#e9a34341035ac7745b71eb87dabc8501aa434376"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=d1ee014#d1ee0146a0a238ee87f10e20f3cc8905abf656e8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -4900,7 +4900,7 @@ dependencies = [
 [[package]]
 name = "sqd-assignments"
 version = "0.3.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=625de07#625de07388d90c29799fe3f73f7f65a2bcd64853"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=4939971#49399718778160b4187715b075762aa9620c3008"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -4900,7 +4900,7 @@ dependencies = [
 [[package]]
 name = "sqd-assignments"
 version = "0.3.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=339a0d7#339a0d7ed961f2698d65215f37344c1f61024589"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=625de07#625de07388d90c29799fe3f73f7f65a2bcd64853"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4916,6 +4916,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "url",
+ "zstd 0.13.3",
 ]
 
 [[package]]
@@ -6401,7 +6402,7 @@ dependencies = [
  "pbkdf2 0.11.0",
  "sha1",
  "time",
- "zstd",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -6416,7 +6417,16 @@ version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe 7.2.4",
 ]
 
 [[package]]
@@ -6426,6 +6436,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
  "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
  "zstd-sys",
 ]
 

--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -4899,8 +4899,8 @@ dependencies = [
 
 [[package]]
 name = "sqd-assignments"
-version = "0.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=67f54cc#67f54ccec1e82a80ef95bd419af2fc20bb942129"
+version = "0.3.0"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=339a0d7#339a0d7ed961f2698d65215f37344c1f61024589"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4913,6 +4913,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "thiserror 2.0.18",
  "tracing",
  "url",
 ]

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -24,14 +24,17 @@ hex = "0.4"
 sha2 = "0.10"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-libp2p-identity = { version = "0.2", features = ["ed25519", "rand", "peerid"] }
+libp2p-identity = { version = "=0.2.12", features = ["ed25519", "rand", "peerid"] }
 
 # Same pinned revs as the portal's Cargo.toml — the stubs must speak the exact wire ABI.
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "4939971", features = ["builder", "reader"] }
-sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", features = ["signatures"] }
-sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", features = ["worker"] }
-sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434" }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "d1ee014", features = ["builder", "reader"] }
+sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "d1ee014", features = ["signatures"] }
+sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "d1ee014", features = ["worker"] }
+sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "d1ee014" }
 
 [profile.dev]
 # The libp2p tree is slow at opt-level 0 and QUIC handshakes are timing-sensitive.
 opt-level = 1
+
+[patch.crates-io]
+libp2p-identity = { git = "https://github.com/kalabukdima/rust-libp2p.git", rev = "fac3b0c9" }

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -27,7 +27,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 libp2p-identity = { version = "0.2", features = ["ed25519", "rand", "peerid"] }
 
 # Same pinned revs as the portal's Cargo.toml — the stubs must speak the exact wire ABI.
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "625de07", features = ["builder", "reader"] }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "4939971", features = ["builder", "reader"] }
 sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", features = ["signatures"] }
 sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", features = ["worker"] }
 sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434" }

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -27,7 +27,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 libp2p-identity = { version = "0.2", features = ["ed25519", "rand", "peerid"] }
 
 # Same pinned revs as the portal's Cargo.toml — the stubs must speak the exact wire ABI.
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "67f54cc", features = ["builder", "reader"] }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "339a0d7", features = ["builder", "reader"] }
 sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", features = ["signatures"] }
 sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", features = ["worker"] }
 sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434" }

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -27,7 +27,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 libp2p-identity = { version = "0.2", features = ["ed25519", "rand", "peerid"] }
 
 # Same pinned revs as the portal's Cargo.toml — the stubs must speak the exact wire ABI.
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "339a0d7", features = ["builder", "reader"] }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "625de07", features = ["builder", "reader"] }
 sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", features = ["signatures"] }
 sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434", features = ["worker"] }
 sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "e9a3434" }

--- a/harness/src/artifact.rs
+++ b/harness/src/artifact.rs
@@ -98,11 +98,14 @@ pub fn build_portal_gzipped(world: &ToyWorld, workers: &[PeerId]) -> anyhow::Res
         let Some(network_id) = &ds.network_id else {
             continue;
         };
+        // Chunks are staged under the dataset they were opened against rather than naming one
+        // themselves. Schema ids are inert — the portal doesn't read them yet.
+        let mut dataset = b.new_dataset(network_id, 0);
         let mut head_hash = None;
         for chunk in &ds.chunks {
-            b.new_chunk()
+            dataset
+                .new_chunk()
                 .id(&chunk.id(&ds.name))
-                .dataset_id(network_id)
                 .block_range(chunk.first..=chunk.last)
                 .last_block_timestamp(world.timestamp(chunk.last))
                 .worker_indexes(&worker_indexes)
@@ -111,8 +114,10 @@ pub fn build_portal_gzipped(world: &ToyWorld, workers: &[PeerId]) -> anyhow::Res
             head_hash = Some(world.hash(&ds.name, chunk.last));
         }
         // Only the dataset's head hash survives the split; per-chunk hashes were dropped
-        // because no query needs one. Schema ids are inert — the portal doesn't read them yet.
-        b.finish_dataset(0, head_hash.as_deref());
+        // because no query needs one.
+        dataset
+            .finish(head_hash.as_deref())
+            .map_err(|e| anyhow::anyhow!("dataset build: {e}"))?;
     }
 
     for worker in &workers {

--- a/harness/src/stubs/worker.rs
+++ b/harness/src/stubs/worker.rs
@@ -15,7 +15,7 @@ use clap::Parser;
 use flate2::{write::GzEncoder, Compression};
 use futures::StreamExt;
 use libp2p_identity::Keypair;
-use sqd_messages::query_error;
+use sqd_messages::{query_error, ProstMsg};
 use sqd_network_transport::{
     AgentInfo, P2PTransportBuilder, TransportArgs, WorkerConfig, WorkerEvent,
 };
@@ -144,19 +144,31 @@ pub async fn start(
     let ledger = Ledger::default();
     let ledger2 = ledger.clone();
     tokio::spawn(async move {
+        // Responses now go straight down `resp_chan`, so nothing here calls the handle — but
+        // dropping it stops the transport task, so it has to outlive the event loop.
+        let _handle = handle;
         futures::pin_mut!(events);
         while let Some(event) = events.next().await {
             match event {
+                // The transport hands over raw protobuf now: decoding moved to the consumer,
+                // so a stub worker has to do exactly what a real one does with the bytes.
                 WorkerEvent::Query {
                     peer_id,
-                    query,
+                    request,
                     resp_chan,
                 } => {
+                    let query = match sqd_messages::Query::decode(request.as_ref()) {
+                        Ok(query) => query,
+                        Err(e) => {
+                            tracing::warn!(%peer_id, error = %e, "undecodable query");
+                            continue;
+                        }
+                    };
                     let fault = faults.next();
                     tracing::info!(%peer_id, chunk = %query.chunk_id, ?fault, "stub worker query");
                     let result = answer(&world, &signing_keypair, &query, &ledger2, fault);
-                    if handle.send_query_result(result, resp_chan).is_err() {
-                        tracing::warn!("query result queue full");
+                    if let Err(e) = resp_chan.send(&result.encode_to_vec()).await {
+                        tracing::warn!(%peer_id, error = %e, "failed to send query result");
                     }
                 }
                 other => tracing::debug!("ignoring worker event: {other:?}"),
@@ -249,7 +261,10 @@ fn answer(
     let mut result = sqd_messages::QueryResult {
         query_id: query.query_id.clone(),
         result: Some(sqd_messages::query_result::Result::Ok(
-            sqd_messages::QueryOk { data, last_block },
+            sqd_messages::QueryOk {
+                data: data.into(),
+                last_block,
+            },
         )),
         ..Default::default()
     };

--- a/spec/03-data-model.md
+++ b/spec/03-data-model.md
@@ -20,7 +20,15 @@ the query's field selection. Per-chain record schemas are explicitly unspecified
 
 **DEF-3 — Chunk.** An immutable, contiguous, non-overlapping range of finalized blocks;
 the archival network's unit of storage, assignment, and query. Chunks of a dataset are
-totally ordered and gap-free from the dataset's start block to the archival head.
+totally ordered and non-overlapping. Coverage is normally continuous from the dataset's
+start block to the archival head, but a **coverage gap** — a block range no chunk holds —
+is legal, and the two published artifacts (P-ASSIGNMENT-SOURCE) differ in what the Portal
+can do about one. The `portal` artifact states each chunk's last block, so a block inside a
+gap is recognised as such and resolves *forward*, to the first chunk after it: a stream
+crosses the hole and continues. The `legacy` artifact is ordered on first blocks alone, so
+the same block resolves *backward*, to the chunk before the gap — which shares none of the
+requested range — and the request yields no data (INV-27) even where later chunks hold
+some. Neither resolution skips data a chunk actually holds.
 
 **DEF-4 — Assignment artifact.** The routing document the network publishes:
 (identifier, effective-from time, worker set, per-dataset chunk sequences — each chunk

--- a/spec/03-data-model.md
+++ b/spec/03-data-model.md
@@ -34,8 +34,10 @@ some. Neither resolution skips data a chunk actually holds.
 (identifier, effective-from time, worker set, per-dataset chunk sequences — each chunk
 carrying its block range and the reference (DEF-2) of its last block — and the chunk →
 worker-subset mapping). Identifiers are opaque; artifacts are ordered by their
-effective-from times. The **applied artifact** is the single artifact the Portal
-currently routes by. An artifact is *applied* atomically, never partially (INV-1), no
+effective-from times. An artifact is fetched compressed and decompressed as it streams;
+the published url's suffix names the codec, `.zst` for zstd and gzip otherwise, since the
+network state carries no field for it. The **applied artifact** is the single artifact the
+Portal currently routes by. An artifact is *applied* atomically, never partially (INV-1), no
 earlier than its effective-from time, and never with an effective-from earlier than the
 applied one's (regression guard, INV-2).
 

--- a/spec/07-invariants.md
+++ b/spec/07-invariants.md
@@ -195,13 +195,18 @@ never carries one; no code outside DEF-10 is emitted.
 *Check:* CT-5 — exhaustive fault matrix → assert type, code, hint presence, body shape.
 
 **INV-27 — Empty-success semantics.** [response]
-For an admitted request, EMPTY is returned iff no conflict takes precedence (INV-23)
-and the first block exceeds the frontier (or falls in the archival/real-time retention
-gap); it is delayed ≥ P-NO-DATA-DELAY, carries current head metadata (DEF-8), and
-implies no skipped data: the client's progress is unchanged.
+For an admitted request, EMPTY is returned iff no conflict takes precedence (INV-23) and
+the requested range holds no data: the first block exceeds the frontier, or falls in the
+archival/real-time retention gap, or the chunk the request resolves to shares no block
+with it (a coverage gap, DEF-3). It is delayed ≥ P-NO-DATA-DELAY, carries current head
+metadata (DEF-8), and implies no skipped data: the client's progress is unchanged.
 *Why:* EMPTY doubles as the head-polling throttle (REQ-5); it must not consume a stream
-census slot while delaying the HTTP response.
-*Check:* CT-1 — frontier boundary sweep; timing assertion.
+census slot while delaying the HTTP response. The coverage-gap arm is the one where the
+throttle reads oddly — that range will never fill, so the delay paces a client that has
+nothing to wait for — but answering it as anything else would mean a class for "never"
+that no client reads today.
+*Check:* CT-1 — frontier boundary sweep; timing assertion; coverage-gap resolution under
+each artifact, and a range sharing no block with the chunk it resolved to.
 
 **INV-28 — Response-content purity.** [response]
 The rule of 04: record content is a function of (request, configuration, dependency

--- a/spec/13-conformance.md
+++ b/spec/13-conformance.md
@@ -1,7 +1,7 @@
 # 13 — Conformance & TDD plan
 
-**Mutable doc.** Statuses as of **2026-08-13** (0.13.1,
-`master@ab821f91d5b4345ec6dc6cbf05595867f41eb7de`). Statuses: **C** covered · **P** partial ·
+**Mutable doc.** Statuses as of **2026-08-17** (0.13.2,
+`master@375911e6695f3512fd2e3508fa08fbfdb4aac9cf`). Statuses: **C** covered · **P** partial ·
 **U** unchecked; *known-violated* / *known-suspect* where reality contradicts the property.
 **The authorization band (REQ-50..56, DC-8, OP-11 and the invariants scoped to them) has
 landed and is CT-10-covered on its request path.** A deployment with no `auth:` block
@@ -166,7 +166,7 @@ chunk-boundary records FV-6 licenses.
 | INV-24 | CT-5 | P | smoke asserts head markers against stub/artifact heads on success paths |
 | INV-25 | CT-2 | U | truncation never exercised |
 | INV-26 | CT-5 | C | CT-5 asserts the envelope, status, type/code and hint presence across the local and proxied emitters, including the 409 sibling, the OVERLOADED hint floor, replacement of an unusable upstream hint (0, non-numeric, HTTP-date), the classes that get no invented hint (upstream 503/500), a wrong verb keeping 405 with its `Allow`, and normalization of the router's other rejections |
-| INV-27 | CT-1 | P | gap detection tested; proxied 204 smoke-tested; delay untested |
+| INV-27 | CT-1 | P | retention-gap detection tested; coverage-gap resolution unit-tested on both artifacts, as is a range sharing no block with the chunk it resolved to; proxied 204 smoke-tested; delay untested |
 | INV-28 | CT-3 | U | — |
 | INV-29 | CT-1 | P | boundary emission asserted by the CT-1 selective-tail resume on both sources; the network multi-chunk case exercises the per-chunk granularity FV-6 licenses. Interior boundary records are not audited, and the EMPTY case (no block evaluated) is untested. Boundary pinning is a worker-engine behavior — re-prove before adopting new engine/format fields on a dependency bump |
 | INV-30 | CT-3/7 | U | gauge accounting was a past defect class |
@@ -239,7 +239,7 @@ chunk-boundary records FV-6 licenses.
 | REQ-55 | P | CT-10 runs a shadow portal: a request with no credential, one with an ungrammatical token and one the control plane denies are all served, the verdict enforcement would have returned is in the protected log, and the keyless scrape carries only the neutral `shadow_evaluated` series with no code and no exchange counters. The control-plane ledger shows it exchanging on the same cache-miss rule enforcement uses — once, for the only request that presented something to exchange. Indeterminate exchange outcomes are not separately driven |
 | REQ-56 | P | CT-10 runs a portal with no `auth:` block: gated routes are served without a credential, a credential presented anyway is not a reason to refuse, and no authorization series appears in the scrape at all. The empty-block startup error is unit-tested in `auth::config` rather than here, and the startup mode line is logged but not asserted |
 
-## Gap register — 2026-08-13
+## Gap register — 2026-08-17
 
 Priorities: P0 blocks the program · P1 active production risk · P2 correctness hole
 with plausible trigger · P3 polish. "Next" = cheapest failing-test-first entry.

--- a/spec/13-conformance.md
+++ b/spec/13-conformance.md
@@ -1,6 +1,6 @@
 # 13 — Conformance & TDD plan
 
-**Mutable doc.** Statuses as of **2026-08-17** (0.13.2,
+**Mutable doc.** Statuses as of **2026-08-18** (0.13.2,
 `master@375911e6695f3512fd2e3508fa08fbfdb4aac9cf`). Statuses: **C** covered · **P** partial ·
 **U** unchecked; *known-violated* / *known-suspect* where reality contradicts the property.
 **The authorization band (REQ-50..56, DC-8, OP-11 and the invariants scoped to them) has
@@ -239,7 +239,7 @@ chunk-boundary records FV-6 licenses.
 | REQ-55 | P | CT-10 runs a shadow portal: a request with no credential, one with an ungrammatical token and one the control plane denies are all served, the verdict enforcement would have returned is in the protected log, and the keyless scrape carries only the neutral `shadow_evaluated` series with no code and no exchange counters. The control-plane ledger shows it exchanging on the same cache-miss rule enforcement uses — once, for the only request that presented something to exchange. Indeterminate exchange outcomes are not separately driven |
 | REQ-56 | P | CT-10 runs a portal with no `auth:` block: gated routes are served without a credential, a credential presented anyway is not a reason to refuse, and no authorization series appears in the scrape at all. The empty-block startup error is unit-tested in `auth::config` rather than here, and the startup mode line is logged but not asserted |
 
-## Gap register — 2026-08-17
+## Gap register — 2026-08-18
 
 Priorities: P0 blocks the program · P1 active production risk · P2 correctness hole
 with plausible trigger · P3 polish. "Next" = cheapest failing-test-first entry.

--- a/spec/13-conformance.md
+++ b/spec/13-conformance.md
@@ -108,7 +108,7 @@ integrity failure, which is WORKER-FAILURE (DC-1); after the first record ⇒ tr
 | FV-2 | speculative attempt count/timing | ≤ 1 + retries per chunk |
 | FV-3 | truncation point | any record boundary after the first record |
 | FV-4 | coverage extent | contiguous evaluated prefix from `fromBlock`; *matching* records may be empty, but the coverage boundary is always emitted (INV-29), so ≥1 record whenever ≥1 block is evaluated |
-| FV-5 | compression choice/framing | must decode; gzip default, zstd when offered |
+| FV-5 | compression choice/framing | responses: must decode; gzip default, zstd when offered. Artifacts: the publisher picks gzip or zstd and names it in the url suffix (DEF-4); the Portal decodes either, unit-tested both ways |
 | FV-6 | boundary-record granularity | the source emits a header-only coverage boundary per *served chunk* (`Plan::execute` runs per chunk), not only at the response's global first/last; these interior header-only records are licensed. Conformance checks the last record (= coverage cursor, INV-29) and the matched-record set, not exact record-set equality |
 
 Everything else — the content and order of the records that are present, error type/code,

--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -1098,7 +1098,7 @@ fn parse_response(
     let last_block = result.last_block;
 
     let state = if last_block == *range.end() {
-        RequestState::Done(Ok(result.data))
+        RequestState::Done(Ok(result.data.to_vec()))
     } else if last_block < *range.start() {
         // Unreachable: `check_response_range` rejects this before the response
         // gets here. Kept because falling through would emit blocks below the
@@ -1109,7 +1109,7 @@ fn parse_response(
         ))))
     } else {
         RequestState::Partial(PartialResult {
-            data: result.data,
+            data: result.data.to_vec(),
             next_range: BlockRange::new(last_block + 1, *range.end()),
         })
     };
@@ -1352,7 +1352,8 @@ mod tests {
                 Ok(QuerySuccess {
                     ok: sqd_messages::QueryOk {
                         data: format!("data-{}-{}", block_range.start(), block_range.end())
-                            .into_bytes(),
+                            .into_bytes()
+                            .into(),
                         last_block: *block_range.end(),
                     },
                     ttfb: Duration::from_millis(1),
@@ -1646,7 +1647,7 @@ mod tests {
                 }
                 Ok(QuerySuccess {
                     ok: sqd_messages::QueryOk {
-                        data: format!("{start}:{last}").into_bytes(),
+                        data: format!("{start}:{last}").into_bytes().into(),
                         last_block: last,
                     },
                     ttfb: Duration::from_millis(1),
@@ -1992,7 +1993,7 @@ mod tests {
         let success = |last_block| {
             Ok(QuerySuccess {
                 ok: sqd_messages::QueryOk {
-                    data: b"data".to_vec(),
+                    data: b"data".to_vec().into(),
                     last_block,
                 },
                 ttfb: Duration::from_millis(1),

--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -1098,7 +1098,7 @@ fn parse_response(
     let last_block = result.last_block;
 
     let state = if last_block == *range.end() {
-        RequestState::Done(Ok(result.data.to_vec()))
+        RequestState::Done(Ok(result.data))
     } else if last_block < *range.start() {
         // Unreachable: `check_response_range` rejects this before the response
         // gets here. Kept because falling through would emit blocks below the
@@ -1109,7 +1109,7 @@ fn parse_response(
         ))))
     } else {
         RequestState::Partial(PartialResult {
-            data: result.data.to_vec(),
+            data: result.data,
             next_range: BlockRange::new(last_block + 1, *range.end()),
         })
     };
@@ -1196,7 +1196,7 @@ mod tests {
 
     fn partial_result(end: u64, last_returned: u64, data: &[u8]) -> PartialResult {
         PartialResult {
-            data: data.to_vec(),
+            data: data.to_vec().into(),
             next_range: BlockRange::new(last_returned + 1, end),
         }
     }
@@ -1205,7 +1205,7 @@ mod tests {
         BufferedResponse {
             chunk_index: 0,
             read_range: 100..=149,
-            result: Ok(vec![1, 2, 3]),
+            result: Ok(vec![1, 2, 3].into()),
         }
     }
 
@@ -1219,7 +1219,7 @@ mod tests {
         assert_eq!(response.read_range, BlockRange::new(100, 120));
         assert_eq!(response.chunk_index, 0);
         match response.result {
-            Ok(data) => assert_eq!(data, b"first"),
+            Ok(data) => assert_eq!(data.as_ref(), b"first"),
             Err(_) => panic!("partial data should become an emit-ready response"),
         }
         assert_eq!(continuation.range, BlockRange::new(121, 200));
@@ -1260,7 +1260,7 @@ mod tests {
     fn active_partial_counts_as_stored_result() {
         let chunk_slot = ChunkSlot {
             active: Some(slot(RequestState::Partial(PartialResult {
-                data: vec![1],
+                data: vec![1].into(),
                 next_range: 150..=199,
             }))),
             buffered: VecDeque::new(),
@@ -1273,7 +1273,7 @@ mod tests {
     fn partial_continuation_requires_capacity_for_next_active_result() {
         let mut chunk_slot = ChunkSlot {
             active: Some(slot(RequestState::Partial(PartialResult {
-                data: vec![1],
+                data: vec![1].into(),
                 next_range: 150..=199,
             }))),
             buffered: VecDeque::new(),
@@ -1290,7 +1290,7 @@ mod tests {
     #[test]
     fn terminal_response_can_use_last_capacity_slot() {
         let mut chunk_slot = ChunkSlot {
-            active: Some(slot(RequestState::Done(Ok(vec![4, 5, 6])))),
+            active: Some(slot(RequestState::Done(Ok(vec![4, 5, 6].into())))),
             buffered: VecDeque::new(),
         };
 
@@ -1820,7 +1820,7 @@ mod tests {
         while let Some(item) = controller.next().await {
             match item {
                 Ok(bytes) => {
-                    let text = String::from_utf8(bytes).unwrap();
+                    let text = String::from_utf8(bytes.to_vec()).unwrap();
                     let (start, last) = text.split_once(':').unwrap();
                     emissions.push((start.parse().unwrap(), last.parse().unwrap()));
                 }

--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -201,12 +201,7 @@ impl<N: StreamingNetwork> StreamController<N> {
             }
         };
 
-        // Neither reader promises a chunk that holds `first_block`, and a gap is how both miss:
-        // the portal resolves forward and can land past the requested range, the legacy format
-        // cannot see the gap at all and hands back the chunk before it. Either way the chunk can
-        // share no block with the query, and scheduling it would reach `start_querying_chunk`
-        // with nothing to intersect. Checked as the intersection itself, so it holds whichever
-        // side the chunk falls on.
+        // Gap resolution can return a chunk on either side of the requested range.
         if request
             .query
             .intersect_with(&first_chunk.block_range())
@@ -1389,13 +1384,6 @@ mod tests {
         }
     }
 
-    /// Neither reader promises a chunk holding the requested block when a gap is involved, and
-    /// the chunk can then miss the query on either side: the portal resolves a gap forward and
-    /// lands past the range, the legacy format cannot see the gap and hands back the chunk
-    /// before it. Both used to reach `start_querying_chunk`, whose `intersect_with` has nothing
-    /// to return, and panic.
-    ///
-    /// `stream_request` asks for 100..=150, against a dataset holding 0-99 and 200-299.
     #[tokio::test(start_paused = true)]
     async fn a_chunk_sharing_no_block_with_the_query_is_no_data() {
         for chunk in [

--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -201,14 +201,16 @@ impl<N: StreamingNetwork> StreamController<N> {
             }
         };
 
-        // A gap between chunks resolves forward, so the chunk found for `first_block` can start
-        // past the requested range and share no block with it. `get_next_chunk` already ends the
-        // stream on that; the first chunk is the one path that never checked, and scheduling it
-        // would reach `start_querying_chunk` with nothing to intersect.
+        // Neither reader promises a chunk that holds `first_block`, and a gap is how both miss:
+        // the portal resolves forward and can land past the requested range, the legacy format
+        // cannot see the gap at all and hands back the chunk before it. Either way the chunk can
+        // share no block with the query, and scheduling it would reach `start_querying_chunk`
+        // with nothing to intersect. Checked as the intersection itself, so it holds whichever
+        // side the chunk falls on.
         if request
             .query
-            .last_block()
-            .is_some_and(|last_block| last_block < first_chunk.first_block)
+            .intersect_with(&first_chunk.block_range())
+            .is_none()
         {
             return Err(RequestError::NoData);
         }
@@ -1386,26 +1388,32 @@ mod tests {
         }
     }
 
-    /// A gap between chunks resolves forward, so a query that falls entirely inside one gets
-    /// back the chunk *after* it -- sharing no block with the request. That reached
-    /// `start_querying_chunk`, whose `intersect_with` has nothing to return, and panicked.
+    /// Neither reader promises a chunk holding the requested block when a gap is involved, and
+    /// the chunk can then miss the query on either side: the portal resolves a gap forward and
+    /// lands past the range, the legacy format cannot see the gap and hands back the chunk
+    /// before it. Both used to reach `start_querying_chunk`, whose `intersect_with` has nothing
+    /// to return, and panic.
     ///
-    /// `stream_request` asks for 100..=150; the mock stands in for a dataset whose next chunk
-    /// after the gap starts at 200.
+    /// `stream_request` asks for 100..=150, against a dataset holding 0-99 and 200-299.
     #[tokio::test(start_paused = true)]
-    async fn a_query_entirely_inside_a_gap_is_no_data() {
-        let network = Arc::new(MockNetwork {
-            chunk: DataChunk::new(0, 200, 299, "aaaaa").unwrap(),
-            backoff_until: Instant::now(),
-            queries_sent: AtomicUsize::new(0),
-        });
+    async fn a_chunk_sharing_no_block_with_the_query_is_no_data() {
+        for chunk in [
+            DataChunk::new(0, 200, 299, "aaaaa").unwrap(), // portal: the gap resolved forward
+            DataChunk::new(0, 0, 99, "aaaaa").unwrap(),    // legacy: the chunk before the gap
+        ] {
+            let network = Arc::new(MockNetwork {
+                chunk,
+                backoff_until: Instant::now(),
+                queries_sent: AtomicUsize::new(0),
+            });
 
-        let result = StreamController::new(stream_request(), network, 0, 1);
+            let result = StreamController::new(stream_request(), network, 0, 1);
 
-        let Err(err) = result else {
-            panic!("a range holding no data is not a stream");
-        };
-        assert!(matches!(err, RequestError::NoData), "got {err:?}");
+            let Err(err) = result else {
+                panic!("a range holding no data is not a stream ({chunk})");
+            };
+            assert!(matches!(err, RequestError::NoData), "{chunk}: got {err:?}");
+        }
     }
 
     /// Regression test for the duplicated-response incident: a request whose

--- a/src/controller/stream.rs
+++ b/src/controller/stream.rs
@@ -201,6 +201,18 @@ impl<N: StreamingNetwork> StreamController<N> {
             }
         };
 
+        // A gap between chunks resolves forward, so the chunk found for `first_block` can start
+        // past the requested range and share no block with it. `get_next_chunk` already ends the
+        // stream on that; the first chunk is the one path that never checked, and scheduling it
+        // would reach `start_querying_chunk` with nothing to intersect.
+        if request
+            .query
+            .last_block()
+            .is_some_and(|last_block| last_block < first_chunk.first_block)
+        {
+            return Err(RequestError::NoData);
+        }
+
         Ok(Self {
             network,
             buffer: SlidingArray::with_capacity(request.buffer_size),
@@ -1372,6 +1384,28 @@ mod tests {
             compression: Compression::Gzip,
             skip_parent_hash_validation: false,
         }
+    }
+
+    /// A gap between chunks resolves forward, so a query that falls entirely inside one gets
+    /// back the chunk *after* it -- sharing no block with the request. That reached
+    /// `start_querying_chunk`, whose `intersect_with` has nothing to return, and panicked.
+    ///
+    /// `stream_request` asks for 100..=150; the mock stands in for a dataset whose next chunk
+    /// after the gap starts at 200.
+    #[tokio::test(start_paused = true)]
+    async fn a_query_entirely_inside_a_gap_is_no_data() {
+        let network = Arc::new(MockNetwork {
+            chunk: DataChunk::new(0, 200, 299, "aaaaa").unwrap(),
+            backoff_until: Instant::now(),
+            queries_sent: AtomicUsize::new(0),
+        });
+
+        let result = StreamController::new(stream_request(), network, 0, 1);
+
+        let Err(err) = result else {
+            panic!("a range holding no data is not a stream");
+        };
+        assert!(matches!(err, RequestError::NoData), "got {err:?}");
     }
 
     /// Regression test for the duplicated-response incident: a request whose

--- a/src/endpoints/stream.rs
+++ b/src/endpoints/stream.rs
@@ -6,7 +6,6 @@ use axum::{
     response::{IntoResponse, Response},
     Extension,
 };
-use bytes::Bytes;
 use futures::{Stream, StreamExt};
 
 use crate::{
@@ -17,7 +16,7 @@ use crate::{
     http_server::{forward_hotblocks_response, forward_response},
     network::NetworkClient,
     openapi::{BaseBlockConflictResponse, StreamRequestBody},
-    types::{Compression, DatasetId, ErrorResponse, RequestError, StreamRequest},
+    types::{Compression, DatasetId, ErrorResponse, RequestError, ResponseChunk, StreamRequest},
     utils::conversion::{join_gzip_default, recompress_gzip},
 };
 
@@ -420,16 +419,20 @@ async fn stream_after_network_head(network: &NetworkClient, dataset_id: DatasetI
 }
 
 fn response_body(
-    stream: impl Stream<Item = Vec<u8>> + Send + 'static,
+    stream: impl Stream<Item = ResponseChunk> + Send + 'static,
     compression: Compression,
     use_gzjoin: bool,
 ) -> Body {
     match compression {
-        Compression::Gzip if use_gzjoin => Body::from_stream(join_gzip_default(stream)),
-        Compression::Gzip => Body::from_stream(recompress_gzip(stream)),
-        Compression::Zstd => {
-            Body::from_stream(stream.map(|result| std::io::Result::Ok(Bytes::from_owner(result))))
+        // The gzip path owns its input: it hands the buffer to zlib through a raw pointer, so it
+        // cannot take a slice of one shared with the decoded response. That copy is the whole
+        // reason `ResponseChunk` is not `Bytes` all the way down; lifting it means auditing that
+        // `inflate` only ever reads `next_in`, which is not this change's business.
+        Compression::Gzip if use_gzjoin => {
+            Body::from_stream(join_gzip_default(stream.map(|chunk| chunk.to_vec())))
         }
+        Compression::Gzip => Body::from_stream(recompress_gzip(stream.map(|chunk| chunk.to_vec()))),
+        Compression::Zstd => Body::from_stream(stream.map(std::io::Result::Ok)),
     }
 }
 

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -1013,9 +1013,11 @@ async fn execute_query(
     let Ok(chunk) = client.find_chunk(&dataset_id, query.first_block()) else {
         return RequestError::NoData.into_response();
     };
-    let range = query
-        .intersect_with(&chunk.block_range())
-        .expect("Found chunk should intersect with query");
+    // A gap resolves forward, so the chunk found for the query's first block can start past the
+    // requested range and share no block with it.
+    let Some(range) = query.intersect_with(&chunk.block_range()) else {
+        return RequestError::NoData.into_response();
+    };
 
     let lease = match client.reserve_worker(worker_id) {
         Some(lease) => lease,

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -1013,8 +1013,6 @@ async fn execute_query(
     let Ok(chunk) = client.find_chunk(&dataset_id, query.first_block()) else {
         return RequestError::NoData.into_response();
     };
-    // A gap resolves forward, so the chunk found for the query's first block can start past the
-    // requested range and share no block with it.
     let Some(range) = query.intersect_with(&chunk.block_range()) else {
         return RequestError::NoData.into_response();
     };

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -191,6 +191,25 @@ impl Verdict {
     }
 }
 
+/// The response buffer as `Bytes`, adopting its allocation when that is not wasteful.
+///
+/// `QueryOk::data` is a `bytes` field, and prost shares the input buffer for one only when the
+/// input is itself `Bytes`; from a slice it allocates and copies the whole payload. Adopting the
+/// read buffer instead hands the payload onwards having been copied once, off the socket.
+///
+/// The catch is that `Bytes::from(Vec)` takes the allocation whole, capacity included, and the
+/// read buffer starts at a megabyte. A barely-filled one would pin all of it for as long as the
+/// payload sits in a stream's buffer, which is bounded by response *count*, not bytes. So the
+/// buffer is only adopted while it is at least half full, which caps what a payload can hold at
+/// twice its own size; a smaller response is copied, where copying is cheap and the saving large.
+fn share_or_copy(buf: Vec<u8>) -> bytes::Bytes {
+    if buf.len().saturating_mul(2) >= buf.capacity() {
+        bytes::Bytes::from(buf)
+    } else {
+        bytes::Bytes::copy_from_slice(&buf)
+    }
+}
+
 /// The data is opaque, so a `last_block` outside the queried range cannot be trimmed to
 /// it, and the continuation derived from it is inverted or re-covers delivered blocks.
 fn out_of_range(ok: &QueryOk, range: &BlockRange) -> bool {
@@ -837,7 +856,13 @@ impl NetworkClient {
         transfer_time: Duration,
         query_time: Duration,
     ) -> QueryResult {
-        let result = sqd_messages::QueryResult::decode(buf.as_slice())
+        // Decoded from `Bytes`, not `&[u8]`: `QueryOk::data` is a `bytes` field, and prost only
+        // shares the input buffer when the input is itself `Bytes` -- from a slice it allocates
+        // and copies the payload instead. `Bytes::from(Vec)` takes the read buffer's allocation
+        // without copying, so the payload reaches the caller having been copied once, off the
+        // socket, and not again.
+        let response_size = buf.len();
+        let result = sqd_messages::QueryResult::decode(share_or_copy(buf))
             .map_err(|e| QueryFailure::InvalidResponse(e.to_string()));
 
         if let Some(logs_tx) = &self.logs_tx {
@@ -850,7 +875,6 @@ impl NetworkClient {
             }
         }
 
-        let response_size = buf.len();
         let throughput = if transfer_time.as_secs_f64() > 0.0 {
             Some(response_size as f64 / transfer_time.as_secs_f64())
         } else {
@@ -1232,6 +1256,31 @@ mod tests {
     fn parse_base_block_mismatch_malformed_no_number() {
         let msg = "unexpected base block: expected 0xabc, but got #0xdef";
         assert!(parse_base_block_mismatch(msg).is_none());
+    }
+
+    #[test]
+    fn a_response_is_shared_when_that_does_not_pin_much_more_than_it_holds() {
+        // Zero-copy is worth having only where the copy would cost something. A well-filled
+        // buffer is adopted; a barely-filled one is copied, so a small payload cannot hold a
+        // megabyte of read buffer open while it waits in a stream's queue.
+        let mut full = Vec::with_capacity(1024);
+        full.extend(std::iter::repeat_n(7u8, 1024));
+        let full_ptr = full.as_ptr();
+
+        let mut sparse = Vec::with_capacity(1024);
+        sparse.extend_from_slice(&[7u8; 8]);
+        let sparse_ptr = sparse.as_ptr();
+
+        let shared = share_or_copy(full);
+        let copied = share_or_copy(sparse);
+
+        assert_eq!(shared.as_ptr(), full_ptr, "a full buffer should be adopted");
+        assert_ne!(copied.as_ptr(), sparse_ptr, "a sparse one should be copied");
+        assert_eq!(
+            copied.as_ref(),
+            &[7u8; 8],
+            "the copy still carries the payload"
+        );
     }
 
     #[test]

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -734,8 +734,6 @@ impl NetworkClient {
             // 0 for a chunk the legacy artifact produced, which names no version: proto3 leaves
             // the default off the wire, so the field is absent exactly when there is none to send.
             chunk_version: chunk_id.chunk.version(),
-            // Protocol defaults: the portal asks for jsonl from the default engine, which is what
-            // it asked for before these fields existed.
             query_engine: Default::default(),
             output_format: Default::default(),
         };
@@ -856,11 +854,6 @@ impl NetworkClient {
         transfer_time: Duration,
         query_time: Duration,
     ) -> QueryResult {
-        // Decoded from `Bytes`, not `&[u8]`: `QueryOk::data` is a `bytes` field, and prost only
-        // shares the input buffer when the input is itself `Bytes` -- from a slice it allocates
-        // and copies the payload instead. `Bytes::from(Vec)` takes the read buffer's allocation
-        // without copying, so the payload reaches the caller having been copied once, off the
-        // socket, and not again.
         let response_size = buf.len();
         let result = sqd_messages::QueryResult::decode(share_or_copy(buf))
             .map_err(|e| QueryFailure::InvalidResponse(e.to_string()));

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -114,8 +114,9 @@ enum Health {
     Error,
 }
 
-/// Matched verbatim: the wire carries no code for this verdict (GAP-25).
+/// Matched verbatim: the wire carries no code for these verdicts (GAP-25).
 const STALE_ENVELOPE: &str = "timestamp out of allowed range";
+const RESPONSE_TOO_LARGE: &str = "Response too large";
 
 /// One DC-1 row: how a worker verdict is classified, counted, and charged. The three
 /// were chosen independently in each match arm — eight arms times three decisions — and
@@ -150,28 +151,30 @@ impl Verdict {
             ),
             // Probably still downloading the chunk.
             Err::NotFound(s) => row(QueryError::Retriable(s), "not_found", Health::Error, false),
-            // Input validation, not a bad response.
-            Err::ServerError(s) if parse_base_block_mismatch(&s).is_some() => row(
-                QueryError::BaseBlockMismatch(parse_base_block_mismatch(&s).expect("just matched")),
-                "block_mismatch",
-                Health::Ok,
-                false,
-            ),
-            // The query covers too much data: narrowing it is the client's move, and
-            // another worker would answer the same.
-            Err::ServerError(s) if s == "Response too large" => row(
-                QueryError::BadRequest(
-                    "the response for this block exceeds the size limit; \
-                     try narrowing the query to request only the necessary data"
-                        .to_owned(),
+            // Three rows share the wire's catch-all class, so they are split here rather than by
+            // guard: a guard would have to re-parse the message to bind what it just matched.
+            Err::ServerError(s) => match parse_base_block_mismatch(&s) {
+                // Input validation, not a bad response.
+                Some(base_block) => row(
+                    QueryError::BaseBlockMismatch(base_block),
+                    "block_mismatch",
+                    Health::Ok,
+                    false,
                 ),
-                "response_too_large",
-                Health::Ok,
-                false,
-            ),
-            Err::ServerError(s) => {
-                row(QueryError::Failure(s), "server_error", Health::Error, false)
-            }
+                // The query covers too much data: narrowing it is the client's move, and
+                // another worker would answer the same.
+                None if s == RESPONSE_TOO_LARGE => row(
+                    QueryError::BadRequest(
+                        "the response for this block exceeds the size limit; \
+                         try narrowing the query to request only the necessary data"
+                            .to_owned(),
+                    ),
+                    "response_too_large",
+                    Health::Ok,
+                    false,
+                ),
+                None => row(QueryError::Failure(s), "server_error", Health::Error, false),
+            },
             // One row, two verdicts: both are capacity refusals.
             Err::ServerOverloaded(()) => row(
                 QueryError::RateLimitExceeded,
@@ -1242,5 +1245,26 @@ mod tests {
         assert!(matches!(verdict.error, QueryError::BadRequest(_)));
         assert!(matches!(verdict.health, Health::Ok));
         assert_eq!(verdict.label, "bad_request");
+    }
+
+    #[test]
+    fn server_errors_split_into_three_rows() {
+        // The wire's catch-all class; only the message tells the three apart.
+        let mismatch = Verdict::of(query_error::Err::ServerError(
+            "unexpected base block: expected 0xabc, but got 42#0xdef".to_owned(),
+        ));
+        assert!(matches!(mismatch.error, QueryError::BaseBlockMismatch(_)));
+        assert_eq!(mismatch.label, "block_mismatch");
+        assert!(matches!(mismatch.health, Health::Ok));
+
+        let too_large = Verdict::of(query_error::Err::ServerError(RESPONSE_TOO_LARGE.to_owned()));
+        assert!(matches!(too_large.error, QueryError::BadRequest(_)));
+        assert_eq!(too_large.label, "response_too_large");
+        assert!(matches!(too_large.health, Health::Ok));
+
+        let other = Verdict::of(query_error::Err::ServerError("disk on fire".to_owned()));
+        assert!(matches!(other.error, QueryError::Failure(_)));
+        assert_eq!(other.label, "server_error");
+        assert!(matches!(other.health, Health::Error));
     }
 }

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -712,6 +712,13 @@ impl NetworkClient {
             timestamp_ms: timestamp_now_ms(),
             signature: Default::default(),
             compression,
+            // 0 for a chunk the legacy artifact produced, which names no version: proto3 leaves
+            // the default off the wire, so the field is absent exactly when there is none to send.
+            chunk_version: chunk_id.chunk.version(),
+            // Protocol defaults: the portal asks for jsonl from the default engine, which is what
+            // it asked for before these fields existed.
+            query_engine: Default::default(),
+            output_format: Default::default(),
         };
         tokio::task::spawn_blocking({
             let keypair = self.keypair.clone();

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -114,9 +114,8 @@ enum Health {
     Error,
 }
 
-/// Matched verbatim: the wire carries no code for these verdicts (GAP-25).
+/// Matched verbatim: the wire carries no code for this verdict (GAP-25).
 const STALE_ENVELOPE: &str = "timestamp out of allowed range";
-const RESPONSE_TOO_LARGE: &str = "Response too large";
 
 /// One DC-1 row: how a worker verdict is classified, counted, and charged. The three
 /// were chosen independently in each match arm — eight arms times three decisions — and
@@ -151,8 +150,8 @@ impl Verdict {
             ),
             // Probably still downloading the chunk.
             Err::NotFound(s) => row(QueryError::Retriable(s), "not_found", Health::Error, false),
-            // Three rows share the wire's catch-all class, so they are split here rather than by
-            // guard: a guard would have to re-parse the message to bind what it just matched.
+            // Split inside the arm, not by guard: a guard cannot bind what it matched, so it
+            // had to parse once to test and again to use, behind an `expect`.
             Err::ServerError(s) => match parse_base_block_mismatch(&s) {
                 // Input validation, not a bad response.
                 Some(base_block) => row(
@@ -163,7 +162,7 @@ impl Verdict {
                 ),
                 // The query covers too much data: narrowing it is the client's move, and
                 // another worker would answer the same.
-                None if s == RESPONSE_TOO_LARGE => row(
+                None if s == "Response too large" => row(
                     QueryError::BadRequest(
                         "the response for this block exceeds the size limit; \
                          try narrowing the query to request only the necessary data"
@@ -1255,12 +1254,12 @@ mod tests {
         ));
         assert!(matches!(mismatch.error, QueryError::BaseBlockMismatch(_)));
         assert_eq!(mismatch.label, "block_mismatch");
-        assert!(matches!(mismatch.health, Health::Ok));
 
-        let too_large = Verdict::of(query_error::Err::ServerError(RESPONSE_TOO_LARGE.to_owned()));
+        let too_large = Verdict::of(query_error::Err::ServerError(
+            "Response too large".to_owned(),
+        ));
         assert!(matches!(too_large.error, QueryError::BadRequest(_)));
         assert_eq!(too_large.label, "response_too_large");
-        assert!(matches!(too_large.health, Health::Ok));
 
         let other = Verdict::of(query_error::Err::ServerError("disk on fire".to_owned()));
         assert!(matches!(other.error, QueryError::Failure(_)));

--- a/src/network/storage.rs
+++ b/src/network/storage.rs
@@ -391,7 +391,10 @@ impl StorageClient {
     }
 
     pub fn next_chunk(&self, dataset: &DatasetId, chunk: &DataChunk) -> Option<DataChunk> {
-        self.find_chunk(dataset, chunk.last_block + 1).ok()
+        let next_block = chunk.last_block.checked_add(1)?;
+        self.find_chunk(dataset, next_block)
+            .ok()
+            .filter(|next| advances_past(chunk, next))
     }
 
     pub fn first_block(&self, dataset: &DatasetId) -> Option<BlockNumber> {
@@ -486,6 +489,10 @@ impl StorageClient {
                 .collect(),
         })
     }
+}
+
+fn advances_past(current: &DataChunk, candidate: &DataChunk) -> bool {
+    candidate.first_block > current.last_block
 }
 
 fn accumulate_range(
@@ -943,16 +950,19 @@ mod tests {
     }
 
     #[test]
-    fn legacy_walks_back_into_the_chunk_that_just_ended() {
-        // `next_chunk` is `find_chunk(last_block + 1)`. Across a gap that resolves backward to
-        // the chunk it just finished, so a legacy stream is handed the same chunk again instead
-        // of advancing -- the portal counterpart crosses the gap
-        // (`the_block_after_a_chunk_crosses_the_gap`).
+    fn legacy_cannot_advance_across_a_gap() {
+        // The legacy reader resolves the block after the first chunk backward, to that same
+        // chunk. `next_chunk` rejects this non-advancing result, so the stream stops instead of
+        // querying 0-99 repeatedly.
         let legacy = gapped_legacy_assignment();
+        let current = legacy.find_chunk(GAPPED_DATASET, 0).unwrap();
 
         let after_first = legacy.find_chunk(GAPPED_DATASET, 100).unwrap();
 
-        assert_eq!(after_first.first_block(), 0, "legacy did not advance");
+        assert_eq!(after_first.first_block(), current.first_block());
+        let current = current.id().parse::<DataChunk>().unwrap();
+        let after_first = after_first.id().parse::<DataChunk>().unwrap();
+        assert!(!advances_past(&current, &after_first));
     }
 
     #[test]
@@ -966,12 +976,16 @@ mod tests {
 
     #[test]
     fn the_block_after_a_chunk_crosses_the_gap() {
-        // How `next_chunk` walks a stream forward: without the skip it would return the chunk it
-        // was already on, or nothing at all.
+        // The portal reader resolves the block after the first chunk to the next real chunk, so
+        // `next_chunk` accepts it as strict forward progress and the stream crosses the gap.
         let assignment = gapped_portal_assignment();
+        let current = find_portal_chunk(&assignment, GAPPED_DATASET, 0).unwrap();
 
         let chunk = find_portal_chunk(&assignment, GAPPED_DATASET, 100).unwrap();
         assert_eq!(chunk.first_block(), 200);
+        let current = portal_data_chunk(current).unwrap();
+        let chunk = portal_data_chunk(chunk).unwrap();
+        assert!(advances_past(&current, &chunk));
     }
 
     #[test]

--- a/src/network/storage.rs
+++ b/src/network/storage.rs
@@ -71,6 +71,11 @@ pub enum ChunkNotFound {
     BeforeFirst { first_block: BlockNumber },
     #[error("Block is after the last block")]
     AfterLast,
+    /// Only the portal artifact can report this: it gives each chunk its own end, so a block
+    /// between two chunks is an answer rather than the preceding chunk. The legacy reader has no
+    /// per-chunk end and silently attributes such a block to the chunk before it.
+    #[error("Block falls in a gap between chunks")]
+    InGap,
     #[error("Invalid chunk ID: {0}")]
     InvalidID(String),
 }
@@ -248,10 +253,10 @@ impl StorageClient {
                     assignment
                         .datasets()
                         .iter()
-                        .map(|d| (d.id(), d.chunks().len(), d.last_block())),
+                        .map(|d| (d.id(), d.chunk_count(), d.last_block())),
                     |id| match prev.as_ref() {
                         Some(ActiveAssignment::Portal(p)) => {
-                            p.get_dataset(id).map(|d| d.chunks().len())
+                            p.get_dataset(id).map(|d| d.chunk_count())
                         }
                         _ => None,
                     },
@@ -304,12 +309,13 @@ impl StorageClient {
             )?
             .id()
             .to_owned(),
-            ActiveAssignment::Portal(assignment) => find_chunk_with(
-                || assignment.find_chunk(dataset_url, block),
-                || assignment.get_dataset(dataset_url).unwrap().first_block(),
-            )?
-            .id()
-            .to_owned(),
+            ActiveAssignment::Portal(assignment) => portal_chunk_id(
+                find_chunk_with(
+                    || find_portal_chunk(assignment, dataset_url, block),
+                    || assignment.get_dataset(dataset_url).unwrap().first_block(),
+                )?
+                .id(),
+            )?,
         };
         chunk_id.parse().map_err(|e| {
             tracing::warn!(error = %e, "Failed to parse chunk ID");
@@ -331,12 +337,13 @@ impl StorageClient {
             )?
             .id()
             .to_owned(),
-            ActiveAssignment::Portal(assignment) => find_chunk_with(
-                || assignment.find_chunk_by_timestamp(dataset_url, ts),
-                || assignment.get_dataset(dataset_url).unwrap().first_block(),
-            )?
-            .id()
-            .to_owned(),
+            ActiveAssignment::Portal(assignment) => portal_chunk_id(
+                find_chunk_with(
+                    || assignment.find_chunk_by_timestamp(dataset_url, ts),
+                    || assignment.get_dataset(dataset_url).unwrap().first_block(),
+                )?
+                .id(),
+            )?,
         };
         chunk_id.parse().map_err(|e| {
             tracing::warn!(error = %e, "Failed to parse chunk ID");
@@ -366,15 +373,13 @@ impl StorageClient {
             }
             ActiveAssignment::Portal(assignment) => {
                 let chunk = find_chunk_with(
-                    || assignment.find_chunk(dataset_url, block),
+                    || find_portal_chunk(assignment, dataset_url, block),
                     || assignment.get_dataset(dataset_url).unwrap().first_block(),
                 )?;
-                Ok(
-                    self.filtered_worker_ids(chunk.worker_indexes().iter(), |idx| {
-                        let w = assignment.get_worker_by_index(idx);
-                        (w.status(), w.peer_id())
-                    }),
-                )
+                Ok(self.filtered_worker_ids(chunk.worker_indexes(), |idx| {
+                    let w = assignment.get_worker_by_index(idx);
+                    (w.status(), w.peer_id())
+                }))
             }
         }
     }
@@ -465,8 +470,14 @@ impl StorageClient {
                 }
             }
             ActiveAssignment::Portal(assignment) => {
-                for c in assignment.get_dataset(dataset_url)?.chunks().iter() {
-                    accumulate_range(&mut ranges, c.id(), c.worker_indexes().iter(), |idx| {
+                for c in assignment.get_dataset(dataset_url)?.chunks() {
+                    // A chunk whose hash isn't UTF-8 has no id to build a range from; reporting
+                    // the rest of the dataset beats reporting none of it.
+                    let Some(id) = c.id() else {
+                        tracing::warn!("Skipped a chunk whose hash is not valid UTF-8");
+                        continue;
+                    };
+                    accumulate_range(&mut ranges, &id, c.worker_indexes(), |idx| {
                         assignment.get_worker_id(idx)
                     });
                 }
@@ -680,6 +691,71 @@ mod tests {
             "20260807T192153_BBBB"
         ));
     }
+
+    const GAPPED_DATASET: &str = "s3://gapped-dataset";
+
+    /// Two chunks covering 0-99 and 200-299, leaving 100-199 covered by neither. Only the portal
+    /// format can express this, and only with the builder's continuity check off.
+    fn gapped_portal_assignment() -> PortalAssignment {
+        let mut builder = sqd_assignments::PortalAssignmentBuilder::new().check_continuity(false);
+        let mut dataset = builder.new_dataset(GAPPED_DATASET, 0);
+        for (first, last) in [(0u64, 99u64), (200, 299)] {
+            let staged = dataset
+                .new_chunk()
+                .id(&format!("0000000000/{first:010}-{last:010}-aaaaa"))
+                .block_range(first..=last)
+                .finish();
+            // With the check off a gap is still reported, but the chunk is staged anyway. Any
+            // other error means the test built something the reader would reject.
+            if let Err(e) = staged {
+                assert!(
+                    e.to_string().contains("must be contiguous"),
+                    "unexpected chunk build error: {e}"
+                );
+            }
+        }
+        dataset.finish(Some("0xhead")).unwrap();
+        PortalAssignment::from_owned(builder.finish()).unwrap()
+    }
+
+    #[test]
+    fn a_block_in_a_gap_resolves_to_the_next_chunk() {
+        // Ending the stream here would drop 200-299, which a worker does hold.
+        let assignment = gapped_portal_assignment();
+
+        let chunk = find_portal_chunk(&assignment, GAPPED_DATASET, 150).unwrap();
+        assert_eq!(chunk.first_block(), 200);
+    }
+
+    #[test]
+    fn the_block_after_a_chunk_crosses_the_gap() {
+        // How `next_chunk` walks a stream forward: without the skip it would return the chunk it
+        // was already on, or nothing at all.
+        let assignment = gapped_portal_assignment();
+
+        let chunk = find_portal_chunk(&assignment, GAPPED_DATASET, 100).unwrap();
+        assert_eq!(chunk.first_block(), 200);
+    }
+
+    #[test]
+    fn a_covered_block_still_resolves_to_its_own_chunk() {
+        let assignment = gapped_portal_assignment();
+
+        for (block, expected) in [(0, 0), (50, 0), (99, 0), (200, 200), (299, 200)] {
+            let chunk = find_portal_chunk(&assignment, GAPPED_DATASET, block).unwrap();
+            assert_eq!(chunk.first_block(), expected, "block {block}");
+        }
+    }
+
+    #[test]
+    fn a_block_past_the_last_chunk_is_still_after_last() {
+        let assignment = gapped_portal_assignment();
+
+        assert_eq!(
+            find_portal_chunk(&assignment, GAPPED_DATASET, 300).err(),
+            Some(sqd_assignments::ChunkNotFound::AfterLast)
+        );
+    }
 }
 
 /// Runs a per-format `find_chunk`/`find_chunk_by_timestamp` call and converts a not-found error,
@@ -702,7 +778,58 @@ fn convert_chunk_not_found(
             first_block: first_block(),
         },
         sqd_assignments::ChunkNotFound::UnknownDataset => ChunkNotFound::UnknownDataset,
+        sqd_assignments::ChunkNotFound::InGap => ChunkNotFound::InGap,
     }
+}
+
+/// A portal chunk's id is rebuilt from its columns rather than stored, and comes back `None` only
+/// when the hash it was built from isn't UTF-8 -- so there is no id to name in the error.
+fn portal_chunk_id(id: Option<String>) -> Result<String, ChunkNotFound> {
+    id.ok_or_else(|| ChunkNotFound::InvalidID("chunk hash is not valid UTF-8".to_owned()))
+}
+
+/// The chunk holding `block`, or -- when `block` falls in a gap between two chunks -- the first
+/// chunk after it.
+///
+/// Only the portal artifact can report a gap: it gives each chunk its own end rather than running
+/// it to the next chunk's start, so a block between two chunks is an answer rather than the chunk
+/// before it. A portal only ever streams forward, so the next chunk that does hold data is the
+/// useful answer -- reporting nothing would end a stream at every gap, and the legacy format
+/// could not express one to begin with.
+fn find_portal_chunk<'a>(
+    assignment: &'a PortalAssignment,
+    dataset_url: &str,
+    block: u64,
+) -> Result<sqd_assignments::PortalChunk<'a>, sqd_assignments::ChunkNotFound> {
+    match assignment.find_chunk(dataset_url, block) {
+        Err(sqd_assignments::ChunkNotFound::InGap) => {
+            let dataset = assignment
+                .get_dataset(dataset_url)
+                .expect("a gap is only reported for a dataset that was found");
+            // A gap past the last chunk is still within `last_block`, which is the dataset's head
+            // rather than the last chunk's end, so there is not always a chunk after one.
+            first_chunk_from(dataset, block).ok_or(sqd_assignments::ChunkNotFound::AfterLast)
+        }
+        other => other,
+    }
+}
+
+/// The first chunk starting at or after `block`, by bisection over `first_blocks` -- the same
+/// ascending column [`PortalAssignment::find_chunk`] bisects.
+fn first_chunk_from(
+    dataset: sqd_assignments::fb::PortalAssignmentDataset<'_>,
+    block: u64,
+) -> Option<sqd_assignments::PortalChunk<'_>> {
+    let (mut low, mut high) = (0u32, dataset.chunk_count() as u32);
+    while low < high {
+        let mid = low + (high - low) / 2;
+        if dataset.chunk(mid)?.first_block() < block {
+            low = mid + 1;
+        } else {
+            high = mid;
+        }
+    }
+    dataset.chunk(low)
 }
 
 /// Whether `candidate` is older than the applied assignment, and so must not replace it.

--- a/src/network/storage.rs
+++ b/src/network/storage.rs
@@ -51,58 +51,6 @@ enum ActiveAssignment {
     Portal(PortalAssignment),
 }
 
-/// Evaluates `$body` against whichever wire format the assignment is in.
-///
-/// The two readers are unrelated types that happen to expose the same surface, and the datasets,
-/// chunks and workers they hand back are unrelated too. A trait spanning them would need a
-/// generic associated type per returned type and four impls to bridge, all to serve an enum that
-/// exists only until the migration ends. Expanding the body once per arm instead type-checks each
-/// against its own concrete reader and costs nothing to delete afterwards.
-///
-/// Only for the paths that genuinely read the same on both. Where the formats differ -- the chunk
-/// id, the per-chunk end block -- the arms stay written out, so the difference stays visible.
-macro_rules! dispatch {
-    ($assignment:expr, |$reader:ident| $body:expr) => {
-        match $assignment {
-            ActiveAssignment::Legacy($reader) => $body,
-            ActiveAssignment::Portal($reader) => $body,
-        }
-    };
-}
-
-/// A dataset's first block, or `None` when it is absent or holds no chunks.
-///
-/// `first_block()` indexes the first chunk on both readers, so an empty dataset would panic. The
-/// scheduler has no reason to publish one, but every caller sits in the request path and a bad
-/// artifact should cost a lookup, not the task serving it.
-macro_rules! first_block_of {
-    ($assignment:expr, $dataset_url:expr) => {
-        $assignment
-            .get_dataset($dataset_url)
-            .filter(|dataset| dataset.num_chunks() > 0)
-            .map(|dataset| dataset.first_block())
-    };
-}
-
-/// The one dataset accessor the two formats spell differently -- the legacy dataset owns a chunk
-/// vector, the portal one a set of parallel columns. Naming it once is what lets the shared
-/// paths above be written once.
-trait DatasetChunks {
-    fn num_chunks(&self) -> usize;
-}
-
-impl DatasetChunks for sqd_assignments::fb::Dataset<'_> {
-    fn num_chunks(&self) -> usize {
-        self.chunks().len()
-    }
-}
-
-impl DatasetChunks for sqd_assignments::fb::PortalAssignmentDataset<'_> {
-    fn num_chunks(&self) -> usize {
-        self.chunk_count()
-    }
-}
-
 pub struct StorageClient {
     assignment: RwLock<Option<ActiveAssignment>>,
     datasets_config: Arc<RwLock<Datasets>>,
@@ -129,7 +77,7 @@ pub enum ChunkNotFound {
     #[error("Block falls in a gap between chunks")]
     InGap,
     #[error("Invalid chunk ID: {0}")]
-    InvalidId(String),
+    InvalidID(String),
 }
 
 impl StorageClient {
@@ -153,7 +101,7 @@ impl StorageClient {
                 .read_timeout(Duration::from_secs(5))
                 .user_agent(format!("SQD Portal/{}", env!("CARGO_PKG_VERSION")))
                 .build()
-                .expect("the assignment http client is configured with constants"),
+                .unwrap(),
             ignore_deprecated_workers: false,
             assignment_source: AssignmentSource::default(),
         }
@@ -169,14 +117,18 @@ impl StorageClient {
 
     pub fn num_workers(&self) -> usize {
         match self.assignment.read().as_ref() {
-            Some(assignment) => dispatch!(assignment, |a| a.workers().len()),
+            Some(ActiveAssignment::Legacy(a)) => a.workers().len(),
+            Some(ActiveAssignment::Portal(a)) => a.workers().len(),
             None => 0,
         }
     }
 
     pub async fn try_update_assignment(&self) {
-        if let Err(err) = self.update_assignment().await {
-            tracing::error!(error = ?err, "Failed to update assignment, waiting for the next one");
+        match self.update_assignment().await {
+            Ok(_) => {}
+            Err(err) => {
+                tracing::error!(error = ?err, "Failed to update assignment, waiting for the next one");
+            }
         }
     }
 
@@ -190,42 +142,37 @@ impl StorageClient {
             .inspect_err(|_| {
                 metrics::MISSING_ASSIGNMENT_SOURCE.inc();
             })?;
-        let assignment_id = selected.id.as_str();
-
-        // Scoped: it is a std lock, and the awaits below span a download plus the wait for the
-        // new assignment to take effect.
-        let had_assignment = {
-            let latest = self.latest_assignment_id.read();
-            match latest.as_deref() {
-                Some(current) if current == assignment_id => {
-                    tracing::debug!("Assignment has not been changed");
-                    return Ok(());
-                }
-                Some(current) if is_stale(current, assignment_id) => {
-                    // Applying it would move the head backwards, dropping already-advertised
-                    // chunks and opening a range no source covers. A later poll brings the newer
-                    // one back.
-                    tracing::warn!(
-                        stale_id = %assignment_id,
-                        current_id = %current,
-                        "Rejected an assignment older than the current one"
-                    );
-                    metrics::STALE_ASSIGNMENTS_REJECTED.inc();
-                    return Ok(());
-                }
-                current => current.is_some(),
-            }
-        };
-
-        let assignment = self
-            .fetch_assignment(assignment_url, self.assignment_source)
-            .await?;
-
-        if had_assignment {
-            sleep_until(selected.effective_from).await;
+        let assignment_id = selected.id.clone();
+        let effective_from = selected.effective_from;
+        let latest = self.latest_assignment_id.read().clone();
+        if latest.as_deref() == Some(assignment_id.as_str()) {
+            tracing::debug!("Assignment has not been changed");
+            return Ok(());
         }
 
-        self.set_assignment(assignment, assignment_id);
+        if let Some(latest) = &latest {
+            if is_stale(latest, &assignment_id) {
+                // Applying it would move the head backwards, dropping already-advertised chunks
+                // and opening a range no source covers. A later poll brings the newer one back.
+                tracing::warn!(
+                    stale_id = %assignment_id,
+                    current_id = %latest,
+                    "Rejected an assignment older than the current one"
+                );
+                metrics::STALE_ASSIGNMENTS_REJECTED.inc();
+                return Ok(());
+            }
+        }
+
+        let assignment = self
+            .fetch_assignment(&assignment_url, self.assignment_source)
+            .await?;
+
+        if latest.is_some() {
+            sleep_until(effective_from).await;
+        }
+
+        self.set_assignment(assignment, &assignment_id);
 
         tracing::info!("Applied assignment \"{}\"", assignment_id);
         Ok(())
@@ -284,36 +231,56 @@ impl StorageClient {
     fn set_assignment(&self, assignment: ActiveAssignment, id: &str) {
         *self.latest_assignment_id.write() = Some(id.to_owned());
 
-        let workers_len = {
-            // Scoped: the swap below takes the write lock, and `prev_counts` borrows the reader
-            // this guard protects.
-            let prev = self.assignment.read();
-            let prev_counts = prev.as_ref().map(chunk_counts).unwrap_or_default();
-            dispatch!(&assignment, |a| {
-                self.report_datasets(
-                    a.datasets()
+        let prev = self.assignment.read();
+        let workers_len = match &assignment {
+            ActiveAssignment::Legacy(assignment) => {
+                self.update_datasets(
+                    assignment
+                        .datasets()
                         .iter()
-                        .map(|d| (d.id(), d.num_chunks(), d.last_block())),
-                    &prev_counts,
+                        .map(|d| (d.id(), d.chunks().len(), d.last_block())),
+                    |id| match prev.as_ref() {
+                        Some(ActiveAssignment::Legacy(p)) => {
+                            p.get_dataset(id).map(|d| d.chunks().len())
+                        }
+                        _ => None,
+                    },
                 );
-                a.workers().len()
-            })
+                assignment.workers().len()
+            }
+            ActiveAssignment::Portal(assignment) => {
+                self.update_datasets(
+                    assignment
+                        .datasets()
+                        .iter()
+                        .map(|d| (d.id(), d.chunk_count(), d.last_block())),
+                    |id| match prev.as_ref() {
+                        Some(ActiveAssignment::Portal(p)) => {
+                            p.get_dataset(id).map(|d| d.chunk_count())
+                        }
+                        _ => None,
+                    },
+                );
+                assignment.workers().len()
+            }
         };
+        drop(prev);
 
-        metrics::KNOWN_WORKERS.set(i64::try_from(workers_len).unwrap_or(i64::MAX));
+        crate::metrics::KNOWN_WORKERS.set(workers_len as i64);
 
         *self.assignment.write() = Some(assignment);
     }
 
-    /// Reports each dataset's new chunk count against `prev_counts`, the counts read off the
-    /// assignment being replaced.
-    fn report_datasets<'a>(
+    /// Reports each dataset's new chunk count against its previous one (`prev_len`, keyed by
+    /// dataset id), shared across both assignment formats -- the only thing that differs between
+    /// them is how `(id, new_len, last_block)` and `prev_len` are looked up.
+    fn update_datasets<'a>(
         &self,
         datasets_info: impl Iterator<Item = (&'a str, usize, u64)>,
-        prev_counts: &HashMap<&str, usize>,
+        prev_len: impl Fn(&str) -> Option<usize>,
     ) {
         for (dataset_url, new_len, last_block) in datasets_info {
-            let old_len = prev_counts.get(dataset_url).copied().unwrap_or(0);
+            let old_len = prev_len(dataset_url).unwrap_or(0);
             let dataset_id = DatasetId::from_url(dataset_url);
             if old_len < new_len {
                 tracing::info!(
@@ -336,18 +303,24 @@ impl StorageClient {
         let dataset_url = dataset.to_url();
         let guard = self.assignment.read();
         let chunk_id = match guard.as_ref().ok_or(ChunkNotFound::UnknownDataset)? {
-            ActiveAssignment::Legacy(a) => a
-                .find_chunk(dataset_url, block)
-                .map_err(|e| convert_chunk_not_found(e, || first_block_of!(a, dataset_url)))?
-                .id()
-                .to_owned(),
-            ActiveAssignment::Portal(a) => portal_chunk_id(
-                find_portal_chunk(a, dataset_url, block)
-                    .map_err(|e| convert_chunk_not_found(e, || first_block_of!(a, dataset_url)))?
-                    .id(),
+            ActiveAssignment::Legacy(assignment) => find_chunk_with(
+                || assignment.find_chunk(dataset_url, block),
+                || legacy_first_block(assignment, dataset_url).unwrap_or(0),
+            )?
+            .id()
+            .to_owned(),
+            ActiveAssignment::Portal(assignment) => portal_chunk_id(
+                find_chunk_with(
+                    || find_portal_chunk(assignment, dataset_url, block),
+                    || portal_first_block(assignment, dataset_url).unwrap_or(0),
+                )?
+                .id(),
             )?,
         };
-        parse_chunk_id(&chunk_id)
+        chunk_id.parse().map_err(|e| {
+            tracing::warn!(error = %e, "Failed to parse chunk ID");
+            ChunkNotFound::InvalidID(chunk_id)
+        })
     }
 
     pub fn find_chunk_by_timestamp(
@@ -358,18 +331,24 @@ impl StorageClient {
         let dataset_url = dataset.to_url();
         let guard = self.assignment.read();
         let chunk_id = match guard.as_ref().ok_or(ChunkNotFound::UnknownDataset)? {
-            ActiveAssignment::Legacy(a) => a
-                .find_chunk_by_timestamp(dataset_url, ts)
-                .map_err(|e| convert_chunk_not_found(e, || first_block_of!(a, dataset_url)))?
-                .id()
-                .to_owned(),
-            ActiveAssignment::Portal(a) => portal_chunk_id(
-                a.find_chunk_by_timestamp(dataset_url, ts)
-                    .map_err(|e| convert_chunk_not_found(e, || first_block_of!(a, dataset_url)))?
-                    .id(),
+            ActiveAssignment::Legacy(assignment) => find_chunk_with(
+                || assignment.find_chunk_by_timestamp(dataset_url, ts),
+                || legacy_first_block(assignment, dataset_url).unwrap_or(0),
+            )?
+            .id()
+            .to_owned(),
+            ActiveAssignment::Portal(assignment) => portal_chunk_id(
+                find_chunk_with(
+                    || assignment.find_chunk_by_timestamp(dataset_url, ts),
+                    || portal_first_block(assignment, dataset_url).unwrap_or(0),
+                )?
+                .id(),
             )?,
         };
-        parse_chunk_id(&chunk_id)
+        chunk_id.parse().map_err(|e| {
+            tracing::warn!(error = %e, "Failed to parse chunk ID");
+            ChunkNotFound::InvalidID(chunk_id)
+        })
     }
 
     pub fn find_workers(
@@ -380,22 +359,25 @@ impl StorageClient {
         let dataset_url = dataset.to_url();
         let guard = self.assignment.read();
         match guard.as_ref().ok_or(ChunkNotFound::UnknownDataset)? {
-            ActiveAssignment::Legacy(a) => {
-                let chunk = a
-                    .find_chunk(dataset_url, block)
-                    .map_err(|e| convert_chunk_not_found(e, || first_block_of!(a, dataset_url)))?;
+            ActiveAssignment::Legacy(assignment) => {
+                let chunk = find_chunk_with(
+                    || assignment.find_chunk(dataset_url, block),
+                    || legacy_first_block(assignment, dataset_url).unwrap_or(0),
+                )?;
                 Ok(
                     self.filtered_worker_ids(chunk.worker_indexes().iter(), |idx| {
-                        let w = a.get_worker_by_index(idx);
+                        let w = assignment.get_worker_by_index(idx);
                         (w.status(), w.peer_id())
                     }),
                 )
             }
-            ActiveAssignment::Portal(a) => {
-                let chunk = find_portal_chunk(a, dataset_url, block)
-                    .map_err(|e| convert_chunk_not_found(e, || first_block_of!(a, dataset_url)))?;
+            ActiveAssignment::Portal(assignment) => {
+                let chunk = find_chunk_with(
+                    || find_portal_chunk(assignment, dataset_url, block),
+                    || portal_first_block(assignment, dataset_url).unwrap_or(0),
+                )?;
                 Ok(self.filtered_worker_ids(chunk.worker_indexes(), |idx| {
-                    let w = a.get_worker_by_index(idx);
+                    let w = assignment.get_worker_by_index(idx);
                     (w.status(), w.peer_id())
                 }))
             }
@@ -433,34 +415,49 @@ impl StorageClient {
 
     pub fn first_block(&self, dataset: &DatasetId) -> Option<BlockNumber> {
         let dataset_url = dataset.to_url();
-        let guard = self.assignment.read();
-        dispatch!(guard.as_ref()?, |a| first_block_of!(a, dataset_url))
+        match self.assignment.read().as_ref()? {
+            ActiveAssignment::Legacy(a) => legacy_first_block(a, dataset_url),
+            ActiveAssignment::Portal(a) => portal_first_block(a, dataset_url),
+        }
     }
 
     pub fn head(&self, dataset: &DatasetId) -> Option<BlockRef> {
         let dataset_url = dataset.to_url();
-        let guard = self.assignment.read();
-        dispatch!(guard.as_ref()?, |a| {
-            let dataset = a.get_dataset(dataset_url)?;
-            // The legacy reader takes the head hash off the last chunk, so an empty dataset
-            // would index out of bounds. It has no head to report either way.
-            if dataset.num_chunks() == 0 {
-                return None;
+        match self.assignment.read().as_ref()? {
+            ActiveAssignment::Legacy(a) => {
+                let dataset = a.get_dataset(dataset_url)?;
+                // Reads the last chunk, which an empty dataset does not have -- and it has no
+                // head to report either way.
+                if dataset.chunks().is_empty() {
+                    return None;
+                }
+                dataset.last_block_hash().map(|hash| BlockRef {
+                    hash: hash.to_owned(),
+                    number: dataset.last_block(),
+                })
             }
-            dataset.last_block_hash().map(|hash| BlockRef {
-                hash: hash.to_owned(),
-                number: dataset.last_block(),
-            })
-        })
+            ActiveAssignment::Portal(a) => {
+                let dataset = a.get_dataset(dataset_url)?;
+                dataset.last_block_hash().map(|hash| BlockRef {
+                    hash: hash.to_owned(),
+                    number: dataset.last_block(),
+                })
+            }
+        }
     }
 
     pub fn get_all_workers(&self) -> Vec<PeerId> {
         match self.assignment.read().as_ref() {
-            Some(assignment) => dispatch!(assignment, |a| a
+            Some(ActiveAssignment::Legacy(a)) => a
                 .workers()
                 .iter()
                 .filter_map(|w| (*w.worker_id()).try_into().ok())
-                .collect()),
+                .collect(),
+            Some(ActiveAssignment::Portal(a)) => a
+                .workers()
+                .iter()
+                .filter_map(|w| (*w.worker_id()).try_into().ok())
+                .collect(),
             None => Vec::new(),
         }
     }
@@ -468,50 +465,38 @@ impl StorageClient {
     #[instrument(skip(self))]
     pub fn get_dataset_state(&self, dataset: &DatasetId) -> Option<DatasetState> {
         let dataset_url = dataset.to_url();
-        let mut ranges: HashMap<PeerId, Vec<sqd_messages::Range>> = HashMap::new();
-        let mut unparsed_chunks = 0usize;
-        let guard = self.assignment.read();
-        match guard.as_ref()? {
-            ActiveAssignment::Legacy(a) => {
-                for c in a.get_dataset(dataset_url)?.chunks().iter() {
-                    // A legacy chunk carries no end block, so its id is the only place to read
-                    // one from -- and the id is wire data, so one bad chunk must not sink the
+        let mut ranges: HashMap<_, Vec<_>> = HashMap::new();
+        match self.assignment.read().as_ref()? {
+            ActiveAssignment::Legacy(assignment) => {
+                for c in assignment.get_dataset(dataset_url)?.chunks().iter() {
+                    // A legacy chunk has no end block of its own, so its id is the only place to
+                    // read one from -- and ids are wire data, so a bad one must not sink the
                     // whole dataset's state.
-                    let Ok(chunk) = c.id().parse::<DataChunk>() else {
-                        unparsed_chunks += 1;
-                        continue;
+                    let range = match c.id().parse::<DataChunk>() {
+                        Ok(chunk) => chunk.range_msg(),
+                        Err(e) => {
+                            tracing::warn!(error = %e, "Skipped a chunk with an unparseable ID");
+                            continue;
+                        }
                     };
-                    accumulate_range(
-                        &mut ranges,
-                        chunk.range_msg(),
-                        c.worker_indexes().iter(),
-                        |idx| a.get_worker_id(idx),
-                    );
+                    accumulate_range(&mut ranges, range, c.worker_indexes().iter(), |idx| {
+                        assignment.get_worker_id(idx)
+                    });
                 }
             }
-            ActiveAssignment::Portal(a) => {
-                for c in a.get_dataset(dataset_url)?.chunks() {
-                    // Both ends are columns here, so the range needs no id. Rebuilding one to
-                    // parse it straight back would allocate per chunk and add the only way this
-                    // loop can fail -- a hash that isn't UTF-8 yields no id.
+            ActiveAssignment::Portal(assignment) => {
+                for c in assignment.get_dataset(dataset_url)?.chunks() {
+                    // Both ends are columns here, so the range needs no id: no rebuild, no parse,
+                    // and nothing to skip when a chunk's hash isn't UTF-8.
                     let range = sqd_messages::Range {
                         begin: c.first_block(),
                         end: c.last_block(),
                     };
                     accumulate_range(&mut ranges, range, c.worker_indexes(), |idx| {
-                        a.get_worker_id(idx)
+                        assignment.get_worker_id(idx)
                     });
                 }
             }
-        }
-        if unparsed_chunks > 0 {
-            // Counted and reported once: a format change makes every chunk fail, and a warning
-            // per chunk would bury the rest of the log.
-            tracing::warn!(
-                dataset = %dataset,
-                unparsed_chunks,
-                "Skipped chunks with unparseable IDs"
-            );
         }
         Some(DatasetState {
             worker_ranges: ranges
@@ -520,16 +505,6 @@ impl StorageClient {
                 .collect(),
         })
     }
-}
-
-/// Chunk count per dataset url, read off an assignment before it is replaced so the new-chunks
-/// delta survives the swap.
-fn chunk_counts(assignment: &ActiveAssignment) -> HashMap<&str, usize> {
-    dispatch!(assignment, |a| a
-        .datasets()
-        .iter()
-        .map(|d| (d.id(), d.num_chunks()))
-        .collect())
 }
 
 fn accumulate_range(
@@ -561,12 +536,12 @@ fn accumulate_range(
 fn usable_assignment(
     network_state: &sqd_assignments::NetworkState,
     source: AssignmentSource,
-) -> anyhow::Result<(&NetworkAssignment, &str)> {
+) -> anyhow::Result<(&NetworkAssignment, String)> {
     let selected = select_assignment(network_state, source)
         .ok_or_else(|| anyhow!("network state publishes no {source} assignment"))?;
     let url = selected
         .fb_url_v1
-        .as_deref()
+        .clone()
         .ok_or_else(|| anyhow!("the {source} assignment carries no fb_url_v1"))?;
     Ok((selected, url))
 }
@@ -584,126 +559,6 @@ fn select_assignment(
     match source {
         AssignmentSource::Legacy => network_state.assignment.as_ref(),
         AssignmentSource::Portal => network_state.portal_assignment.as_ref(),
-    }
-}
-
-/// A chunk id as published, or a routing failure -- the id is wire data, not an invariant.
-fn parse_chunk_id(chunk_id: &str) -> Result<DataChunk, ChunkNotFound> {
-    chunk_id.parse().map_err(|e| {
-        tracing::warn!(error = %e, "Failed to parse chunk ID");
-        ChunkNotFound::InvalidId(chunk_id.to_owned())
-    })
-}
-
-/// `first_block` is only consulted for [`BeforeFirst`], and reads as 0 when the dataset turns out
-/// to be absent or empty -- 0 is the only answer that cannot exclude a block that does exist.
-///
-/// [`BeforeFirst`]: ChunkNotFound::BeforeFirst
-fn convert_chunk_not_found(
-    e: sqd_assignments::ChunkNotFound,
-    first_block: impl FnOnce() -> Option<u64>,
-) -> ChunkNotFound {
-    match e {
-        sqd_assignments::ChunkNotFound::AfterLast => ChunkNotFound::AfterLast,
-        sqd_assignments::ChunkNotFound::BeforeFirst => ChunkNotFound::BeforeFirst {
-            first_block: first_block().unwrap_or(0),
-        },
-        sqd_assignments::ChunkNotFound::UnknownDataset => ChunkNotFound::UnknownDataset,
-        sqd_assignments::ChunkNotFound::InGap => ChunkNotFound::InGap,
-    }
-}
-
-/// A portal chunk's id is rebuilt from its columns rather than stored, and comes back `None` only
-/// when the hash it was built from isn't UTF-8 -- so there is no id to name in the error.
-fn portal_chunk_id(id: Option<String>) -> Result<String, ChunkNotFound> {
-    id.ok_or_else(|| ChunkNotFound::InvalidId("chunk hash is not valid UTF-8".to_owned()))
-}
-
-/// The chunk holding `block`, or -- when `block` falls in a gap between two chunks -- the first
-/// chunk after it.
-///
-/// Only the portal artifact can report a gap: it gives each chunk its own end rather than running
-/// it to the next chunk's start, so a block between two chunks is an answer rather than the chunk
-/// before it. A portal only ever streams forward, so the next chunk that does hold data is the
-/// useful answer -- reporting nothing would end a stream at every gap, and the legacy format
-/// could not express one to begin with.
-fn find_portal_chunk<'a>(
-    assignment: &'a PortalAssignment,
-    dataset_url: &str,
-    block: u64,
-) -> Result<sqd_assignments::PortalChunk<'a>, sqd_assignments::ChunkNotFound> {
-    match assignment.find_chunk(dataset_url, block) {
-        Err(sqd_assignments::ChunkNotFound::InGap) => {
-            let dataset = assignment
-                .get_dataset(dataset_url)
-                .expect("a gap is only reported for a dataset that was found");
-            // A gap past the last chunk is still within `last_block`, which is the dataset's head
-            // rather than the last chunk's end, so there is not always a chunk after one.
-            first_chunk_from(dataset, block).ok_or(sqd_assignments::ChunkNotFound::AfterLast)
-        }
-        other => other,
-    }
-}
-
-/// The first chunk starting at or after `block`, by bisection over `first_blocks` -- the same
-/// ascending column [`PortalAssignment::find_chunk`] bisects.
-fn first_chunk_from(
-    dataset: sqd_assignments::fb::PortalAssignmentDataset<'_>,
-    block: u64,
-) -> Option<sqd_assignments::PortalChunk<'_>> {
-    // `chunk` addresses chunks by u32, so anything above that is unreachable regardless -- and
-    // saturating searches as much of the dataset as can be named, where `as` would wrap and
-    // silently search a prefix of it.
-    let (mut low, mut high) = (
-        0u32,
-        u32::try_from(dataset.chunk_count()).unwrap_or(u32::MAX),
-    );
-    while low < high {
-        let mid = low + (high - low) / 2;
-        if dataset.chunk(mid)?.first_block() < block {
-            low = mid + 1;
-        } else {
-            high = mid;
-        }
-    }
-    dataset.chunk(low)
-}
-
-/// Whether `candidate` is older than the applied assignment, and so must not replace it.
-///
-/// Ids are `<timestamp>_<hash>` with a fixed-width timestamp, so prefixes order lexicographically.
-/// The hash is excluded: it carries no ordering, and would order same-second ids arbitrarily.
-///
-/// Both ids always come from the same source, which is fixed for the process lifetime, so they are
-/// always drawn from one sequence and directly comparable.
-///
-/// Every uncertain case returns false. Wrongly accepting costs one poll; wrongly rejecting freezes
-/// the head until restart.
-fn is_stale(applied_id: &str, candidate: &str) -> bool {
-    let (Some(current), Some(new)) = (timestamp_prefix(applied_id), timestamp_prefix(candidate))
-    else {
-        return false;
-    };
-    // Differing lengths mean differing formats, which lexicographic order cannot span.
-    if current.len() != new.len() {
-        return false;
-    }
-    new < current
-}
-
-/// The ordering-bearing prefix of an id, or `None` if it isn't shaped `<timestamp>_<hash>`.
-fn timestamp_prefix(id: &str) -> Option<&str> {
-    let (timestamp, hash) = id.split_once('_')?;
-    (!timestamp.is_empty() && !hash.is_empty()).then_some(timestamp)
-}
-
-async fn sleep_until(timestamp: u64) {
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::SystemTime::UNIX_EPOCH)
-        .expect("time should be after 1970");
-    let until = Duration::from_secs(timestamp);
-    if let Some(delta) = until.checked_sub(now) {
-        tokio::time::sleep(delta).await;
     }
 }
 
@@ -917,34 +772,142 @@ mod tests {
     }
 
     #[test]
-    fn an_unparseable_chunk_id_is_a_routing_failure() {
-        // Ids are wire data: a malformed one must surface as a miss, not a panic.
-        let err = parse_chunk_id("not-a-chunk-id").unwrap_err();
-
-        assert!(matches!(err, ChunkNotFound::InvalidId(id) if id == "not-a-chunk-id"));
-    }
-
-    #[test]
-    fn an_unknown_first_block_reads_as_zero() {
-        // BeforeFirst names the block a client should start from. An absent or empty dataset has
-        // none, and 0 is the only answer that cannot exclude a block that does exist.
-        let converted =
-            convert_chunk_not_found(sqd_assignments::ChunkNotFound::BeforeFirst, || None);
-
-        assert!(matches!(
-            converted,
-            ChunkNotFound::BeforeFirst { first_block: 0 }
-        ));
-    }
-
-    #[test]
-    fn a_dataset_that_was_not_published_has_no_first_block() {
-        // The `num_chunks` half of the same guard can't be exercised from here -- the builder
-        // rejects an empty dataset -- but the portal reads downloaded bytes through
-        // `from_owned_unchecked`, so nothing rejects one on the way in either.
+    fn an_unpublished_dataset_has_no_first_block() {
+        // The empty-chunks half of the same guard can't be built here -- the builder rejects an
+        // empty dataset -- but the portal reads downloaded bytes with `from_owned_unchecked`, so
+        // nothing rejects one on the way in either.
         let assignment = gapped_portal_assignment();
 
-        assert_eq!(first_block_of!(&assignment, GAPPED_DATASET), Some(0));
-        assert_eq!(first_block_of!(&assignment, "s3://never-published"), None);
+        assert_eq!(portal_first_block(&assignment, GAPPED_DATASET), Some(0));
+        assert_eq!(
+            portal_first_block(&assignment, "s3://never-published"),
+            None
+        );
+    }
+}
+
+/// Runs a per-format `find_chunk`/`find_chunk_by_timestamp` call and converts a not-found error,
+/// generic over the chunk type so both `Assignment` and `PortalAssignment` share this instead of
+/// duplicating the `map_err` wrapping in each match arm.
+fn find_chunk_with<C>(
+    find: impl FnOnce() -> Result<C, sqd_assignments::ChunkNotFound>,
+    first_block: impl FnOnce() -> u64,
+) -> Result<C, ChunkNotFound> {
+    find().map_err(|e| convert_chunk_not_found(e, first_block))
+}
+
+fn convert_chunk_not_found(
+    e: sqd_assignments::ChunkNotFound,
+    first_block: impl FnOnce() -> u64,
+) -> ChunkNotFound {
+    match e {
+        sqd_assignments::ChunkNotFound::AfterLast => ChunkNotFound::AfterLast,
+        sqd_assignments::ChunkNotFound::BeforeFirst => ChunkNotFound::BeforeFirst {
+            first_block: first_block(),
+        },
+        sqd_assignments::ChunkNotFound::UnknownDataset => ChunkNotFound::UnknownDataset,
+        sqd_assignments::ChunkNotFound::InGap => ChunkNotFound::InGap,
+    }
+}
+
+/// A portal chunk's id is rebuilt from its columns rather than stored, and comes back `None` only
+/// when the hash it was built from isn't UTF-8 -- so there is no id to name in the error.
+fn portal_chunk_id(id: Option<String>) -> Result<String, ChunkNotFound> {
+    id.ok_or_else(|| ChunkNotFound::InvalidID("chunk hash is not valid UTF-8".to_owned()))
+}
+
+/// A dataset's first block, or `None` when it holds no chunks -- `first_block()` reads chunk 0 on
+/// both readers, so an empty dataset panics them. Only a malformed artifact has one, but the
+/// portal parses downloaded bytes with `from_owned_unchecked`, so nothing rejects one on the way
+/// in and the callers sit in the request path.
+fn legacy_first_block(assignment: &Assignment, dataset_url: &str) -> Option<u64> {
+    let dataset = assignment.get_dataset(dataset_url)?;
+    (!dataset.chunks().is_empty()).then(|| dataset.first_block())
+}
+
+fn portal_first_block(assignment: &PortalAssignment, dataset_url: &str) -> Option<u64> {
+    let dataset = assignment.get_dataset(dataset_url)?;
+    (dataset.chunk_count() > 0).then(|| dataset.first_block())
+}
+
+/// The chunk holding `block`, or -- when `block` falls in a gap between two chunks -- the first
+/// chunk after it.
+///
+/// Only the portal artifact can report a gap: it gives each chunk its own end rather than running
+/// it to the next chunk's start, so a block between two chunks is an answer rather than the chunk
+/// before it. A portal only ever streams forward, so the next chunk that does hold data is the
+/// useful answer -- reporting nothing would end a stream at every gap, and the legacy format
+/// could not express one to begin with.
+fn find_portal_chunk<'a>(
+    assignment: &'a PortalAssignment,
+    dataset_url: &str,
+    block: u64,
+) -> Result<sqd_assignments::PortalChunk<'a>, sqd_assignments::ChunkNotFound> {
+    match assignment.find_chunk(dataset_url, block) {
+        Err(sqd_assignments::ChunkNotFound::InGap) => {
+            let dataset = assignment
+                .get_dataset(dataset_url)
+                .expect("a gap is only reported for a dataset that was found");
+            // A gap past the last chunk is still within `last_block`, which is the dataset's head
+            // rather than the last chunk's end, so there is not always a chunk after one.
+            first_chunk_from(dataset, block).ok_or(sqd_assignments::ChunkNotFound::AfterLast)
+        }
+        other => other,
+    }
+}
+
+/// The first chunk starting at or after `block`, by bisection over `first_blocks` -- the same
+/// ascending column [`PortalAssignment::find_chunk`] bisects.
+fn first_chunk_from(
+    dataset: sqd_assignments::fb::PortalAssignmentDataset<'_>,
+    block: u64,
+) -> Option<sqd_assignments::PortalChunk<'_>> {
+    let (mut low, mut high) = (0u32, dataset.chunk_count() as u32);
+    while low < high {
+        let mid = low + (high - low) / 2;
+        if dataset.chunk(mid)?.first_block() < block {
+            low = mid + 1;
+        } else {
+            high = mid;
+        }
+    }
+    dataset.chunk(low)
+}
+
+/// Whether `candidate` is older than the applied assignment, and so must not replace it.
+///
+/// Ids are `<timestamp>_<hash>` with a fixed-width timestamp, so prefixes order lexicographically.
+/// The hash is excluded: it carries no ordering, and would order same-second ids arbitrarily.
+///
+/// Both ids always come from the same source, which is fixed for the process lifetime, so they are
+/// always drawn from one sequence and directly comparable.
+///
+/// Every uncertain case returns false. Wrongly accepting costs one poll; wrongly rejecting freezes
+/// the head until restart.
+fn is_stale(applied_id: &str, candidate: &str) -> bool {
+    let (Some(current), Some(new)) = (timestamp_prefix(applied_id), timestamp_prefix(candidate))
+    else {
+        return false;
+    };
+    // Differing lengths mean differing formats, which lexicographic order cannot span.
+    if current.len() != new.len() {
+        return false;
+    }
+    new < current
+}
+
+/// The ordering-bearing prefix of an id, or `None` if it isn't shaped `<timestamp>_<hash>`.
+fn timestamp_prefix(id: &str) -> Option<&str> {
+    let (timestamp, hash) = id.split_once('_')?;
+    (!timestamp.is_empty() && !hash.is_empty()).then_some(timestamp)
+}
+
+async fn sleep_until(timestamp: u64) {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .expect("time should be after 1970");
+    let until = Duration::from_secs(timestamp);
+    if let Some(delta) = until.checked_sub(now) {
+        tokio::time::sleep(delta).await;
     }
 }

--- a/src/network/storage.rs
+++ b/src/network/storage.rs
@@ -550,9 +550,6 @@ fn select_assignment(
     }
 }
 
-/// Runs a per-format `find_chunk`/`find_chunk_by_timestamp` call and converts a not-found error,
-/// generic over the chunk type so both `Assignment` and `PortalAssignment` share this instead of
-/// duplicating the `map_err` wrapping in each match arm.
 fn find_chunk_with<C>(
     find: impl FnOnce() -> Result<C, sqd_assignments::ChunkNotFound>,
     first_block: impl FnOnce() -> u64,
@@ -598,8 +595,6 @@ impl ArtifactCodec {
     }
 }
 
-/// Reads an artifact body, decompressing it as `codec` while it streams: the compressed copy is
-/// never held whole, which on mainnet is the difference of a P-ASSIGNMENT-SIZE allocation.
 async fn decompress_artifact(
     body: impl tokio::io::AsyncBufRead + Unpin,
     codec: ArtifactCodec,
@@ -616,8 +611,6 @@ async fn decompress_artifact(
     Ok(buf)
 }
 
-/// The legacy chunk stores its id, and stores no end block of its own, so parsing it is the only
-/// way to a `DataChunk`.
 fn parse_chunk_id(chunk_id: &str) -> Result<DataChunk, ChunkNotFound> {
     chunk_id.parse().map_err(|e| {
         tracing::warn!(error = %e, "Failed to parse chunk ID");
@@ -625,8 +618,6 @@ fn parse_chunk_id(chunk_id: &str) -> Result<DataChunk, ChunkNotFound> {
     })
 }
 
-/// A portal chunk holds those same fields as columns, so the `DataChunk` is built from them.
-/// Its `id()` would format the four into a string that `DataChunk` immediately takes apart again.
 fn portal_data_chunk(chunk: sqd_assignments::PortalChunk<'_>) -> Result<DataChunk, ChunkNotFound> {
     let hash = chunk
         .hash()
@@ -680,8 +671,6 @@ fn find_portal_chunk<'a>(
     }
 }
 
-/// The first chunk starting at or after `block`, by bisection over `first_blocks` -- the same
-/// ascending column [`PortalAssignment::find_chunk`] bisects.
 fn first_chunk_from(
     dataset: sqd_assignments::fb::PortalAssignmentDataset<'_>,
     block: u64,
@@ -882,8 +871,6 @@ mod tests {
 
     const GAPPED_DATASET: &str = "s3://gapped-dataset";
 
-    /// Two chunks covering 0-99 and 200-299, leaving 100-199 covered by neither. Only the portal
-    /// format can express this, and only with the builder's continuity check off.
     fn gapped_portal_assignment() -> PortalAssignment {
         let mut builder = sqd_assignments::PortalAssignmentBuilder::new().check_continuity(false);
         let mut dataset = builder.new_dataset(GAPPED_DATASET, 0);
@@ -906,8 +893,6 @@ mod tests {
         PortalAssignment::from_owned(builder.finish()).unwrap()
     }
 
-    /// The same two chunks in the legacy format. Its `Dataset` has no per-chunk end block, so
-    /// nothing here marks 100-199 as absent -- the hole exists only because the ids say so.
     fn gapped_legacy_assignment() -> Assignment {
         let mut builder =
             sqd_assignments::AssignmentBuilder::new("test-secret").check_continuity(false);
@@ -935,7 +920,6 @@ mod tests {
         Assignment::from_owned(builder.finish()).unwrap()
     }
 
-    /// A one-chunk dataset whose chunk is a re-ingested copy, so its version is not the default.
     fn versioned_portal_assignment() -> PortalAssignment {
         let mut builder = sqd_assignments::PortalAssignmentBuilder::new();
         let mut dataset = builder.new_dataset(GAPPED_DATASET, 0);
@@ -952,9 +936,6 @@ mod tests {
 
     #[test]
     fn only_a_portal_chunk_carries_a_version() {
-        // A query names the copy it wants, and only this artifact says which copy that is. A
-        // legacy chunk has no such column, so it stays at 0 -- the value proto3 leaves off the
-        // wire, which is how the field is absent rather than guessed.
         let portal = versioned_portal_assignment();
         let legacy = gapped_legacy_assignment();
 
@@ -965,25 +946,19 @@ mod tests {
 
         assert_eq!(portal_chunk.version(), 7);
         assert_eq!(legacy_chunk.version(), 0);
-        // The version rides beside the id, never inside it: both name the same chunk.
         assert_eq!(portal_chunk.to_string(), legacy_chunk.to_string());
     }
 
     #[test]
     fn the_two_formats_resolve_the_same_gap_in_opposite_directions() {
-        // The behavioural difference this branch turns on, asserted rather than described.
         let legacy = gapped_legacy_assignment();
         let portal = gapped_portal_assignment();
 
         let legacy_chunk = legacy.find_chunk(GAPPED_DATASET, 150).unwrap();
         let portal_chunk = find_portal_chunk(&portal, GAPPED_DATASET, 150).unwrap();
 
-        // Legacy resolves backward, to the chunk before the hole: it holds no block 150, and
-        // its own id says so -- 0-99 ends well short of the request.
         assert_eq!(legacy_chunk.first_block(), 0);
         assert_eq!(legacy_chunk.id(), "0000000000/0000000000-0000000099-aaaaa");
-        // The portal reader sees the per-chunk end, calls it a gap, and resolves forward to the
-        // next chunk that does hold data.
         assert_eq!(portal_chunk.first_block(), 200);
     }
 
@@ -1005,7 +980,6 @@ mod tests {
 
     #[test]
     fn a_block_in_a_gap_resolves_to_the_next_chunk() {
-        // Ending the stream here would drop 200-299, which a worker does hold.
         let assignment = gapped_portal_assignment();
 
         let chunk = find_portal_chunk(&assignment, GAPPED_DATASET, 150).unwrap();
@@ -1048,9 +1022,6 @@ mod tests {
 
     #[test]
     fn a_portal_chunk_builds_to_what_its_id_parses_to() {
-        // `id()` formats the same four values `DataChunk` holds, so building from the columns
-        // must land on exactly the chunk the round-trip produced -- `top` included, which is a
-        // run lookup rather than a plain column.
         let assignment = gapped_portal_assignment();
 
         for block in [0, 250] {
@@ -1086,7 +1057,6 @@ mod tests {
 
     #[tokio::test]
     async fn an_artifact_is_read_gzipped_or_zstd_compressed() {
-        // Long enough that neither codec's output is the payload itself.
         let payload = b"portal assignment bytes".repeat(64);
 
         for codec in [ArtifactCodec::Gzip, ArtifactCodec::Zstd] {
@@ -1102,8 +1072,6 @@ mod tests {
 
     #[tokio::test]
     async fn an_artifact_compressed_the_other_way_is_refused() {
-        // The suffix is trusted, so a publisher that mislabels one fails the fetch and keeps the
-        // assignment already in service, rather than feeding the reader whatever came out.
         let body = compress(b"portal assignment bytes", ArtifactCodec::Zstd).await;
 
         let err = decompress_artifact(std::io::Cursor::new(body), ArtifactCodec::Gzip)

--- a/src/network/storage.rs
+++ b/src/network/storage.rs
@@ -302,25 +302,19 @@ impl StorageClient {
     pub fn find_chunk(&self, dataset: &DatasetId, block: u64) -> Result<DataChunk, ChunkNotFound> {
         let dataset_url = dataset.to_url();
         let guard = self.assignment.read();
-        let chunk_id = match guard.as_ref().ok_or(ChunkNotFound::UnknownDataset)? {
-            ActiveAssignment::Legacy(assignment) => find_chunk_with(
-                || assignment.find_chunk(dataset_url, block),
-                || legacy_first_block(assignment, dataset_url).unwrap_or(0),
-            )?
-            .id()
-            .to_owned(),
-            ActiveAssignment::Portal(assignment) => portal_chunk_id(
+        match guard.as_ref().ok_or(ChunkNotFound::UnknownDataset)? {
+            ActiveAssignment::Legacy(assignment) => parse_chunk_id(
                 find_chunk_with(
-                    || find_portal_chunk(assignment, dataset_url, block),
-                    || portal_first_block(assignment, dataset_url).unwrap_or(0),
+                    || assignment.find_chunk(dataset_url, block),
+                    || legacy_first_block(assignment, dataset_url).unwrap_or(0),
                 )?
                 .id(),
-            )?,
-        };
-        chunk_id.parse().map_err(|e| {
-            tracing::warn!(error = %e, "Failed to parse chunk ID");
-            ChunkNotFound::InvalidID(chunk_id)
-        })
+            ),
+            ActiveAssignment::Portal(assignment) => portal_data_chunk(find_chunk_with(
+                || find_portal_chunk(assignment, dataset_url, block),
+                || portal_first_block(assignment, dataset_url).unwrap_or(0),
+            )?),
+        }
     }
 
     pub fn find_chunk_by_timestamp(
@@ -330,25 +324,19 @@ impl StorageClient {
     ) -> Result<DataChunk, ChunkNotFound> {
         let dataset_url = dataset.to_url();
         let guard = self.assignment.read();
-        let chunk_id = match guard.as_ref().ok_or(ChunkNotFound::UnknownDataset)? {
-            ActiveAssignment::Legacy(assignment) => find_chunk_with(
-                || assignment.find_chunk_by_timestamp(dataset_url, ts),
-                || legacy_first_block(assignment, dataset_url).unwrap_or(0),
-            )?
-            .id()
-            .to_owned(),
-            ActiveAssignment::Portal(assignment) => portal_chunk_id(
+        match guard.as_ref().ok_or(ChunkNotFound::UnknownDataset)? {
+            ActiveAssignment::Legacy(assignment) => parse_chunk_id(
                 find_chunk_with(
                     || assignment.find_chunk_by_timestamp(dataset_url, ts),
-                    || portal_first_block(assignment, dataset_url).unwrap_or(0),
+                    || legacy_first_block(assignment, dataset_url).unwrap_or(0),
                 )?
                 .id(),
-            )?,
-        };
-        chunk_id.parse().map_err(|e| {
-            tracing::warn!(error = %e, "Failed to parse chunk ID");
-            ChunkNotFound::InvalidID(chunk_id)
-        })
+            ),
+            ActiveAssignment::Portal(assignment) => portal_data_chunk(find_chunk_with(
+                || assignment.find_chunk_by_timestamp(dataset_url, ts),
+                || portal_first_block(assignment, dataset_url).unwrap_or(0),
+            )?),
+        }
     }
 
     pub fn find_workers(
@@ -562,6 +550,146 @@ fn select_assignment(
     }
 }
 
+/// Runs a per-format `find_chunk`/`find_chunk_by_timestamp` call and converts a not-found error,
+/// generic over the chunk type so both `Assignment` and `PortalAssignment` share this instead of
+/// duplicating the `map_err` wrapping in each match arm.
+fn find_chunk_with<C>(
+    find: impl FnOnce() -> Result<C, sqd_assignments::ChunkNotFound>,
+    first_block: impl FnOnce() -> u64,
+) -> Result<C, ChunkNotFound> {
+    find().map_err(|e| convert_chunk_not_found(e, first_block))
+}
+
+fn convert_chunk_not_found(
+    e: sqd_assignments::ChunkNotFound,
+    first_block: impl FnOnce() -> u64,
+) -> ChunkNotFound {
+    match e {
+        sqd_assignments::ChunkNotFound::AfterLast => ChunkNotFound::AfterLast,
+        sqd_assignments::ChunkNotFound::BeforeFirst => ChunkNotFound::BeforeFirst {
+            first_block: first_block(),
+        },
+        sqd_assignments::ChunkNotFound::UnknownDataset => ChunkNotFound::UnknownDataset,
+        sqd_assignments::ChunkNotFound::InGap => ChunkNotFound::InGap,
+    }
+}
+
+/// The legacy chunk stores its id, and stores no end block of its own, so parsing it is the only
+/// way to a `DataChunk`.
+fn parse_chunk_id(chunk_id: &str) -> Result<DataChunk, ChunkNotFound> {
+    chunk_id.parse().map_err(|e| {
+        tracing::warn!(error = %e, "Failed to parse chunk ID");
+        ChunkNotFound::InvalidID(chunk_id.to_owned())
+    })
+}
+
+/// A portal chunk holds those same fields as columns, so the `DataChunk` is built from them.
+/// Its `id()` would format the four into a string that `DataChunk` immediately takes apart again.
+fn portal_data_chunk(chunk: sqd_assignments::PortalChunk<'_>) -> Result<DataChunk, ChunkNotFound> {
+    let hash = chunk
+        .hash()
+        .ok_or_else(|| ChunkNotFound::InvalidID("chunk hash is not valid UTF-8".to_owned()))?;
+    DataChunk::new(chunk.top(), chunk.first_block(), chunk.last_block(), hash).ok_or_else(|| {
+        ChunkNotFound::InvalidID(format!("chunk hash {hash:?} has an unusable length"))
+    })
+}
+
+/// A dataset's first block, or `None` when it holds no chunks -- `first_block()` reads chunk 0 on
+/// both readers, so an empty dataset panics them. Only a malformed artifact has one, but the
+/// portal parses downloaded bytes with `from_owned_unchecked`, so nothing rejects one on the way
+/// in and the callers sit in the request path.
+fn legacy_first_block(assignment: &Assignment, dataset_url: &str) -> Option<u64> {
+    let dataset = assignment.get_dataset(dataset_url)?;
+    (!dataset.chunks().is_empty()).then(|| dataset.first_block())
+}
+
+fn portal_first_block(assignment: &PortalAssignment, dataset_url: &str) -> Option<u64> {
+    let dataset = assignment.get_dataset(dataset_url)?;
+    (dataset.chunk_count() > 0).then(|| dataset.first_block())
+}
+
+/// The chunk holding `block`, or -- when `block` falls in a gap between two chunks -- the first
+/// chunk after it.
+///
+/// Only the portal artifact can report a gap: it gives each chunk its own end rather than running
+/// it to the next chunk's start, so a block between two chunks is an answer rather than the chunk
+/// before it. A portal only ever streams forward, so the next chunk that does hold data is the
+/// useful answer -- reporting nothing would end a stream at every gap, and the legacy format
+/// could not express one to begin with.
+fn find_portal_chunk<'a>(
+    assignment: &'a PortalAssignment,
+    dataset_url: &str,
+    block: u64,
+) -> Result<sqd_assignments::PortalChunk<'a>, sqd_assignments::ChunkNotFound> {
+    match assignment.find_chunk(dataset_url, block) {
+        Err(sqd_assignments::ChunkNotFound::InGap) => {
+            let dataset = assignment
+                .get_dataset(dataset_url)
+                .expect("a gap is only reported for a dataset that was found");
+            // A gap past the last chunk is still within `last_block`, which is the dataset's head
+            // rather than the last chunk's end, so there is not always a chunk after one.
+            first_chunk_from(dataset, block).ok_or(sqd_assignments::ChunkNotFound::AfterLast)
+        }
+        other => other,
+    }
+}
+
+/// The first chunk starting at or after `block`, by bisection over `first_blocks` -- the same
+/// ascending column [`PortalAssignment::find_chunk`] bisects.
+fn first_chunk_from(
+    dataset: sqd_assignments::fb::PortalAssignmentDataset<'_>,
+    block: u64,
+) -> Option<sqd_assignments::PortalChunk<'_>> {
+    let (mut low, mut high) = (0u32, dataset.chunk_count() as u32);
+    while low < high {
+        let mid = low + (high - low) / 2;
+        if dataset.chunk(mid)?.first_block() < block {
+            low = mid + 1;
+        } else {
+            high = mid;
+        }
+    }
+    dataset.chunk(low)
+}
+
+/// Whether `candidate` is older than the applied assignment, and so must not replace it.
+///
+/// Ids are `<timestamp>_<hash>` with a fixed-width timestamp, so prefixes order lexicographically.
+/// The hash is excluded: it carries no ordering, and would order same-second ids arbitrarily.
+///
+/// Both ids always come from the same source, which is fixed for the process lifetime, so they are
+/// always drawn from one sequence and directly comparable.
+///
+/// Every uncertain case returns false. Wrongly accepting costs one poll; wrongly rejecting freezes
+/// the head until restart.
+fn is_stale(applied_id: &str, candidate: &str) -> bool {
+    let (Some(current), Some(new)) = (timestamp_prefix(applied_id), timestamp_prefix(candidate))
+    else {
+        return false;
+    };
+    // Differing lengths mean differing formats, which lexicographic order cannot span.
+    if current.len() != new.len() {
+        return false;
+    }
+    new < current
+}
+
+/// The ordering-bearing prefix of an id, or `None` if it isn't shaped `<timestamp>_<hash>`.
+fn timestamp_prefix(id: &str) -> Option<&str> {
+    let (timestamp, hash) = id.split_once('_')?;
+    (!timestamp.is_empty() && !hash.is_empty()).then_some(timestamp)
+}
+
+async fn sleep_until(timestamp: u64) {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .expect("time should be after 1970");
+    let until = Duration::from_secs(timestamp);
+    if let Some(delta) = until.checked_sub(now) {
+        tokio::time::sleep(delta).await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -772,6 +900,24 @@ mod tests {
     }
 
     #[test]
+    fn a_portal_chunk_builds_to_what_its_id_parses_to() {
+        // `id()` formats the same four values `DataChunk` holds, so building from the columns
+        // must land on exactly the chunk the round-trip produced -- `top` included, which is a
+        // run lookup rather than a plain column.
+        let assignment = gapped_portal_assignment();
+
+        for block in [0, 250] {
+            let chunk = find_portal_chunk(&assignment, GAPPED_DATASET, block).unwrap();
+            let id = chunk.id().unwrap();
+
+            let built = portal_data_chunk(chunk).unwrap();
+
+            assert_eq!(built, id.parse::<DataChunk>().unwrap(), "block {block}");
+            assert_eq!(built.to_string(), id, "block {block}");
+        }
+    }
+
+    #[test]
     fn an_unpublished_dataset_has_no_first_block() {
         // The empty-chunks half of the same guard can't be built here -- the builder rejects an
         // empty dataset -- but the portal reads downloaded bytes with `from_owned_unchecked`, so
@@ -783,131 +929,5 @@ mod tests {
             portal_first_block(&assignment, "s3://never-published"),
             None
         );
-    }
-}
-
-/// Runs a per-format `find_chunk`/`find_chunk_by_timestamp` call and converts a not-found error,
-/// generic over the chunk type so both `Assignment` and `PortalAssignment` share this instead of
-/// duplicating the `map_err` wrapping in each match arm.
-fn find_chunk_with<C>(
-    find: impl FnOnce() -> Result<C, sqd_assignments::ChunkNotFound>,
-    first_block: impl FnOnce() -> u64,
-) -> Result<C, ChunkNotFound> {
-    find().map_err(|e| convert_chunk_not_found(e, first_block))
-}
-
-fn convert_chunk_not_found(
-    e: sqd_assignments::ChunkNotFound,
-    first_block: impl FnOnce() -> u64,
-) -> ChunkNotFound {
-    match e {
-        sqd_assignments::ChunkNotFound::AfterLast => ChunkNotFound::AfterLast,
-        sqd_assignments::ChunkNotFound::BeforeFirst => ChunkNotFound::BeforeFirst {
-            first_block: first_block(),
-        },
-        sqd_assignments::ChunkNotFound::UnknownDataset => ChunkNotFound::UnknownDataset,
-        sqd_assignments::ChunkNotFound::InGap => ChunkNotFound::InGap,
-    }
-}
-
-/// A portal chunk's id is rebuilt from its columns rather than stored, and comes back `None` only
-/// when the hash it was built from isn't UTF-8 -- so there is no id to name in the error.
-fn portal_chunk_id(id: Option<String>) -> Result<String, ChunkNotFound> {
-    id.ok_or_else(|| ChunkNotFound::InvalidID("chunk hash is not valid UTF-8".to_owned()))
-}
-
-/// A dataset's first block, or `None` when it holds no chunks -- `first_block()` reads chunk 0 on
-/// both readers, so an empty dataset panics them. Only a malformed artifact has one, but the
-/// portal parses downloaded bytes with `from_owned_unchecked`, so nothing rejects one on the way
-/// in and the callers sit in the request path.
-fn legacy_first_block(assignment: &Assignment, dataset_url: &str) -> Option<u64> {
-    let dataset = assignment.get_dataset(dataset_url)?;
-    (!dataset.chunks().is_empty()).then(|| dataset.first_block())
-}
-
-fn portal_first_block(assignment: &PortalAssignment, dataset_url: &str) -> Option<u64> {
-    let dataset = assignment.get_dataset(dataset_url)?;
-    (dataset.chunk_count() > 0).then(|| dataset.first_block())
-}
-
-/// The chunk holding `block`, or -- when `block` falls in a gap between two chunks -- the first
-/// chunk after it.
-///
-/// Only the portal artifact can report a gap: it gives each chunk its own end rather than running
-/// it to the next chunk's start, so a block between two chunks is an answer rather than the chunk
-/// before it. A portal only ever streams forward, so the next chunk that does hold data is the
-/// useful answer -- reporting nothing would end a stream at every gap, and the legacy format
-/// could not express one to begin with.
-fn find_portal_chunk<'a>(
-    assignment: &'a PortalAssignment,
-    dataset_url: &str,
-    block: u64,
-) -> Result<sqd_assignments::PortalChunk<'a>, sqd_assignments::ChunkNotFound> {
-    match assignment.find_chunk(dataset_url, block) {
-        Err(sqd_assignments::ChunkNotFound::InGap) => {
-            let dataset = assignment
-                .get_dataset(dataset_url)
-                .expect("a gap is only reported for a dataset that was found");
-            // A gap past the last chunk is still within `last_block`, which is the dataset's head
-            // rather than the last chunk's end, so there is not always a chunk after one.
-            first_chunk_from(dataset, block).ok_or(sqd_assignments::ChunkNotFound::AfterLast)
-        }
-        other => other,
-    }
-}
-
-/// The first chunk starting at or after `block`, by bisection over `first_blocks` -- the same
-/// ascending column [`PortalAssignment::find_chunk`] bisects.
-fn first_chunk_from(
-    dataset: sqd_assignments::fb::PortalAssignmentDataset<'_>,
-    block: u64,
-) -> Option<sqd_assignments::PortalChunk<'_>> {
-    let (mut low, mut high) = (0u32, dataset.chunk_count() as u32);
-    while low < high {
-        let mid = low + (high - low) / 2;
-        if dataset.chunk(mid)?.first_block() < block {
-            low = mid + 1;
-        } else {
-            high = mid;
-        }
-    }
-    dataset.chunk(low)
-}
-
-/// Whether `candidate` is older than the applied assignment, and so must not replace it.
-///
-/// Ids are `<timestamp>_<hash>` with a fixed-width timestamp, so prefixes order lexicographically.
-/// The hash is excluded: it carries no ordering, and would order same-second ids arbitrarily.
-///
-/// Both ids always come from the same source, which is fixed for the process lifetime, so they are
-/// always drawn from one sequence and directly comparable.
-///
-/// Every uncertain case returns false. Wrongly accepting costs one poll; wrongly rejecting freezes
-/// the head until restart.
-fn is_stale(applied_id: &str, candidate: &str) -> bool {
-    let (Some(current), Some(new)) = (timestamp_prefix(applied_id), timestamp_prefix(candidate))
-    else {
-        return false;
-    };
-    // Differing lengths mean differing formats, which lexicographic order cannot span.
-    if current.len() != new.len() {
-        return false;
-    }
-    new < current
-}
-
-/// The ordering-bearing prefix of an id, or `None` if it isn't shaped `<timestamp>_<hash>`.
-fn timestamp_prefix(id: &str) -> Option<&str> {
-    let (timestamp, hash) = id.split_once('_')?;
-    (!timestamp.is_empty() && !hash.is_empty()).then_some(timestamp)
-}
-
-async fn sleep_until(timestamp: u64) {
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::SystemTime::UNIX_EPOCH)
-        .expect("time should be after 1970");
-    let until = Duration::from_secs(timestamp);
-    if let Some(delta) = until.checked_sub(now) {
-        tokio::time::sleep(delta).await;
     }
 }

--- a/src/network/storage.rs
+++ b/src/network/storage.rs
@@ -195,9 +195,7 @@ impl StorageClient {
         url: &str,
         source: AssignmentSource,
     ) -> anyhow::Result<ActiveAssignment> {
-        use async_compression::tokio::bufread::GzipDecoder;
         use futures::TryStreamExt;
-        use tokio::io::AsyncReadExt;
         use tokio_util::io::StreamReader;
 
         let response = self
@@ -208,12 +206,7 @@ impl StorageClient {
             .error_for_status()?;
         let stream = response.bytes_stream();
         let reader = StreamReader::new(stream.map_err(std::io::Error::other));
-        let mut buf = Vec::new();
-        let mut decoder = GzipDecoder::new(reader);
-        decoder
-            .read_to_end(&mut buf)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to decompress assignment: {}", e))?;
+        let buf = decompress_artifact(reader, ArtifactCodec::of(url)).await?;
 
         tracing::debug!("Downloaded assignment from {}", url);
 
@@ -572,6 +565,48 @@ fn convert_chunk_not_found(
         sqd_assignments::ChunkNotFound::UnknownDataset => ChunkNotFound::UnknownDataset,
         sqd_assignments::ChunkNotFound::InGap => ChunkNotFound::InGap,
     }
+}
+
+/// How an artifact is compressed, taken from the url the network state points at: `.zst` for
+/// zstd, anything else gzip -- which is what every artifact was before zstd existed, so an
+/// unsuffixed or unfamiliar url keeps working exactly as it did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ArtifactCodec {
+    Gzip,
+    Zstd,
+}
+
+impl ArtifactCodec {
+    fn of(url: &str) -> Self {
+        // Object stores hand out urls carrying a query, and the suffix is on the path.
+        let path = match url.split_once(['?', '#']) {
+            Some((path, _)) => path,
+            None => url,
+        };
+        if path.ends_with(".zst") {
+            Self::Zstd
+        } else {
+            Self::Gzip
+        }
+    }
+}
+
+/// Reads an artifact body, decompressing it as `codec` while it streams: the compressed copy is
+/// never held whole, which on mainnet is the difference of a P-ASSIGNMENT-SIZE allocation.
+async fn decompress_artifact(
+    body: impl tokio::io::AsyncBufRead + Unpin,
+    codec: ArtifactCodec,
+) -> anyhow::Result<Vec<u8>> {
+    use async_compression::tokio::bufread::{GzipDecoder, ZstdDecoder};
+    use tokio::io::AsyncReadExt;
+
+    let mut buf = Vec::new();
+    match codec {
+        ArtifactCodec::Gzip => GzipDecoder::new(body).read_to_end(&mut buf).await,
+        ArtifactCodec::Zstd => ZstdDecoder::new(body).read_to_end(&mut buf).await,
+    }
+    .map_err(|e| anyhow!("Failed to decompress {codec:?} assignment: {e}"))?;
+    Ok(buf)
 }
 
 /// The legacy chunk stores its id, and stores no end block of its own, so parsing it is the only
@@ -975,6 +1010,80 @@ mod tests {
             assert_eq!(built, id.parse::<DataChunk>().unwrap(), "block {block}");
             assert_eq!(built.to_string(), id, "block {block}");
         }
+    }
+
+    async fn compress(payload: &[u8], codec: ArtifactCodec) -> Vec<u8> {
+        use async_compression::tokio::write::{GzipEncoder, ZstdEncoder};
+        use tokio::io::AsyncWriteExt;
+
+        let mut out = Vec::new();
+        match codec {
+            ArtifactCodec::Gzip => {
+                let mut enc = GzipEncoder::new(&mut out);
+                enc.write_all(payload).await.unwrap();
+                enc.shutdown().await.unwrap();
+            }
+            ArtifactCodec::Zstd => {
+                let mut enc = ZstdEncoder::new(&mut out);
+                enc.write_all(payload).await.unwrap();
+                enc.shutdown().await.unwrap();
+            }
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn an_artifact_is_read_gzipped_or_zstd_compressed() {
+        // Long enough that neither codec's output is the payload itself.
+        let payload = b"portal assignment bytes".repeat(64);
+
+        for codec in [ArtifactCodec::Gzip, ArtifactCodec::Zstd] {
+            let body = compress(&payload, codec).await;
+
+            let read = decompress_artifact(std::io::Cursor::new(body), codec)
+                .await
+                .unwrap();
+
+            assert_eq!(read, payload, "{codec:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn an_artifact_compressed_the_other_way_is_refused() {
+        // The suffix is trusted, so a publisher that mislabels one fails the fetch and keeps the
+        // assignment already in service, rather than feeding the reader whatever came out.
+        let body = compress(b"portal assignment bytes", ArtifactCodec::Zstd).await;
+
+        let err = decompress_artifact(std::io::Cursor::new(body), ArtifactCodec::Gzip)
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("Failed to decompress"),
+            "got {err}"
+        );
+    }
+
+    #[test]
+    fn the_url_suffix_names_the_codec() {
+        assert_eq!(
+            ArtifactCodec::of("https://e.test/portal-assignment.fb.zst"),
+            ArtifactCodec::Zstd
+        );
+        assert_eq!(
+            ArtifactCodec::of("https://e.test/assignment.fb.gz"),
+            ArtifactCodec::Gzip
+        );
+        // A query does not hide the suffix, and anything unfamiliar stays on gzip -- which is
+        // what every artifact was before zstd.
+        assert_eq!(
+            ArtifactCodec::of("https://e.test/a.fb.zst?versionId=7&x=1"),
+            ArtifactCodec::Zstd
+        );
+        assert_eq!(
+            ArtifactCodec::of("https://e.test/a.fb"),
+            ArtifactCodec::Gzip
+        );
     }
 
     #[test]

--- a/src/network/storage.rs
+++ b/src/network/storage.rs
@@ -51,6 +51,58 @@ enum ActiveAssignment {
     Portal(PortalAssignment),
 }
 
+/// Evaluates `$body` against whichever wire format the assignment is in.
+///
+/// The two readers are unrelated types that happen to expose the same surface, and the datasets,
+/// chunks and workers they hand back are unrelated too. A trait spanning them would need a
+/// generic associated type per returned type and four impls to bridge, all to serve an enum that
+/// exists only until the migration ends. Expanding the body once per arm instead type-checks each
+/// against its own concrete reader and costs nothing to delete afterwards.
+///
+/// Only for the paths that genuinely read the same on both. Where the formats differ -- the chunk
+/// id, the per-chunk end block -- the arms stay written out, so the difference stays visible.
+macro_rules! dispatch {
+    ($assignment:expr, |$reader:ident| $body:expr) => {
+        match $assignment {
+            ActiveAssignment::Legacy($reader) => $body,
+            ActiveAssignment::Portal($reader) => $body,
+        }
+    };
+}
+
+/// A dataset's first block, or `None` when it is absent or holds no chunks.
+///
+/// `first_block()` indexes the first chunk on both readers, so an empty dataset would panic. The
+/// scheduler has no reason to publish one, but every caller sits in the request path and a bad
+/// artifact should cost a lookup, not the task serving it.
+macro_rules! first_block_of {
+    ($assignment:expr, $dataset_url:expr) => {
+        $assignment
+            .get_dataset($dataset_url)
+            .filter(|dataset| dataset.num_chunks() > 0)
+            .map(|dataset| dataset.first_block())
+    };
+}
+
+/// The one dataset accessor the two formats spell differently -- the legacy dataset owns a chunk
+/// vector, the portal one a set of parallel columns. Naming it once is what lets the shared
+/// paths above be written once.
+trait DatasetChunks {
+    fn num_chunks(&self) -> usize;
+}
+
+impl DatasetChunks for sqd_assignments::fb::Dataset<'_> {
+    fn num_chunks(&self) -> usize {
+        self.chunks().len()
+    }
+}
+
+impl DatasetChunks for sqd_assignments::fb::PortalAssignmentDataset<'_> {
+    fn num_chunks(&self) -> usize {
+        self.chunk_count()
+    }
+}
+
 pub struct StorageClient {
     assignment: RwLock<Option<ActiveAssignment>>,
     datasets_config: Arc<RwLock<Datasets>>,
@@ -77,7 +129,7 @@ pub enum ChunkNotFound {
     #[error("Block falls in a gap between chunks")]
     InGap,
     #[error("Invalid chunk ID: {0}")]
-    InvalidID(String),
+    InvalidId(String),
 }
 
 impl StorageClient {
@@ -101,7 +153,7 @@ impl StorageClient {
                 .read_timeout(Duration::from_secs(5))
                 .user_agent(format!("SQD Portal/{}", env!("CARGO_PKG_VERSION")))
                 .build()
-                .unwrap(),
+                .expect("the assignment http client is configured with constants"),
             ignore_deprecated_workers: false,
             assignment_source: AssignmentSource::default(),
         }
@@ -117,18 +169,14 @@ impl StorageClient {
 
     pub fn num_workers(&self) -> usize {
         match self.assignment.read().as_ref() {
-            Some(ActiveAssignment::Legacy(a)) => a.workers().len(),
-            Some(ActiveAssignment::Portal(a)) => a.workers().len(),
+            Some(assignment) => dispatch!(assignment, |a| a.workers().len()),
             None => 0,
         }
     }
 
     pub async fn try_update_assignment(&self) {
-        match self.update_assignment().await {
-            Ok(_) => {}
-            Err(err) => {
-                tracing::error!(error = ?err, "Failed to update assignment, waiting for the next one");
-            }
+        if let Err(err) = self.update_assignment().await {
+            tracing::error!(error = ?err, "Failed to update assignment, waiting for the next one");
         }
     }
 
@@ -142,37 +190,42 @@ impl StorageClient {
             .inspect_err(|_| {
                 metrics::MISSING_ASSIGNMENT_SOURCE.inc();
             })?;
-        let assignment_id = selected.id.clone();
-        let effective_from = selected.effective_from;
-        let latest = self.latest_assignment_id.read().clone();
-        if latest.as_deref() == Some(assignment_id.as_str()) {
-            tracing::debug!("Assignment has not been changed");
-            return Ok(());
-        }
+        let assignment_id = selected.id.as_str();
 
-        if let Some(latest) = &latest {
-            if is_stale(latest, &assignment_id) {
-                // Applying it would move the head backwards, dropping already-advertised chunks
-                // and opening a range no source covers. A later poll brings the newer one back.
-                tracing::warn!(
-                    stale_id = %assignment_id,
-                    current_id = %latest,
-                    "Rejected an assignment older than the current one"
-                );
-                metrics::STALE_ASSIGNMENTS_REJECTED.inc();
-                return Ok(());
+        // Scoped: it is a std lock, and the awaits below span a download plus the wait for the
+        // new assignment to take effect.
+        let had_assignment = {
+            let latest = self.latest_assignment_id.read();
+            match latest.as_deref() {
+                Some(current) if current == assignment_id => {
+                    tracing::debug!("Assignment has not been changed");
+                    return Ok(());
+                }
+                Some(current) if is_stale(current, assignment_id) => {
+                    // Applying it would move the head backwards, dropping already-advertised
+                    // chunks and opening a range no source covers. A later poll brings the newer
+                    // one back.
+                    tracing::warn!(
+                        stale_id = %assignment_id,
+                        current_id = %current,
+                        "Rejected an assignment older than the current one"
+                    );
+                    metrics::STALE_ASSIGNMENTS_REJECTED.inc();
+                    return Ok(());
+                }
+                current => current.is_some(),
             }
-        }
+        };
 
         let assignment = self
-            .fetch_assignment(&assignment_url, self.assignment_source)
+            .fetch_assignment(assignment_url, self.assignment_source)
             .await?;
 
-        if latest.is_some() {
-            sleep_until(effective_from).await;
+        if had_assignment {
+            sleep_until(selected.effective_from).await;
         }
 
-        self.set_assignment(assignment, &assignment_id);
+        self.set_assignment(assignment, assignment_id);
 
         tracing::info!("Applied assignment \"{}\"", assignment_id);
         Ok(())
@@ -231,56 +284,36 @@ impl StorageClient {
     fn set_assignment(&self, assignment: ActiveAssignment, id: &str) {
         *self.latest_assignment_id.write() = Some(id.to_owned());
 
-        let prev = self.assignment.read();
-        let workers_len = match &assignment {
-            ActiveAssignment::Legacy(assignment) => {
-                self.update_datasets(
-                    assignment
-                        .datasets()
+        let workers_len = {
+            // Scoped: the swap below takes the write lock, and `prev_counts` borrows the reader
+            // this guard protects.
+            let prev = self.assignment.read();
+            let prev_counts = prev.as_ref().map(chunk_counts).unwrap_or_default();
+            dispatch!(&assignment, |a| {
+                self.report_datasets(
+                    a.datasets()
                         .iter()
-                        .map(|d| (d.id(), d.chunks().len(), d.last_block())),
-                    |id| match prev.as_ref() {
-                        Some(ActiveAssignment::Legacy(p)) => {
-                            p.get_dataset(id).map(|d| d.chunks().len())
-                        }
-                        _ => None,
-                    },
+                        .map(|d| (d.id(), d.num_chunks(), d.last_block())),
+                    &prev_counts,
                 );
-                assignment.workers().len()
-            }
-            ActiveAssignment::Portal(assignment) => {
-                self.update_datasets(
-                    assignment
-                        .datasets()
-                        .iter()
-                        .map(|d| (d.id(), d.chunk_count(), d.last_block())),
-                    |id| match prev.as_ref() {
-                        Some(ActiveAssignment::Portal(p)) => {
-                            p.get_dataset(id).map(|d| d.chunk_count())
-                        }
-                        _ => None,
-                    },
-                );
-                assignment.workers().len()
-            }
+                a.workers().len()
+            })
         };
-        drop(prev);
 
-        crate::metrics::KNOWN_WORKERS.set(workers_len as i64);
+        metrics::KNOWN_WORKERS.set(i64::try_from(workers_len).unwrap_or(i64::MAX));
 
         *self.assignment.write() = Some(assignment);
     }
 
-    /// Reports each dataset's new chunk count against its previous one (`prev_len`, keyed by
-    /// dataset id), shared across both assignment formats -- the only thing that differs between
-    /// them is how `(id, new_len, last_block)` and `prev_len` are looked up.
-    fn update_datasets<'a>(
+    /// Reports each dataset's new chunk count against `prev_counts`, the counts read off the
+    /// assignment being replaced.
+    fn report_datasets<'a>(
         &self,
         datasets_info: impl Iterator<Item = (&'a str, usize, u64)>,
-        prev_len: impl Fn(&str) -> Option<usize>,
+        prev_counts: &HashMap<&str, usize>,
     ) {
         for (dataset_url, new_len, last_block) in datasets_info {
-            let old_len = prev_len(dataset_url).unwrap_or(0);
+            let old_len = prev_counts.get(dataset_url).copied().unwrap_or(0);
             let dataset_id = DatasetId::from_url(dataset_url);
             if old_len < new_len {
                 tracing::info!(
@@ -303,24 +336,18 @@ impl StorageClient {
         let dataset_url = dataset.to_url();
         let guard = self.assignment.read();
         let chunk_id = match guard.as_ref().ok_or(ChunkNotFound::UnknownDataset)? {
-            ActiveAssignment::Legacy(assignment) => find_chunk_with(
-                || assignment.find_chunk(dataset_url, block),
-                || assignment.get_dataset(dataset_url).unwrap().first_block(),
-            )?
-            .id()
-            .to_owned(),
-            ActiveAssignment::Portal(assignment) => portal_chunk_id(
-                find_chunk_with(
-                    || find_portal_chunk(assignment, dataset_url, block),
-                    || assignment.get_dataset(dataset_url).unwrap().first_block(),
-                )?
-                .id(),
+            ActiveAssignment::Legacy(a) => a
+                .find_chunk(dataset_url, block)
+                .map_err(|e| convert_chunk_not_found(e, || first_block_of!(a, dataset_url)))?
+                .id()
+                .to_owned(),
+            ActiveAssignment::Portal(a) => portal_chunk_id(
+                find_portal_chunk(a, dataset_url, block)
+                    .map_err(|e| convert_chunk_not_found(e, || first_block_of!(a, dataset_url)))?
+                    .id(),
             )?,
         };
-        chunk_id.parse().map_err(|e| {
-            tracing::warn!(error = %e, "Failed to parse chunk ID");
-            ChunkNotFound::InvalidID(chunk_id)
-        })
+        parse_chunk_id(&chunk_id)
     }
 
     pub fn find_chunk_by_timestamp(
@@ -331,24 +358,18 @@ impl StorageClient {
         let dataset_url = dataset.to_url();
         let guard = self.assignment.read();
         let chunk_id = match guard.as_ref().ok_or(ChunkNotFound::UnknownDataset)? {
-            ActiveAssignment::Legacy(assignment) => find_chunk_with(
-                || assignment.find_chunk_by_timestamp(dataset_url, ts),
-                || assignment.get_dataset(dataset_url).unwrap().first_block(),
-            )?
-            .id()
-            .to_owned(),
-            ActiveAssignment::Portal(assignment) => portal_chunk_id(
-                find_chunk_with(
-                    || assignment.find_chunk_by_timestamp(dataset_url, ts),
-                    || assignment.get_dataset(dataset_url).unwrap().first_block(),
-                )?
-                .id(),
+            ActiveAssignment::Legacy(a) => a
+                .find_chunk_by_timestamp(dataset_url, ts)
+                .map_err(|e| convert_chunk_not_found(e, || first_block_of!(a, dataset_url)))?
+                .id()
+                .to_owned(),
+            ActiveAssignment::Portal(a) => portal_chunk_id(
+                a.find_chunk_by_timestamp(dataset_url, ts)
+                    .map_err(|e| convert_chunk_not_found(e, || first_block_of!(a, dataset_url)))?
+                    .id(),
             )?,
         };
-        chunk_id.parse().map_err(|e| {
-            tracing::warn!(error = %e, "Failed to parse chunk ID");
-            ChunkNotFound::InvalidID(chunk_id)
-        })
+        parse_chunk_id(&chunk_id)
     }
 
     pub fn find_workers(
@@ -359,25 +380,22 @@ impl StorageClient {
         let dataset_url = dataset.to_url();
         let guard = self.assignment.read();
         match guard.as_ref().ok_or(ChunkNotFound::UnknownDataset)? {
-            ActiveAssignment::Legacy(assignment) => {
-                let chunk = find_chunk_with(
-                    || assignment.find_chunk(dataset_url, block),
-                    || assignment.get_dataset(dataset_url).unwrap().first_block(),
-                )?;
+            ActiveAssignment::Legacy(a) => {
+                let chunk = a
+                    .find_chunk(dataset_url, block)
+                    .map_err(|e| convert_chunk_not_found(e, || first_block_of!(a, dataset_url)))?;
                 Ok(
                     self.filtered_worker_ids(chunk.worker_indexes().iter(), |idx| {
-                        let w = assignment.get_worker_by_index(idx);
+                        let w = a.get_worker_by_index(idx);
                         (w.status(), w.peer_id())
                     }),
                 )
             }
-            ActiveAssignment::Portal(assignment) => {
-                let chunk = find_chunk_with(
-                    || find_portal_chunk(assignment, dataset_url, block),
-                    || assignment.get_dataset(dataset_url).unwrap().first_block(),
-                )?;
+            ActiveAssignment::Portal(a) => {
+                let chunk = find_portal_chunk(a, dataset_url, block)
+                    .map_err(|e| convert_chunk_not_found(e, || first_block_of!(a, dataset_url)))?;
                 Ok(self.filtered_worker_ids(chunk.worker_indexes(), |idx| {
-                    let w = assignment.get_worker_by_index(idx);
+                    let w = a.get_worker_by_index(idx);
                     (w.status(), w.peer_id())
                 }))
             }
@@ -415,44 +433,34 @@ impl StorageClient {
 
     pub fn first_block(&self, dataset: &DatasetId) -> Option<BlockNumber> {
         let dataset_url = dataset.to_url();
-        match self.assignment.read().as_ref()? {
-            ActiveAssignment::Legacy(a) => Some(a.get_dataset(dataset_url)?.first_block()),
-            ActiveAssignment::Portal(a) => Some(a.get_dataset(dataset_url)?.first_block()),
-        }
+        let guard = self.assignment.read();
+        dispatch!(guard.as_ref()?, |a| first_block_of!(a, dataset_url))
     }
 
     pub fn head(&self, dataset: &DatasetId) -> Option<BlockRef> {
         let dataset_url = dataset.to_url();
-        match self.assignment.read().as_ref()? {
-            ActiveAssignment::Legacy(a) => {
-                let dataset = a.get_dataset(dataset_url)?;
-                dataset.last_block_hash().map(|hash| BlockRef {
-                    hash: hash.to_owned(),
-                    number: dataset.last_block(),
-                })
+        let guard = self.assignment.read();
+        dispatch!(guard.as_ref()?, |a| {
+            let dataset = a.get_dataset(dataset_url)?;
+            // The legacy reader takes the head hash off the last chunk, so an empty dataset
+            // would index out of bounds. It has no head to report either way.
+            if dataset.num_chunks() == 0 {
+                return None;
             }
-            ActiveAssignment::Portal(a) => {
-                let dataset = a.get_dataset(dataset_url)?;
-                dataset.last_block_hash().map(|hash| BlockRef {
-                    hash: hash.to_owned(),
-                    number: dataset.last_block(),
-                })
-            }
-        }
+            dataset.last_block_hash().map(|hash| BlockRef {
+                hash: hash.to_owned(),
+                number: dataset.last_block(),
+            })
+        })
     }
 
     pub fn get_all_workers(&self) -> Vec<PeerId> {
         match self.assignment.read().as_ref() {
-            Some(ActiveAssignment::Legacy(a)) => a
+            Some(assignment) => dispatch!(assignment, |a| a
                 .workers()
                 .iter()
                 .filter_map(|w| (*w.worker_id()).try_into().ok())
-                .collect(),
-            Some(ActiveAssignment::Portal(a)) => a
-                .workers()
-                .iter()
-                .filter_map(|w| (*w.worker_id()).try_into().ok())
-                .collect(),
+                .collect()),
             None => Vec::new(),
         }
     }
@@ -460,28 +468,50 @@ impl StorageClient {
     #[instrument(skip(self))]
     pub fn get_dataset_state(&self, dataset: &DatasetId) -> Option<DatasetState> {
         let dataset_url = dataset.to_url();
-        let mut ranges: HashMap<_, Vec<_>> = HashMap::new();
-        match self.assignment.read().as_ref()? {
-            ActiveAssignment::Legacy(assignment) => {
-                for c in assignment.get_dataset(dataset_url)?.chunks().iter() {
-                    accumulate_range(&mut ranges, c.id(), c.worker_indexes().iter(), |idx| {
-                        assignment.get_worker_id(idx)
-                    });
-                }
-            }
-            ActiveAssignment::Portal(assignment) => {
-                for c in assignment.get_dataset(dataset_url)?.chunks() {
-                    // A chunk whose hash isn't UTF-8 has no id to build a range from; reporting
-                    // the rest of the dataset beats reporting none of it.
-                    let Some(id) = c.id() else {
-                        tracing::warn!("Skipped a chunk whose hash is not valid UTF-8");
+        let mut ranges: HashMap<PeerId, Vec<sqd_messages::Range>> = HashMap::new();
+        let mut unparsed_chunks = 0usize;
+        let guard = self.assignment.read();
+        match guard.as_ref()? {
+            ActiveAssignment::Legacy(a) => {
+                for c in a.get_dataset(dataset_url)?.chunks().iter() {
+                    // A legacy chunk carries no end block, so its id is the only place to read
+                    // one from -- and the id is wire data, so one bad chunk must not sink the
+                    // whole dataset's state.
+                    let Ok(chunk) = c.id().parse::<DataChunk>() else {
+                        unparsed_chunks += 1;
                         continue;
                     };
-                    accumulate_range(&mut ranges, &id, c.worker_indexes(), |idx| {
-                        assignment.get_worker_id(idx)
+                    accumulate_range(
+                        &mut ranges,
+                        chunk.range_msg(),
+                        c.worker_indexes().iter(),
+                        |idx| a.get_worker_id(idx),
+                    );
+                }
+            }
+            ActiveAssignment::Portal(a) => {
+                for c in a.get_dataset(dataset_url)?.chunks() {
+                    // Both ends are columns here, so the range needs no id. Rebuilding one to
+                    // parse it straight back would allocate per chunk and add the only way this
+                    // loop can fail -- a hash that isn't UTF-8 yields no id.
+                    let range = sqd_messages::Range {
+                        begin: c.first_block(),
+                        end: c.last_block(),
+                    };
+                    accumulate_range(&mut ranges, range, c.worker_indexes(), |idx| {
+                        a.get_worker_id(idx)
                     });
                 }
             }
+        }
+        if unparsed_chunks > 0 {
+            // Counted and reported once: a format change makes every chunk fail, and a warning
+            // per chunk would bury the rest of the log.
+            tracing::warn!(
+                dataset = %dataset,
+                unparsed_chunks,
+                "Skipped chunks with unparseable IDs"
+            );
         }
         Some(DatasetState {
             worker_ranges: ranges
@@ -492,13 +522,22 @@ impl StorageClient {
     }
 }
 
+/// Chunk count per dataset url, read off an assignment before it is replaced so the new-chunks
+/// delta survives the swap.
+fn chunk_counts(assignment: &ActiveAssignment) -> HashMap<&str, usize> {
+    dispatch!(assignment, |a| a
+        .datasets()
+        .iter()
+        .map(|d| (d.id(), d.num_chunks()))
+        .collect())
+}
+
 fn accumulate_range(
     ranges: &mut HashMap<PeerId, Vec<sqd_messages::Range>>,
-    chunk_id: &str,
+    range: sqd_messages::Range,
     worker_indexes: impl Iterator<Item = u16>,
     get_worker_id: impl Fn(u16) -> Result<PeerId, anyhow::Error>,
 ) {
-    let range = chunk_id.parse::<DataChunk>().unwrap().range_msg();
     for idx in worker_indexes {
         let peer_id = match get_worker_id(idx) {
             Ok(peer_id) => peer_id,
@@ -522,12 +561,12 @@ fn accumulate_range(
 fn usable_assignment(
     network_state: &sqd_assignments::NetworkState,
     source: AssignmentSource,
-) -> anyhow::Result<(&NetworkAssignment, String)> {
+) -> anyhow::Result<(&NetworkAssignment, &str)> {
     let selected = select_assignment(network_state, source)
         .ok_or_else(|| anyhow!("network state publishes no {source} assignment"))?;
     let url = selected
         .fb_url_v1
-        .clone()
+        .as_deref()
         .ok_or_else(|| anyhow!("the {source} assignment carries no fb_url_v1"))?;
     Ok((selected, url))
 }
@@ -545,6 +584,126 @@ fn select_assignment(
     match source {
         AssignmentSource::Legacy => network_state.assignment.as_ref(),
         AssignmentSource::Portal => network_state.portal_assignment.as_ref(),
+    }
+}
+
+/// A chunk id as published, or a routing failure -- the id is wire data, not an invariant.
+fn parse_chunk_id(chunk_id: &str) -> Result<DataChunk, ChunkNotFound> {
+    chunk_id.parse().map_err(|e| {
+        tracing::warn!(error = %e, "Failed to parse chunk ID");
+        ChunkNotFound::InvalidId(chunk_id.to_owned())
+    })
+}
+
+/// `first_block` is only consulted for [`BeforeFirst`], and reads as 0 when the dataset turns out
+/// to be absent or empty -- 0 is the only answer that cannot exclude a block that does exist.
+///
+/// [`BeforeFirst`]: ChunkNotFound::BeforeFirst
+fn convert_chunk_not_found(
+    e: sqd_assignments::ChunkNotFound,
+    first_block: impl FnOnce() -> Option<u64>,
+) -> ChunkNotFound {
+    match e {
+        sqd_assignments::ChunkNotFound::AfterLast => ChunkNotFound::AfterLast,
+        sqd_assignments::ChunkNotFound::BeforeFirst => ChunkNotFound::BeforeFirst {
+            first_block: first_block().unwrap_or(0),
+        },
+        sqd_assignments::ChunkNotFound::UnknownDataset => ChunkNotFound::UnknownDataset,
+        sqd_assignments::ChunkNotFound::InGap => ChunkNotFound::InGap,
+    }
+}
+
+/// A portal chunk's id is rebuilt from its columns rather than stored, and comes back `None` only
+/// when the hash it was built from isn't UTF-8 -- so there is no id to name in the error.
+fn portal_chunk_id(id: Option<String>) -> Result<String, ChunkNotFound> {
+    id.ok_or_else(|| ChunkNotFound::InvalidId("chunk hash is not valid UTF-8".to_owned()))
+}
+
+/// The chunk holding `block`, or -- when `block` falls in a gap between two chunks -- the first
+/// chunk after it.
+///
+/// Only the portal artifact can report a gap: it gives each chunk its own end rather than running
+/// it to the next chunk's start, so a block between two chunks is an answer rather than the chunk
+/// before it. A portal only ever streams forward, so the next chunk that does hold data is the
+/// useful answer -- reporting nothing would end a stream at every gap, and the legacy format
+/// could not express one to begin with.
+fn find_portal_chunk<'a>(
+    assignment: &'a PortalAssignment,
+    dataset_url: &str,
+    block: u64,
+) -> Result<sqd_assignments::PortalChunk<'a>, sqd_assignments::ChunkNotFound> {
+    match assignment.find_chunk(dataset_url, block) {
+        Err(sqd_assignments::ChunkNotFound::InGap) => {
+            let dataset = assignment
+                .get_dataset(dataset_url)
+                .expect("a gap is only reported for a dataset that was found");
+            // A gap past the last chunk is still within `last_block`, which is the dataset's head
+            // rather than the last chunk's end, so there is not always a chunk after one.
+            first_chunk_from(dataset, block).ok_or(sqd_assignments::ChunkNotFound::AfterLast)
+        }
+        other => other,
+    }
+}
+
+/// The first chunk starting at or after `block`, by bisection over `first_blocks` -- the same
+/// ascending column [`PortalAssignment::find_chunk`] bisects.
+fn first_chunk_from(
+    dataset: sqd_assignments::fb::PortalAssignmentDataset<'_>,
+    block: u64,
+) -> Option<sqd_assignments::PortalChunk<'_>> {
+    // `chunk` addresses chunks by u32, so anything above that is unreachable regardless -- and
+    // saturating searches as much of the dataset as can be named, where `as` would wrap and
+    // silently search a prefix of it.
+    let (mut low, mut high) = (
+        0u32,
+        u32::try_from(dataset.chunk_count()).unwrap_or(u32::MAX),
+    );
+    while low < high {
+        let mid = low + (high - low) / 2;
+        if dataset.chunk(mid)?.first_block() < block {
+            low = mid + 1;
+        } else {
+            high = mid;
+        }
+    }
+    dataset.chunk(low)
+}
+
+/// Whether `candidate` is older than the applied assignment, and so must not replace it.
+///
+/// Ids are `<timestamp>_<hash>` with a fixed-width timestamp, so prefixes order lexicographically.
+/// The hash is excluded: it carries no ordering, and would order same-second ids arbitrarily.
+///
+/// Both ids always come from the same source, which is fixed for the process lifetime, so they are
+/// always drawn from one sequence and directly comparable.
+///
+/// Every uncertain case returns false. Wrongly accepting costs one poll; wrongly rejecting freezes
+/// the head until restart.
+fn is_stale(applied_id: &str, candidate: &str) -> bool {
+    let (Some(current), Some(new)) = (timestamp_prefix(applied_id), timestamp_prefix(candidate))
+    else {
+        return false;
+    };
+    // Differing lengths mean differing formats, which lexicographic order cannot span.
+    if current.len() != new.len() {
+        return false;
+    }
+    new < current
+}
+
+/// The ordering-bearing prefix of an id, or `None` if it isn't shaped `<timestamp>_<hash>`.
+fn timestamp_prefix(id: &str) -> Option<&str> {
+    let (timestamp, hash) = id.split_once('_')?;
+    (!timestamp.is_empty() && !hash.is_empty()).then_some(timestamp)
+}
+
+async fn sleep_until(timestamp: u64) {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .expect("time should be after 1970");
+    let until = Duration::from_secs(timestamp);
+    if let Some(delta) = until.checked_sub(now) {
+        tokio::time::sleep(delta).await;
     }
 }
 
@@ -756,116 +915,36 @@ mod tests {
             Some(sqd_assignments::ChunkNotFound::AfterLast)
         );
     }
-}
 
-/// Runs a per-format `find_chunk`/`find_chunk_by_timestamp` call and converts a not-found error,
-/// generic over the chunk type so both `Assignment` and `PortalAssignment` share this instead of
-/// duplicating the `map_err` wrapping in each match arm.
-fn find_chunk_with<C>(
-    find: impl FnOnce() -> Result<C, sqd_assignments::ChunkNotFound>,
-    first_block: impl FnOnce() -> u64,
-) -> Result<C, ChunkNotFound> {
-    find().map_err(|e| convert_chunk_not_found(e, first_block))
-}
+    #[test]
+    fn an_unparseable_chunk_id_is_a_routing_failure() {
+        // Ids are wire data: a malformed one must surface as a miss, not a panic.
+        let err = parse_chunk_id("not-a-chunk-id").unwrap_err();
 
-fn convert_chunk_not_found(
-    e: sqd_assignments::ChunkNotFound,
-    first_block: impl FnOnce() -> u64,
-) -> ChunkNotFound {
-    match e {
-        sqd_assignments::ChunkNotFound::AfterLast => ChunkNotFound::AfterLast,
-        sqd_assignments::ChunkNotFound::BeforeFirst => ChunkNotFound::BeforeFirst {
-            first_block: first_block(),
-        },
-        sqd_assignments::ChunkNotFound::UnknownDataset => ChunkNotFound::UnknownDataset,
-        sqd_assignments::ChunkNotFound::InGap => ChunkNotFound::InGap,
+        assert!(matches!(err, ChunkNotFound::InvalidId(id) if id == "not-a-chunk-id"));
     }
-}
 
-/// A portal chunk's id is rebuilt from its columns rather than stored, and comes back `None` only
-/// when the hash it was built from isn't UTF-8 -- so there is no id to name in the error.
-fn portal_chunk_id(id: Option<String>) -> Result<String, ChunkNotFound> {
-    id.ok_or_else(|| ChunkNotFound::InvalidID("chunk hash is not valid UTF-8".to_owned()))
-}
+    #[test]
+    fn an_unknown_first_block_reads_as_zero() {
+        // BeforeFirst names the block a client should start from. An absent or empty dataset has
+        // none, and 0 is the only answer that cannot exclude a block that does exist.
+        let converted =
+            convert_chunk_not_found(sqd_assignments::ChunkNotFound::BeforeFirst, || None);
 
-/// The chunk holding `block`, or -- when `block` falls in a gap between two chunks -- the first
-/// chunk after it.
-///
-/// Only the portal artifact can report a gap: it gives each chunk its own end rather than running
-/// it to the next chunk's start, so a block between two chunks is an answer rather than the chunk
-/// before it. A portal only ever streams forward, so the next chunk that does hold data is the
-/// useful answer -- reporting nothing would end a stream at every gap, and the legacy format
-/// could not express one to begin with.
-fn find_portal_chunk<'a>(
-    assignment: &'a PortalAssignment,
-    dataset_url: &str,
-    block: u64,
-) -> Result<sqd_assignments::PortalChunk<'a>, sqd_assignments::ChunkNotFound> {
-    match assignment.find_chunk(dataset_url, block) {
-        Err(sqd_assignments::ChunkNotFound::InGap) => {
-            let dataset = assignment
-                .get_dataset(dataset_url)
-                .expect("a gap is only reported for a dataset that was found");
-            // A gap past the last chunk is still within `last_block`, which is the dataset's head
-            // rather than the last chunk's end, so there is not always a chunk after one.
-            first_chunk_from(dataset, block).ok_or(sqd_assignments::ChunkNotFound::AfterLast)
-        }
-        other => other,
+        assert!(matches!(
+            converted,
+            ChunkNotFound::BeforeFirst { first_block: 0 }
+        ));
     }
-}
 
-/// The first chunk starting at or after `block`, by bisection over `first_blocks` -- the same
-/// ascending column [`PortalAssignment::find_chunk`] bisects.
-fn first_chunk_from(
-    dataset: sqd_assignments::fb::PortalAssignmentDataset<'_>,
-    block: u64,
-) -> Option<sqd_assignments::PortalChunk<'_>> {
-    let (mut low, mut high) = (0u32, dataset.chunk_count() as u32);
-    while low < high {
-        let mid = low + (high - low) / 2;
-        if dataset.chunk(mid)?.first_block() < block {
-            low = mid + 1;
-        } else {
-            high = mid;
-        }
-    }
-    dataset.chunk(low)
-}
+    #[test]
+    fn a_dataset_that_was_not_published_has_no_first_block() {
+        // The `num_chunks` half of the same guard can't be exercised from here -- the builder
+        // rejects an empty dataset -- but the portal reads downloaded bytes through
+        // `from_owned_unchecked`, so nothing rejects one on the way in either.
+        let assignment = gapped_portal_assignment();
 
-/// Whether `candidate` is older than the applied assignment, and so must not replace it.
-///
-/// Ids are `<timestamp>_<hash>` with a fixed-width timestamp, so prefixes order lexicographically.
-/// The hash is excluded: it carries no ordering, and would order same-second ids arbitrarily.
-///
-/// Both ids always come from the same source, which is fixed for the process lifetime, so they are
-/// always drawn from one sequence and directly comparable.
-///
-/// Every uncertain case returns false. Wrongly accepting costs one poll; wrongly rejecting freezes
-/// the head until restart.
-fn is_stale(applied_id: &str, candidate: &str) -> bool {
-    let (Some(current), Some(new)) = (timestamp_prefix(applied_id), timestamp_prefix(candidate))
-    else {
-        return false;
-    };
-    // Differing lengths mean differing formats, which lexicographic order cannot span.
-    if current.len() != new.len() {
-        return false;
-    }
-    new < current
-}
-
-/// The ordering-bearing prefix of an id, or `None` if it isn't shaped `<timestamp>_<hash>`.
-fn timestamp_prefix(id: &str) -> Option<&str> {
-    let (timestamp, hash) = id.split_once('_')?;
-    (!timestamp.is_empty() && !hash.is_empty()).then_some(timestamp)
-}
-
-async fn sleep_until(timestamp: u64) {
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::SystemTime::UNIX_EPOCH)
-        .expect("time should be after 1970");
-    let until = Duration::from_secs(timestamp);
-    if let Some(delta) = until.checked_sub(now) {
-        tokio::time::sleep(delta).await;
+        assert_eq!(first_block_of!(&assignment, GAPPED_DATASET), Some(0));
+        assert_eq!(first_block_of!(&assignment, "s3://never-published"), None);
     }
 }

--- a/src/network/storage.rs
+++ b/src/network/storage.rs
@@ -860,6 +860,66 @@ mod tests {
         PortalAssignment::from_owned(builder.finish()).unwrap()
     }
 
+    /// The same two chunks in the legacy format. Its `Dataset` has no per-chunk end block, so
+    /// nothing here marks 100-199 as absent -- the hole exists only because the ids say so.
+    fn gapped_legacy_assignment() -> Assignment {
+        let mut builder =
+            sqd_assignments::AssignmentBuilder::new("test-secret").check_continuity(false);
+        for (first, last) in [(0u64, 99u64), (200, 299)] {
+            let staged = builder
+                .new_chunk()
+                .id(&format!("0000000000/{first:010}-{last:010}-aaaaa"))
+                .dataset_id(GAPPED_DATASET)
+                .block_range(first..=last)
+                .size(1)
+                .dataset_base_url("s3://gapped")
+                .files(&[])
+                .worker_indexes(&[])
+                .finish();
+            // With the check off a gap is still reported, but the chunk is staged anyway. Any
+            // other error means the fixture built something the reader would reject.
+            if let Err(e) = staged {
+                assert!(
+                    e.to_string().contains("must be contiguous"),
+                    "unexpected chunk build error: {e}"
+                );
+            }
+        }
+        builder.finish_dataset();
+        Assignment::from_owned(builder.finish()).unwrap()
+    }
+
+    #[test]
+    fn the_two_formats_resolve_the_same_gap_in_opposite_directions() {
+        // The behavioural difference this branch turns on, asserted rather than described.
+        let legacy = gapped_legacy_assignment();
+        let portal = gapped_portal_assignment();
+
+        let legacy_chunk = legacy.find_chunk(GAPPED_DATASET, 150).unwrap();
+        let portal_chunk = find_portal_chunk(&portal, GAPPED_DATASET, 150).unwrap();
+
+        // Legacy resolves backward, to the chunk before the hole: it holds no block 150, and
+        // its own id says so -- 0-99 ends well short of the request.
+        assert_eq!(legacy_chunk.first_block(), 0);
+        assert_eq!(legacy_chunk.id(), "0000000000/0000000000-0000000099-aaaaa");
+        // The portal reader sees the per-chunk end, calls it a gap, and resolves forward to the
+        // next chunk that does hold data.
+        assert_eq!(portal_chunk.first_block(), 200);
+    }
+
+    #[test]
+    fn legacy_walks_back_into_the_chunk_that_just_ended() {
+        // `next_chunk` is `find_chunk(last_block + 1)`. Across a gap that resolves backward to
+        // the chunk it just finished, so a legacy stream is handed the same chunk again instead
+        // of advancing -- the portal counterpart crosses the gap
+        // (`the_block_after_a_chunk_crosses_the_gap`).
+        let legacy = gapped_legacy_assignment();
+
+        let after_first = legacy.find_chunk(GAPPED_DATASET, 100).unwrap();
+
+        assert_eq!(after_first.first_block(), 0, "legacy did not advance");
+    }
+
     #[test]
     fn a_block_in_a_gap_resolves_to_the_next_chunk() {
         // Ending the stream here would drop 200-299, which a worker does hold.

--- a/src/network/storage.rs
+++ b/src/network/storage.rs
@@ -624,9 +624,13 @@ fn portal_data_chunk(chunk: sqd_assignments::PortalChunk<'_>) -> Result<DataChun
     let hash = chunk
         .hash()
         .ok_or_else(|| ChunkNotFound::InvalidID("chunk hash is not valid UTF-8".to_owned()))?;
-    DataChunk::new(chunk.top(), chunk.first_block(), chunk.last_block(), hash).ok_or_else(|| {
-        ChunkNotFound::InvalidID(format!("chunk hash {hash:?} has an unusable length"))
-    })
+    DataChunk::new(chunk.top(), chunk.first_block(), chunk.last_block(), hash)
+        // Only this artifact states which copy of a chunk workers serve; the legacy one has no
+        // such column, so a chunk from it stays at 0 and the query leaves the field off the wire.
+        .map(|data_chunk| data_chunk.with_version(chunk.version()))
+        .ok_or_else(|| {
+            ChunkNotFound::InvalidID(format!("chunk hash {hash:?} has an unusable length"))
+        })
 }
 
 /// A dataset's first block, or `None` when it holds no chunks -- `first_block()` reads chunk 0 on
@@ -922,6 +926,40 @@ mod tests {
         }
         builder.finish_dataset();
         Assignment::from_owned(builder.finish()).unwrap()
+    }
+
+    /// A one-chunk dataset whose chunk is a re-ingested copy, so its version is not the default.
+    fn versioned_portal_assignment() -> PortalAssignment {
+        let mut builder = sqd_assignments::PortalAssignmentBuilder::new();
+        let mut dataset = builder.new_dataset(GAPPED_DATASET, 0);
+        dataset
+            .new_chunk()
+            .id("0000000000/0000000000-0000000099-aaaaa")
+            .block_range(0..=99)
+            .version(7)
+            .finish()
+            .unwrap();
+        dataset.finish(Some("0xhead")).unwrap();
+        PortalAssignment::from_owned(builder.finish()).unwrap()
+    }
+
+    #[test]
+    fn only_a_portal_chunk_carries_a_version() {
+        // A query names the copy it wants, and only this artifact says which copy that is. A
+        // legacy chunk has no such column, so it stays at 0 -- the value proto3 leaves off the
+        // wire, which is how the field is absent rather than guessed.
+        let portal = versioned_portal_assignment();
+        let legacy = gapped_legacy_assignment();
+
+        let portal_chunk =
+            portal_data_chunk(find_portal_chunk(&portal, GAPPED_DATASET, 50).unwrap()).unwrap();
+        let legacy_chunk =
+            parse_chunk_id(legacy.find_chunk(GAPPED_DATASET, 50).unwrap().id()).unwrap();
+
+        assert_eq!(portal_chunk.version(), 7);
+        assert_eq!(legacy_chunk.version(), 0);
+        // The version rides beside the id, never inside it: both name the same chunk.
+        assert_eq!(portal_chunk.to_string(), legacy_chunk.to_string());
     }
 
     #[test]

--- a/src/types/chunk.rs
+++ b/src/types/chunk.rs
@@ -19,6 +19,10 @@ pub struct DataChunk {
     top_dir: BlockNumber,
     // TODO: use `SID` from the common library
     last_hash: [u8; HASH_MAX_LEN],
+    /// Which copy of the chunk workers serve. Only the portal artifact carries one; a chunk read
+    /// from the legacy artifact, or parsed from an id, is 0 — the ingested copy, and the value a
+    /// query leaves off the wire.
+    version: u32,
 }
 
 impl DataChunk {
@@ -44,7 +48,19 @@ impl DataChunk {
             last_block,
             top_dir,
             last_hash,
+            version: 0,
         })
+    }
+
+    /// The ingested copy is 0, which is also what an id alone can say — an id names no version.
+    #[must_use]
+    pub fn with_version(mut self, version: u32) -> Self {
+        self.version = version;
+        self
+    }
+
+    pub fn version(&self) -> u32 {
+        self.version
     }
 
     pub fn block_range(&self) -> BlockRange {
@@ -100,6 +116,7 @@ impl FromStr for DataChunk {
             last_block,
             top_dir,
             last_hash,
+            version: 0,
         })
     }
 }

--- a/src/types/chunk.rs
+++ b/src/types/chunk.rs
@@ -192,7 +192,6 @@ mod tests {
 
     #[test]
     fn test_data_chunk_new_rejects_hashes_an_id_cannot_carry() {
-        // Accepting these would let `to_string` emit an id that `from_str` refuses.
         assert!(DataChunk::new(0, 0, 1, "abcd").is_none());
         assert!(DataChunk::new(0, 0, 1, "abcdefghi").is_none());
     }

--- a/src/types/chunk.rs
+++ b/src/types/chunk.rs
@@ -9,6 +9,7 @@ use super::{BlockRange, DatasetId};
 pub type BlockNumber = u64;
 
 const HASH_MAX_LEN: usize = 8;
+const HASH_MIN_LEN: usize = 5;
 
 /// Chunk ID which uniquely defines chunk in the dataset
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -21,6 +22,31 @@ pub struct DataChunk {
 }
 
 impl DataChunk {
+    /// Builds a chunk from fields a source already holds separately, for callers that would
+    /// otherwise format them into an id only to parse them straight back out.
+    ///
+    /// `None` if the hash cannot appear in an id, since [`Display`] would then produce something
+    /// [`FromStr`] rejects and a worker would not recognise.
+    pub fn new(
+        top_dir: BlockNumber,
+        first_block: BlockNumber,
+        last_block: BlockNumber,
+        hash: &str,
+    ) -> Option<Self> {
+        let bytes = hash.as_bytes();
+        if !(HASH_MIN_LEN..=HASH_MAX_LEN).contains(&bytes.len()) {
+            return None;
+        }
+        let mut last_hash = [0; HASH_MAX_LEN];
+        last_hash[..bytes.len()].copy_from_slice(bytes);
+        Some(Self {
+            first_block,
+            last_block,
+            top_dir,
+            last_hash,
+        })
+    }
+
     pub fn block_range(&self) -> BlockRange {
         self.first_block..=self.last_block
     }
@@ -48,7 +74,6 @@ impl FromStr for DataChunk {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // "0000000000/0000000000-0000000000-xxxxx[xxx]"
         const BLOCK_NUM_LEN: usize = 10;
-        const HASH_MIN_LEN: usize = 5;
         const SLASH_POS: usize = BLOCK_NUM_LEN;
         const SEP1_POS: usize = BLOCK_NUM_LEN + 1 + BLOCK_NUM_LEN;
         const SEP2_POS: usize = BLOCK_NUM_LEN + 1 + BLOCK_NUM_LEN + 1 + BLOCK_NUM_LEN;
@@ -136,5 +161,22 @@ mod tests {
             chunk_str.parse::<DataChunk>().unwrap().to_string(),
             chunk_str
         );
+    }
+
+    #[test]
+    fn test_data_chunk_new_matches_parsing() {
+        let chunk_str = "0000001000/0000001024-0000002047-0xabcdef";
+
+        let built = DataChunk::new(1000, 1024, 2047, "0xabcdef").unwrap();
+
+        assert_eq!(built, DataChunk::from_str(chunk_str).unwrap());
+        assert_eq!(built.to_string(), chunk_str);
+    }
+
+    #[test]
+    fn test_data_chunk_new_rejects_hashes_an_id_cannot_carry() {
+        // Accepting these would let `to_string` emit an id that `from_str` refuses.
+        assert!(DataChunk::new(0, 0, 1, "abcd").is_none());
+        assert!(DataChunk::new(0, 0, 1, "abcdefghi").is_none());
     }
 }

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -1,4 +1,4 @@
-pub type ResponseChunk = Vec<u8>;
+pub type ResponseChunk = bytes::Bytes;
 
 pub type QueryId = String;
 


### PR DESCRIPTION
# What is this PR about?

Moves the portal assignment path to the columnar reader. Portal chunks now come from their encoded columns, carry their assignment version into worker queries, and can represent coverage gaps explicitly. The legacy assignment path remains supported.

## Assignment handling

**Portal chunks are built directly from columns.** Block bounds, hash, top directory, workers, and chunk version no longer round-trip through a formatted chunk id. The harness uses the new dataset-scoped builder API.

**Assignment artifacts may be gzip or zstd.** The URL suffix selects the codec; gzip remains the fallback for existing and unsuffixed URLs.

**Malformed empty datasets no longer panic request paths.** Missing first/head chunks return no data, and malformed legacy chunk ids are skipped when dataset state is assembled.

## Coverage gaps

- Portal assignments detect a gap and advance to the first real chunk after it.
- Legacy assignments cannot identify the next chunk from their columns. A non-advancing lookup now stops the stream instead of querying the preceding chunk repeatedly.
- A query sharing no blocks with its resolved chunk returns `NoData` rather than reaching an invalid intersection and panicking.
- The data-model and conformance docs now describe both formats explicitly.

## Other changes

- Large protobuf responses reuse a sufficiently full receive buffer, avoiding an extra payload copy without letting small responses pin a large allocation.
- Dependencies accidentally placed under the non-MSVC jemalloc table move back to normal dependencies.
- Worker response classification avoids parsing base-block mismatches twice.
